### PR TITLE
Support reading with schemas and nested map values

### DIFF
--- a/parquet_test.go
+++ b/parquet_test.go
@@ -550,6 +550,69 @@ func TestNestedPointer(t *testing.T) {
 	}
 }
 
+func TestNestedMapValueWithSchema(t *testing.T) {
+	// Main struct used to marshal/unmarshal data.
+	type NestedStructA struct {
+		Val string
+	}
+	type MapValueA struct {
+		Nested NestedStructA
+	}
+	type A struct {
+		TestMap map[string]MapValueA
+	}
+
+	// Clone of the main struct used exclusively to generate the schema.
+	type NestedStructB struct {
+		Val string
+	}
+	type MapValueB struct {
+		Nested NestedStructB
+	}
+	type B struct {
+		TestMap map[string]MapValueB
+	}
+
+	testKey, testValue := "test-key", "test-value"
+	in := A{
+		TestMap: map[string]MapValueA{
+			"test-key": {
+				Nested: NestedStructA{
+					Val: testValue,
+				},
+			},
+		},
+	}
+
+	var f bytes.Buffer
+
+	// Generate a schema for reading/writing using an exact clone of the type.
+	schema := parquet.SchemaOf(B{})
+
+	pw := parquet.NewGenericWriter[A](&f, schema)
+	_, err := pw.Write([]A{in})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = pw.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pr := parquet.NewGenericReader[*A](bytes.NewReader(f.Bytes()), schema)
+
+	out := make([]*A, 1)
+	_, err = pr.Read(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr.Close()
+	if want, got := testValue, out[0].TestMap[testKey].Nested.Val; want != got {
+		t.Error("failed to read map value")
+	}
+}
+
 type benchmarkRowType struct {
 	ID    [16]byte `parquet:"id,uuid"`
 	Value float64  `parquet:"value"`

--- a/row.go
+++ b/row.go
@@ -718,6 +718,18 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 		}
 
 		elem := reflect.New(keyValueElem).Elem()
+
+		// keyValueElem has a type that is encoded in the schema. If the schema was created
+		// from a map with a value type that does not match the type being reconstructed, we
+		// need to create a new keyValue type that matches the target we read into.
+		if !elem.Field(1).CanConvert(v) {
+			fields := reflect.VisibleFields(keyValueElem)
+			fields[1].Type = v
+			kv := reflect.StructOf(fields)
+			elem = reflect.New(kv).Elem()
+			keyValueZero = reflect.Zero(kv)
+		}
+
 		for i := 0; i < n; i++ {
 			for j, column := range values {
 				column = column[:cap(column)]


### PR DESCRIPTION
This works around an issue when reading nested map values using a schema which was not generated from the exact same Go type the data is read into. Schemas created with `parquet.SchemaOf()` contain references to types which are used during reading which can cause panics if the type in the schema doesn't match the type of the target, even though the structure is identical.

Just to explain what's happening in the test:
- There are two structures A and B. Both are equivalent to each other in every way, but they're different Go types.
- It generates a schema from B
- Data is then written from A with the schema (this works regardless)
- It then tries to read the data back into A with the schema. Without the change, this  fails with `panic: reflect.Value.Convert: value of type parquet_test.MapValueB cannot be converted to type parquet_test.MapValueA`

This is likely not the best way to fix the panic, but I hope it helps illustrate the issue. Please let me know if you can see a cleaner way to handle it.