### PR TITLE
Exposes fileOffsetIndex

### DIFF
--- a/file.go
+++ b/file.go
@@ -471,7 +471,7 @@ func (c *fileColumnChunk) OffsetIndex() OffsetIndex {
 	if c.offsetIndex == nil {
 		return nil
 	}
-	return (*fileOffsetIndex)(c.offsetIndex)
+	return (*FileOffsetIndex)(c.offsetIndex)
 }
 
 func (c *fileColumnChunk) BloomFilter() BloomFilter {

--- a/offset_index.go
+++ b/offset_index.go
@@ -23,21 +23,21 @@ type OffsetIndex interface {
 	FirstRowIndex(int) int64
 }
 
-type fileOffsetIndex format.OffsetIndex
+type FileOffsetIndex format.OffsetIndex
 
-func (i *fileOffsetIndex) NumPages() int {
+func (i *FileOffsetIndex) NumPages() int {
 	return len(i.PageLocations)
 }
 
-func (i *fileOffsetIndex) Offset(j int) int64 {
+func (i *FileOffsetIndex) Offset(j int) int64 {
 	return i.PageLocations[j].Offset
 }
 
-func (i *fileOffsetIndex) CompressedPageSize(j int) int64 {
+func (i *FileOffsetIndex) CompressedPageSize(j int) int64 {
 	return int64(i.PageLocations[j].CompressedPageSize)
 }
 
-func (i *fileOffsetIndex) FirstRowIndex(j int) int64 {
+func (i *FileOffsetIndex) FirstRowIndex(j int) int64 {
 	return i.PageLocations[j].FirstRowIndex
 }
 


### PR DESCRIPTION
Expsosing fileOffsetIndex so that it can be utilized outside of parquet-go. 

Example need: https://github.com/polarsignals/frostdb/pull/541