### PR TITLE
Remove format.PageHeader caching

### DIFF
--- a/file.go
+++ b/file.go
@@ -525,10 +525,8 @@ func (f *filePages) ReadPage() (Page, error) {
 		return nil, io.EOF
 	}
 
-	header := getPageHeader()
-	defer putPageHeader(header)
-
 	for {
+		header := new(format.PageHeader)
 		if err := f.decoder.Decode(header); err != nil {
 			return nil, err
 		}
@@ -591,8 +589,7 @@ func (f *filePages) readDictionary() error {
 
 	decoder := thrift.NewDecoder(f.protocol.NewReader(rbuf))
 
-	header := getPageHeader()
-	defer putPageHeader(header)
+	header := new(format.PageHeader)
 
 	if err := decoder.Decode(header); err != nil {
 		return err
@@ -763,21 +760,6 @@ func getBufioReaderPool(size int) *sync.Pool {
 	pool := &sync.Pool{}
 	bufioReaderPool[size] = pool
 	return pool
-}
-
-var pageHeaderPool = &sync.Pool{
-	New: func() interface{} {
-		return new(format.PageHeader)
-	},
-}
-
-func getPageHeader() *format.PageHeader {
-	return pageHeaderPool.Get().(*format.PageHeader)
-}
-
-func putPageHeader(h *format.PageHeader) {
-	*h = format.PageHeader{}
-	pageHeaderPool.Put(h)
 }
 
 func (f *File) readAt(p []byte, off int64) (int, error) {


### PR DESCRIPTION
Removes `format.PageHeader` caching, introduced in https://github.com/segmentio/parquet-go/pull/484. The impact of this optimization turned out to be less than expected after the page was reset before putting back into the pool (https://github.com/parquet-go/parquet-go/pull/11). Because of that, all the values referenced by pointers are lost, which was a significant part of the savings.

Even after that change, reusing page headers still could cause instability issues in certain edge cases. So, it's finally removed.

Fixes https://github.com/parquet-go/parquet-go/issues/70