### PR TITLE
Add minimal support for writing 8-bit values

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestGenericBuffer(t *testing.T) {
 	testGenericBuffer[booleanColumn](t)
+	testGenericBuffer[int8Column](t)
 	testGenericBuffer[int32Column](t)
 	testGenericBuffer[int64Column](t)
 	testGenericBuffer[int96Column](t)
@@ -105,6 +106,7 @@ type generator[T any] interface {
 func BenchmarkGenericBuffer(b *testing.B) {
 	benchmarkGenericBuffer[benchmarkRowType](b)
 	benchmarkGenericBuffer[booleanColumn](b)
+	benchmarkGenericBuffer[int8Column](b)
 	benchmarkGenericBuffer[int32Column](b)
 	benchmarkGenericBuffer[int64Column](b)
 	benchmarkGenericBuffer[floatColumn](b)

--- a/column_index.go
+++ b/column_index.go
@@ -147,6 +147,16 @@ func (i booleanColumnIndex) MaxValue(int) Value  { return makeValueBoolean(i.pag
 func (i booleanColumnIndex) IsAscending() bool   { return false }
 func (i booleanColumnIndex) IsDescending() bool  { return false }
 
+type int8ColumnIndex struct{ page *int32Page }
+
+func (i int8ColumnIndex) NumPages() int       { return 1 }
+func (i int8ColumnIndex) NullCount(int) int64 { return 0 }
+func (i int8ColumnIndex) NullPage(int) bool   { return false }
+func (i int8ColumnIndex) MinValue(int) Value  { return makeValueInt32(i.page.min()) }
+func (i int8ColumnIndex) MaxValue(int) Value  { return makeValueInt32(i.page.max()) }
+func (i int8ColumnIndex) IsAscending() bool   { return false }
+func (i int8ColumnIndex) IsDescending() bool  { return false }
+
 type int32ColumnIndex struct{ page *int32Page }
 
 func (i int32ColumnIndex) NumPages() int       { return 1 }
@@ -220,6 +230,16 @@ func (i fixedLenByteArrayColumnIndex) MaxValue(int) Value {
 }
 func (i fixedLenByteArrayColumnIndex) IsAscending() bool  { return false }
 func (i fixedLenByteArrayColumnIndex) IsDescending() bool { return false }
+
+type uint8ColumnIndex struct{ page *uint32Page }
+
+func (i uint8ColumnIndex) NumPages() int       { return 1 }
+func (i uint8ColumnIndex) NullCount(int) int64 { return 0 }
+func (i uint8ColumnIndex) NullPage(int) bool   { return false }
+func (i uint8ColumnIndex) MinValue(int) Value  { return makeValueUint32(i.page.min()) }
+func (i uint8ColumnIndex) MaxValue(int) Value  { return makeValueUint32(i.page.max()) }
+func (i uint8ColumnIndex) IsAscending() bool   { return false }
+func (i uint8ColumnIndex) IsDescending() bool  { return false }
 
 type uint32ColumnIndex struct{ page *uint32Page }
 

--- a/dictionary.go
+++ b/dictionary.go
@@ -907,6 +907,11 @@ func (d *fixedLenByteArrayDictionary) Page() Page {
 	return &d.fixedLenByteArrayPage
 }
 
+type uint8Dictionary struct {
+	uint32Page
+	table *hashprobe.Uint32Table
+}
+
 type uint32Dictionary struct {
 	uint32Page
 	table *hashprobe.Uint32Table

--- a/offset_index.go
+++ b/offset_index.go
@@ -55,6 +55,13 @@ func (i booleanOffsetIndex) Offset(int) int64             { return 0 }
 func (i booleanOffsetIndex) CompressedPageSize(int) int64 { return i.page.Size() }
 func (i booleanOffsetIndex) FirstRowIndex(int) int64      { return 0 }
 
+type int8OffsetIndex struct{ page *int32Page }
+
+func (i int8OffsetIndex) NumPages() int                { return 1 }
+func (i int8OffsetIndex) Offset(int) int64             { return 0 }
+func (i int8OffsetIndex) CompressedPageSize(int) int64 { return i.page.Size() }
+func (i int8OffsetIndex) FirstRowIndex(int) int64      { return 0 }
+
 type int32OffsetIndex struct{ page *int32Page }
 
 func (i int32OffsetIndex) NumPages() int                { return 1 }
@@ -103,6 +110,13 @@ func (i fixedLenByteArrayOffsetIndex) NumPages() int                { return 1 }
 func (i fixedLenByteArrayOffsetIndex) Offset(int) int64             { return 0 }
 func (i fixedLenByteArrayOffsetIndex) CompressedPageSize(int) int64 { return i.page.Size() }
 func (i fixedLenByteArrayOffsetIndex) FirstRowIndex(int) int64      { return 0 }
+
+type uint8OffsetIndex struct{ page *uint32Page }
+
+func (i uint8OffsetIndex) NumPages() int                { return 1 }
+func (i uint8OffsetIndex) Offset(int) int64             { return 0 }
+func (i uint8OffsetIndex) CompressedPageSize(int) int64 { return i.page.Size() }
+func (i uint8OffsetIndex) FirstRowIndex(int) int64      { return 0 }
 
 type uint32OffsetIndex struct{ page *uint32Page }
 

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -578,6 +578,14 @@ func (row booleanColumn) generate(prng *rand.Rand) booleanColumn {
 	return booleanColumn{Value: prng.Int()%2 == 0}
 }
 
+type int8Column struct {
+	Value int8 `parquet:",delta"`
+}
+
+func (row int8Column) generate(prng *rand.Rand) int8Column {
+	return int8Column{Value: int8(prng.Intn(100))}
+}
+
 type int32Column struct {
 	Value int32 `parquet:",delta"`
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestGenericReader(t *testing.T) {
 	testGenericReader[booleanColumn](t)
+	testGenericReader[int8Column](t)
 	testGenericReader[int32Column](t)
 	testGenericReader[int64Column](t)
 	testGenericReader[int96Column](t)
@@ -227,6 +228,7 @@ func testReadMinPageSize(readSize int, t *testing.T) {
 func BenchmarkGenericReader(b *testing.B) {
 	benchmarkGenericReader[benchmarkRowType](b)
 	benchmarkGenericReader[booleanColumn](b)
+	benchmarkGenericReader[int8Column](b)
 	benchmarkGenericReader[int32Column](b)
 	benchmarkGenericReader[int64Column](b)
 	benchmarkGenericReader[floatColumn](b)
@@ -315,6 +317,11 @@ var readerTests = []struct {
 	{
 		scenario: "BOOLEAN",
 		model:    booleanColumn{},
+	},
+
+	{
+		scenario: "INT8",
+		model:    int8Column{},
 	},
 
 	{

--- a/row_buffer_test.go
+++ b/row_buffer_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestRowBuffer(t *testing.T) {
 	testRowBuffer[booleanColumn](t)
+	testRowBuffer[int8Column](t)
 	testRowBuffer[int32Column](t)
 	testRowBuffer[int64Column](t)
 	testRowBuffer[int96Column](t)

--- a/schema.go
+++ b/schema.go
@@ -779,7 +779,8 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 
 		case "delta":
 			switch t.Kind() {
-			case reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64:
+			case reflect.Int, reflect.Int8, reflect.Int32, reflect.Int64,
+				reflect.Uint, reflect.Uint8, reflect.Uint32, reflect.Uint64:
 				setEncoding(&DeltaBinaryPacked)
 			case reflect.String:
 				setEncoding(&DeltaByteArray)

--- a/schema_test.go
+++ b/schema_test.go
@@ -181,6 +181,16 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+		{
+			value: new(struct {
+				UnsignedByte uint8 `parquet:"unsigned_byte"`
+				SignedByte   int8  `parquet:"signed_byte"`
+			}),
+			print: `message {
+	required int32 unsigned_byte (INT(8,false));
+	required int32 signed_byte (INT(8,true));
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/sparse/array.go
+++ b/sparse/array.go
@@ -88,7 +88,7 @@ func (a BoolArray) UnsafeArray() Array       { return Array{a.array} }
 type Int8Array struct{ array }
 
 func MakeInt8Array(values []int8) Int8Array {
-	return Int8Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Int8Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 1)}
 }
 
 func UnsafeInt8Array(base unsafe.Pointer, length int, offset uintptr) Int8Array {
@@ -197,7 +197,7 @@ func (a Float64Array) UnsafeArray() Array          { return Array{a.array} }
 type Uint8Array struct{ array }
 
 func MakeUint8Array(values []uint8) Uint8Array {
-	return Uint8Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Uint8Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 1)}
 }
 
 func UnsafeUint8Array(base unsafe.Pointer, length int, offset uintptr) Uint8Array {

--- a/sparse/gather.go
+++ b/sparse/gather.go
@@ -2,6 +2,10 @@ package sparse
 
 import "unsafe"
 
+func GatherInt8(dst []int32, src Int8Array) int {
+	return gather8(*(*[]uint32)(unsafe.Pointer(&dst)), src.Uint8Array(), 0xFFFFFF00)
+}
+
 func GatherInt32(dst []int32, src Int32Array) int {
 	return GatherUint32(*(*[]uint32)(unsafe.Pointer(&dst)), src.Uint32Array())
 }
@@ -19,6 +23,8 @@ func GatherFloat64(dst []float64, src Float64Array) int {
 }
 
 func GatherBits(dst []byte, src Uint8Array) int { return gatherBits(dst, src) }
+
+func GatherUint8(dst []uint32, src Uint8Array) int { return gather8(dst, src, 0) }
 
 func GatherUint32(dst []uint32, src Uint32Array) int { return gather32(dst, src) }
 

--- a/sparse/gather_amd64.go
+++ b/sparse/gather_amd64.go
@@ -35,6 +35,24 @@ func gatherBits(dst []byte, src Uint8Array) int {
 	return n
 }
 
+func gather8(dst []uint32, src Uint8Array, bigSignMask uint32) int {
+
+	signMasks := [...]uint32{0x00, bigSignMask}
+
+	n := min(len(dst), src.Len())
+	i := 0
+
+	for i < n {
+		v := src.Index(i)
+		maskIndex := v & 0x80 >> 7
+		signMask := signMasks[maskIndex]
+		dst[i] = uint32(v) | signMask
+		i++
+	}
+
+	return n
+}
+
 func gather32(dst []uint32, src Uint32Array) int {
 	n := min(len(dst), src.Len())
 	i := 0

--- a/value_test.go
+++ b/value_test.go
@@ -41,6 +41,11 @@ func TestValueClone(t *testing.T) {
 		},
 
 		{
+			scenario: "INT8",
+			values:   []interface{}{int8(0), int8(1), int8(math.MinInt8), int8(math.MaxInt8)},
+		},
+
+		{
 			scenario: "INT32",
 			values:   []interface{}{int32(0), int32(1), int32(math.MinInt32), int32(math.MaxInt32)},
 		},

--- a/writer_test.go
+++ b/writer_test.go
@@ -28,6 +28,7 @@ const (
 func BenchmarkGenericWriter(b *testing.B) {
 	benchmarkGenericWriter[benchmarkRowType](b)
 	benchmarkGenericWriter[booleanColumn](b)
+	benchmarkGenericWriter[int8Column](b)
 	benchmarkGenericWriter[int32Column](b)
 	benchmarkGenericWriter[int64Column](b)
 	benchmarkGenericWriter[floatColumn](b)


### PR DESCRIPTION
N.b. Produces corrupt data if `dict` encoding is used. Fix this before merging.