### PR TITLE
Reuse reconstruction columns slice to reduce allocations

### DIFF
--- a/reader_go18.go
+++ b/reader_go18.go
@@ -149,6 +149,9 @@ func (r *GenericReader[T]) readRows(rows []T) (int, error) {
 		r.base.rowbuf = r.base.rowbuf[:nRequest]
 	}
 
+	schema := r.base.Schema()
+	columns := make([][]Value, len(schema.columns))
+
 	var n, nTotal int
 	var err error
 	for {
@@ -159,10 +162,9 @@ func (r *GenericReader[T]) readRows(rows []T) (int, error) {
 		// because sequential reads can cross page boundaries.
 		n, err = r.base.ReadRows(r.base.rowbuf[:nRequest-nTotal])
 		if n > 0 {
-			schema := r.base.Schema()
 
 			for i, row := range r.base.rowbuf[:n] {
-				if err2 := schema.Reconstruct(&rows[nTotal+i], row); err2 != nil {
+				if err2 := schema.reconstructWithColumns(&rows[nTotal+i], row, columns); err2 != nil {
 					return nTotal + i, err2
 				}
 			}

--- a/schema.go
+++ b/schema.go
@@ -244,6 +244,10 @@ func (s *Schema) deconstructValueToColumns(columns [][]Value, value reflect.Valu
 // The method panics if the structure of the go value and parquet row do not
 // match.
 func (s *Schema) Reconstruct(value interface{}, row Row) error {
+	return s.reconstructWithColumns(value, row, make([][]Value, len(s.columns)))
+}
+
+func (s *Schema) reconstructWithColumns(value interface{}, row Row, columns [][]Value) error {
 	v := reflect.ValueOf(value)
 	if !v.IsValid() {
 		panic("cannot reconstruct row into go value of type <nil>")
@@ -261,7 +265,6 @@ func (s *Schema) Reconstruct(value interface{}, row Row) error {
 		v = v.Elem()
 	}
 
-	columns := make([][]Value, len(s.columns))
 	row.Range(func(columnIndex int, columnValues []Value) bool {
 		if columnIndex < len(columns) {
 			columns[columnIndex] = columnValues


### PR DESCRIPTION
Create an internal method on Schema to reconstruct a value, passing in a [][]Value to use as columns. Use this internal method, rather than Reconstruct, when reading rows in GenericReader.

Calling Reconstruct on every row being read, and constructing a new [][]Value, in aggregate, accounts for the majority of allocations while reading parquet files and induces an unnecessarily large GC overhead.

-----

<details>

<summary>Test code used to identify issues</summary>

test.parquet is a 768MB parquet file with 32M records.

```go
type TestStruct struct {
	Field1 int64
	Field2 int64
	Field3 int64
}

func main() {
	entries := make([]TestStruct, 1024)
	inFile, err := os.Open("test.parquet")
	if err != nil {
		log.Fatalf("failed to open parquet file: %v", err)
	}
	pr := parquet.NewGenericReader[TestStruct](inFile)
	for {
		_, err := pr.Read(entries)
		if err == io.EOF {
			break
		} else if err != nil {
			log.Fatalf("failed to read parquet entries: %v\n", err)
		}
	}

	f, err := os.Create("mem.pprof")
	if err != nil {
		log.Fatalf("failed to open file: %v", err)
	}
	defer f.Close()
	if err := pprof.Lookup("allocs").WriteTo(f, 0); err != nil {
		log.Fatalf("failed to write heap profile: %v", err)
	}
}
```

</details>

<details>

<summary>Profile output (before change)</summary>

![profile016](https://github.com/segmentio/parquet-go/assets/7101542/810e36d4-0887-42ca-831c-573ea55da4e7)


</details>

<details>

<summary>Profile output (after change)</summary>

![profile014](https://github.com/segmentio/parquet-go/assets/7101542/db23e50f-eea9-460a-8c15-304a11bd77e6)


</details>