### PR TITLE
fix memory corruption in MergeRowGroups

### DIFF
--- a/sorting_test.go
+++ b/sorting_test.go
@@ -2,9 +2,12 @@ package parquet_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"math/rand"
+	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/parquet-go/parquet-go"
 )
@@ -106,4 +109,151 @@ func TestSortingWriterDropDuplicatedRows(t *testing.T) {
 	}
 
 	assertRowsEqual(t, rows[:n], read)
+}
+
+func TestSortingWriterCorruptedString(t *testing.T) {
+	type Row struct {
+		Tag string `parquet:"tag"`
+	}
+	rowsWant := make([]Row, 107) // passes at 106, but fails at 107+
+	for i := range rowsWant {
+		rowsWant[i].Tag = randString(100)
+	}
+
+	buffer := bytes.NewBuffer(nil)
+
+	writer := parquet.NewSortingWriter[Row](buffer, 2000,
+		&parquet.WriterConfig{
+			PageBufferSize: 2560,
+			Sorting: parquet.SortingConfig{
+				SortingColumns: []parquet.SortingColumn{
+					parquet.Ascending("tag"),
+				},
+			},
+		})
+
+	_, err := writer.Write(rowsWant)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rowsGot, err := parquet.Read[Row](bytes.NewReader(buffer.Bytes()), int64(buffer.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(rowsWant, func(i, j int) bool {
+		return rowsWant[i].Tag < rowsWant[j].Tag
+	})
+
+	assertRowsEqualByRow(t, rowsGot, rowsWant)
+}
+
+func TestSortingWriterCorruptedFixedLenByteArray(t *testing.T) {
+	type Row struct {
+		ID [16]byte `parquet:"id,uuid"`
+	}
+	rowsWant := make([]Row, 700) // passes at 300, fails at 400+.
+	for i := range rowsWant {
+		rowsWant[i].ID = rand16bytes()
+	}
+
+	buffer := bytes.NewBuffer(nil)
+
+	writer := parquet.NewSortingWriter[Row](buffer, 2000,
+		&parquet.WriterConfig{
+			PageBufferSize: 2560,
+			Sorting: parquet.SortingConfig{
+				SortingColumns: []parquet.SortingColumn{
+					parquet.Ascending("id"),
+				},
+			},
+		})
+
+	_, err := writer.Write(rowsWant)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	rowsGot, err := parquet.Read[Row](bytes.NewReader(buffer.Bytes()), int64(buffer.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(rowsWant, func(i, j int) bool {
+		return idLess(rowsWant[i].ID, rowsWant[j].ID)
+	})
+
+	assertRowsEqualByRow(t, rowsGot, rowsWant)
+}
+
+const letterRunes = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterRunes[rand.New(rand.NewSource(time.Now().UnixNano())).Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func rand16bytes() [16]byte {
+	var b [16]byte
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return b
+}
+
+func idLess(ID1, ID2 [16]byte) bool {
+	k1 := binary.BigEndian.Uint64(ID1[:8])
+	k2 := binary.BigEndian.Uint64(ID2[:8])
+	switch {
+	case k1 < k2:
+		return true
+	case k1 > k2:
+		return false
+	}
+	k1 = binary.BigEndian.Uint64(ID1[8:])
+	k2 = binary.BigEndian.Uint64(ID2[8:])
+	return k1 < k2
+}
+
+func assertRowsEqualByRow[T any](t *testing.T, rowsGot, rowsWant []T) {
+	if len(rowsGot) != len(rowsWant) {
+		t.Errorf("want rows length %d but got rows length %d", len(rowsWant), len(rowsGot))
+	}
+	count := 0
+	for i := range rowsGot {
+		if !reflect.DeepEqual(rowsGot[i], rowsWant[i]) {
+			t.Error("rows mismatch at index", i, ":")
+			t.Logf(" want: %#v\n", rowsWant[i])
+			t.Logf("  got: %#v\n", rowsGot[i])
+
+			// check if rowsGot[i] is even present in rowsWant
+			found := false
+			for j := range rowsWant {
+				if reflect.DeepEqual(rowsWant[j], rowsGot[i]) {
+					t.Log("  we found the row at index", j, "in want.")
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Log("  got row index", i, "isn't found in want rows, and is therefore corrupted data.")
+			}
+			count++
+		}
+	}
+	if count > 0 {
+		t.Error(count, "rows mismatched out of", len(rowsWant), "total")
+	}
 }


### PR DESCRIPTION
fixes #23
closes #24

Multiple layers of buffers were causing active rows memory to be overwritten  resulting in data corruption.

While merging rows, we buffer reads to speed up processing, however for cases where we need more data we were calling the underlying `RowGroup` multiple times resulting in  active buffers being overwritten.

Fixing `ReadRows` is a bit challenging. Without buffered reads it becomes a performance bottleneck.

Lucky for us there is an interface `RowWriterTo` which allows us to have control over the active buffers.

This commit implements `RowWriterTo` for the `MergeRowGroups` implementation.
 In this case we ensure that values not yet written are not corrupted.