### PR TITLE
Fix data corruption in column statistics

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1558,11 +1558,13 @@ func (c *writerColumn) recordPageStats(headerSize int32, header *format.PageHead
 			}
 
 			if existingMaxValue.isNull() || c.columnType.Compare(maxValue, existingMaxValue) > 0 {
-				c.columnChunk.MetaData.Statistics.MaxValue = maxValue.Bytes()
+				buf := c.columnChunk.MetaData.Statistics.MaxValue[:0]
+				c.columnChunk.MetaData.Statistics.MaxValue = maxValue.AppendBytes(buf)
 			}
 
 			if existingMinValue.isNull() || c.columnType.Compare(minValue, existingMinValue) < 0 {
-				c.columnChunk.MetaData.Statistics.MinValue = minValue.Bytes()
+				buf := c.columnChunk.MetaData.Statistics.MinValue[:0]
+				c.columnChunk.MetaData.Statistics.MinValue = minValue.AppendBytes(buf)
 			}
 		}
 


### PR DESCRIPTION
Fix a bug in recordPageStats that can cause the writer to corrupt the
min and max values of a byte-array column.

When processing the min and max values of a page to update the min and
max values in the column statistics, byte-array types would store values
backed by the page's values slice. This slice is reused when processing
the next page, and so data in the underlying array may be overwritten,
corrupting the stored min and max values, which can lead to wrong or
garbage values reported as the min or max.

To fix this, recordPageStats is modified to always copy the values into
a new slice owned exclusively by the statistics value, so that the
values remain correct after processing new pages.