### PR TITLE
Fix panic reading/writing `any` types

### DIFF
--- a/node.go
+++ b/node.go
@@ -292,6 +292,9 @@ type groupField struct {
 func (f *groupField) Name() string { return f.name }
 
 func (f *groupField) Value(base reflect.Value) reflect.Value {
+	if base.Kind() == reflect.Interface {
+		base = base.Elem()
+	}
 	return base.MapIndex(reflect.ValueOf(&f.name).Elem())
 }
 

--- a/node.go
+++ b/node.go
@@ -293,7 +293,12 @@ func (f *groupField) Name() string { return f.name }
 
 func (f *groupField) Value(base reflect.Value) reflect.Value {
 	if base.Kind() == reflect.Interface {
-		base = base.Elem()
+		if base.IsNil() {
+			return reflect.ValueOf(nil)
+		}
+		if base = base.Elem(); base.Kind() == reflect.Pointer && base.IsNil() {
+			return reflect.ValueOf(nil)
+		}
 	}
 	return base.MapIndex(reflect.ValueOf(&f.name).Elem())
 }

--- a/row.go
+++ b/row.go
@@ -444,6 +444,10 @@ func deconstructFuncOfOptional(columnIndex int16, node Node) (int16, deconstruct
 func deconstructFuncOfRepeated(columnIndex int16, node Node) (int16, deconstructFunc) {
 	columnIndex, deconstruct := deconstructFuncOf(columnIndex, Required(node))
 	return columnIndex, func(columns [][]Value, levels levels, value reflect.Value) {
+		if value.Kind() == reflect.Interface {
+			value = value.Elem()
+		}
+
 		if !value.IsValid() || value.Len() == 0 {
 			deconstruct(columns, levels, reflect.Value{})
 			return

--- a/value.go
+++ b/value.go
@@ -254,7 +254,12 @@ func FixedLenByteArrayValue(value []byte) Value { return makeValueBytes(FixedLen
 
 func makeValue(k Kind, lt *format.LogicalType, v reflect.Value) Value {
 	if v.Kind() == reflect.Interface {
-		v = v.Elem()
+		if v.IsNil() {
+			return Value{}
+		}
+		if v = v.Elem(); v.Kind() == reflect.Pointer && v.IsNil() {
+			return Value{}
+		}
 	}
 
 	switch v.Type() {

--- a/value.go
+++ b/value.go
@@ -253,6 +253,10 @@ func ByteArrayValue(value []byte) Value { return makeValueBytes(ByteArray, value
 func FixedLenByteArrayValue(value []byte) Value { return makeValueBytes(FixedLenByteArray, value) }
 
 func makeValue(k Kind, lt *format.LogicalType, v reflect.Value) Value {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+
 	switch v.Type() {
 	case reflect.TypeOf(time.Time{}):
 		unit := Nanosecond.TimeUnit()


### PR DESCRIPTION
Fixes a few edge cases where conversions to and/or from `any` types would panic due to boxed reflect.Value types. I've added a unit test to run through the examples I've come across and plugged all the panics from those, but I'm fairly confident there will be other (even more edgier) cases lurking in there.