### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* joe-elliott mdisibio kevinburkesegment achille-roussel gernest
+* @achille-roussel @asubiotto @brancz @gernest @joe-elliott @kevinburkesegment @mdisibio @metalmatze @thorfour

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* joe-elliott mdisibio kevinburkesegment achille-roussel

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @achille-roussel @asubiotto @brancz @joe-elliott @kevinburkesegment @mdisibio @metalmatze @Pryz @thorfour
+* @achille-roussel @asubiotto @brancz @fpetkovski @joe-elliott @kevinburkesegment @mdisibio @metalmatze @Pryz @thorfour

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @achille-roussel @asubiotto @brancz @gernest @joe-elliott @kevinburkesegment @mdisibio @metalmatze @thorfour
+* @achille-roussel @asubiotto @brancz @joe-elliott @kevinburkesegment @mdisibio @metalmatze @Pryz @thorfour

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* joe-elliott mdisibio kevinburkesegment achille-roussel
+* joe-elliott mdisibio kevinburkesegment achille-roussel gernest


### PR DESCRIPTION
Proposing using a CODEOWNERS file to help with maintaining the project. I will add whatever github handles make sense and alphabetize them before merging.

CODEOWNERS can make it easy to request reviews. We can also require a review from a code owner before merging.

There are likely other ways to accomplish this and I don't care if we choose a different path, but I'd like to add some structure/policy to this repo.

Per conversation in https://github.com/parquet-go/parquet-go/issues/36