### PR TITLE
fix: zero value of nested field pointer

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -410,7 +410,8 @@ func fieldByIndex(v reflect.Value, index []int) reflect.Value {
 	for _, i := range index {
 		if v = v.Field(i); v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 			if v.IsNil() {
-				v = reflect.Value{}
+				v.Set(reflect.New(v.Type().Elem()))
+				v = v.Elem()
 				break
 			} else {
 				v = v.Elem()

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,6 +1,7 @@
 package parquet_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/parquet-go/parquet-go"
@@ -191,5 +192,54 @@ func TestSchemaOf(t *testing.T) {
 				t.Errorf("\nexpected:\n\n%s\n\nfound:\n\n%s\n", test.print, s)
 			}
 		})
+	}
+}
+
+func TestNestedPointer(t *testing.T) {
+	type InnerStruct struct {
+		InnerField string
+	}
+
+	type SliceElement struct {
+		Inner *InnerStruct
+	}
+
+	type Outer struct {
+		Slice []*SliceElement
+	}
+	value := "inner-string"
+	in := &Outer{
+		Slice: []*SliceElement{
+			{
+				Inner: &InnerStruct{
+					InnerField: value,
+				},
+			},
+		},
+	}
+
+	var f bytes.Buffer
+
+	pw := parquet.NewGenericWriter[*Outer](&f)
+	_, err := pw.Write([]*Outer{in})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pw.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pr := parquet.NewGenericReader[*Outer](bytes.NewReader(f.Bytes()))
+
+	out := make([]*Outer, 1)
+	_, err = pr.Read(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr.Close()
+	if want, got := value, out[0].Slice[0].Inner.InnerField; want != got {
+		t.Error("failed to set inner field pointer")
 	}
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,7 +1,6 @@
 package parquet_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/parquet-go/parquet-go"
@@ -192,54 +191,5 @@ func TestSchemaOf(t *testing.T) {
 				t.Errorf("\nexpected:\n\n%s\n\nfound:\n\n%s\n", test.print, s)
 			}
 		})
-	}
-}
-
-func TestNestedPointer(t *testing.T) {
-	type InnerStruct struct {
-		InnerField string
-	}
-
-	type SliceElement struct {
-		Inner *InnerStruct
-	}
-
-	type Outer struct {
-		Slice []*SliceElement
-	}
-	value := "inner-string"
-	in := &Outer{
-		Slice: []*SliceElement{
-			{
-				Inner: &InnerStruct{
-					InnerField: value,
-				},
-			},
-		},
-	}
-
-	var f bytes.Buffer
-
-	pw := parquet.NewGenericWriter[*Outer](&f)
-	_, err := pw.Write([]*Outer{in})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = pw.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pr := parquet.NewGenericReader[*Outer](bytes.NewReader(f.Bytes()))
-
-	out := make([]*Outer, 1)
-	_, err = pr.Read(out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pr.Close()
-	if want, got := value, out[0].Slice[0].Inner.InnerField; want != got {
-		t.Error("failed to set inner field pointer")
 	}
 }


### PR DESCRIPTION
fixes #2

When reconstructing the schema for nested structs we call function `fieldByIndex` to get the pointer to the underlying value of the field that we assign the values we read into.

This is the comment on fieldByIndex function

```go
// fieldByIndex is like reflect.Value.FieldByIndex but returns the zero-value of
// reflect.Value if one of the fields was a nil pointer instead of panicking.
```

In theory if we have a field with value `*Foo` a call to fieldByIndex should do the following when this field is not initialized yet (i.e is Nil)

- Create a zero value of `Foo` : `new(Foo)`
- Assign the zero value created to the field.

Before this change this is what fieldByIndex was doing

```go
			if v.IsNil() {
				v = reflect.Value{}
				break
```

`reflect.Value{}` IS NOT A ZERO VALUE of anything , it is an invalid value.

This commit ensures that we correctly initialize zero values of nested pointer fields.