### PR TITLE
Enable schema support for optional *int32 as date & *int64 as timestamp.

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -744,6 +744,10 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 			node = nodeOf(t, tag)
 			return
 		}
+		ft := t
+		if t.Kind() == reflect.Ptr {
+			ft = t.Elem()
+		}
 		switch option {
 		case "":
 			return
@@ -778,70 +782,70 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 			setNode(JSON())
 
 		case "delta":
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64:
 				setEncoding(&DeltaBinaryPacked)
 			case reflect.String:
 				setEncoding(&DeltaByteArray)
 			case reflect.Slice:
-				if t.Elem().Kind() == reflect.Uint8 { // []byte?
+				if ft.Elem().Kind() == reflect.Uint8 { // []byte?
 					setEncoding(&DeltaByteArray)
 				} else {
-					throwInvalidTag(t, name, option)
+					throwInvalidTag(ft, name, option)
 				}
 			case reflect.Array:
-				if t.Elem().Kind() == reflect.Uint8 { // [N]byte?
+				if ft.Elem().Kind() == reflect.Uint8 { // [N]byte?
 					setEncoding(&DeltaByteArray)
 				} else {
-					throwInvalidTag(t, name, option)
+					throwInvalidTag(ft, name, option)
 				}
 			default:
-				throwInvalidTag(t, name, option)
+				throwInvalidTag(ft, name, option)
 			}
 
 		case "split":
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.Float32, reflect.Float64:
 				setEncoding(&ByteStreamSplit)
 			default:
-				throwInvalidTag(t, name, option)
+				throwInvalidTag(ft, name, option)
 			}
 
 		case "list":
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.Slice:
-				element := nodeOf(t.Elem(), nil)
+				element := nodeOf(ft.Elem(), nil)
 				setNode(element)
 				setList()
 			default:
-				throwInvalidTag(t, name, option)
+				throwInvalidTag(ft, name, option)
 			}
 
 		case "enum":
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.String:
 				setNode(Enum())
 			default:
-				throwInvalidTag(t, name, option)
+				throwInvalidTag(ft, name, option)
 			}
 
 		case "uuid":
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.Array:
-				if t.Elem().Kind() != reflect.Uint8 || t.Len() != 16 {
-					throwInvalidTag(t, name, option)
+				if ft.Elem().Kind() != reflect.Uint8 || ft.Len() != 16 {
+					throwInvalidTag(ft, name, option)
 				}
 			default:
-				throwInvalidTag(t, name, option)
+				throwInvalidTag(ft, name, option)
 			}
 
 		case "decimal":
 			scale, precision, err := parseDecimalArgs(args)
 			if err != nil {
-				throwInvalidTag(t, name, option+args)
+				throwInvalidTag(ft, name, option+args)
 			}
 			var baseType Type
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.Int32:
 				baseType = Int32Type
 			case reflect.Int64:
@@ -849,57 +853,39 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 			case reflect.Array, reflect.Slice:
 				baseType = FixedLenByteArrayType(decimalFixedLenByteArraySize(precision))
 			default:
-				throwInvalidTag(t, name, option)
+				throwInvalidTag(ft, name, option)
 			}
 
 			setNode(Decimal(scale, precision, baseType))
 		case "date":
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.Int32:
 				setNode(Date())
-			case reflect.Ptr:
-				switch t.Elem().Kind() {
-				case reflect.Int32:
-					setNode(Date())
-				default:
-					throwInvalidTag(t, name, option)
-				}
 			default:
-				throwInvalidTag(t, name, option)
+				throwInvalidTag(ft, name, option)
 			}
 		case "timestamp":
-			switch t.Kind() {
+			switch ft.Kind() {
 			case reflect.Int64:
 				timeUnit, err := parseTimestampArgs(args)
 				if err != nil {
-					throwInvalidTag(t, name, option)
+					throwInvalidTag(ft, name, option)
 				}
 				setNode(Timestamp(timeUnit))
-			case reflect.Ptr:
-				switch t.Elem().Kind() {
-				case reflect.Int64:
-					timeUnit, err := parseTimestampArgs(args)
-					if err != nil {
-						throwInvalidTag(t, name, option)
-					}
-					setNode(Timestamp(timeUnit))
-				default:
-					throwInvalidTag(t, name, option)
-				}
 			default:
-				switch t {
+				switch ft {
 				case reflect.TypeOf(time.Time{}):
 					timeUnit, err := parseTimestampArgs(args)
 					if err != nil {
-						throwInvalidTag(t, name, option)
+						throwInvalidTag(ft, name, option)
 					}
 					setNode(Timestamp(timeUnit))
 				default:
-					throwInvalidTag(t, name, option)
+					throwInvalidTag(ft, name, option)
 				}
 			}
 		default:
-			throwUnknownTag(t, name, option)
+			throwUnknownTag(ft, name, option)
 		}
 	})
 

--- a/schema.go
+++ b/schema.go
@@ -857,6 +857,13 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 			switch t.Kind() {
 			case reflect.Int32:
 				setNode(Date())
+			case reflect.Ptr:
+				switch t.Elem().Kind() {
+				case reflect.Int32:
+					setNode(Date())
+				default:
+					throwInvalidTag(t, name, option)
+				}
 			default:
 				throwInvalidTag(t, name, option)
 			}
@@ -868,6 +875,17 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 					throwInvalidTag(t, name, option)
 				}
 				setNode(Timestamp(timeUnit))
+			case reflect.Ptr:
+				switch t.Elem().Kind() {
+				case reflect.Int64:
+					timeUnit, err := parseTimestampArgs(args)
+					if err != nil {
+						throwInvalidTag(t, name, option)
+					}
+					setNode(Timestamp(timeUnit))
+				default:
+					throwInvalidTag(t, name, option)
+				}
 			default:
 				switch t {
 				case reflect.TypeOf(time.Time{}):

--- a/schema_test.go
+++ b/schema_test.go
@@ -181,6 +181,35 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+
+		{
+			value: new(struct {
+				Name *string `parquet:""`
+				Age  *int64  `parquet:""`
+			}),
+			print: `message {
+	optional binary Name (STRING);
+	optional int64 Age (INT(64,true));
+}`,
+		},
+
+		{
+			value: new(struct {
+				DatePointer *int32 `parquet:"date_pointer,date,optional"`
+			}),
+			print: `message {
+	optional int32 date_pointer (DATE);
+}`,
+		},
+
+		{
+			value: new(struct {
+				TimestampPointer *int64 `parquet:"timestamp_pointer,timestamp,optional"`
+			}),
+			print: `message {
+	optional int64 timestamp_pointer (TIMESTAMP(isAdjustedToUTC=true,unit=MILLIS));
+}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This is a PR copied from an existing PR where we try to merge it to segmentio/parquet-go. But since that repo is archived it couldn't get merged there.
https://github.com/segmentio/parquet-go/pull/472

The goal for this change is to support pointer type for tag option `date` and `timestamp`.
Currently we would run into the below error if we try running `SchemaOf()` for these pointer types.

```struct {DatePointer *int32 `parquet:"date_pointer,date,optional"`}``` -> panic: date is an invalid parquet tag: date_pointer *int32 [date] [recovered]

```struct {TimestampPointer *int64 `parquet:"timestamp_pointer,timestamp,optional"`}``` -> panic: timestamp is an invalid parquet tag: timestamp_pointer *int64 [timestamp] [recovered]

We would like to add a statement that will redirect to it's Elem() whenever it encounters a **reflect.Ptr** so that it would be able to handle pointer types.

