### PR TITLE
add support for field id

### DIFF
--- a/column.go
+++ b/column.go
@@ -76,6 +76,9 @@ func (c *Column) Path() []string { return c.path[1:] }
 // Name returns the column name.
 func (c *Column) Name() string { return c.schema.Name }
 
+// FieldID returns column field id
+func (c *Column) FieldID() int32 { return c.schema.FieldID }
+
 // Columns returns the list of child columns.
 //
 // The method returns the same slice across multiple calls, the program must

--- a/column.go
+++ b/column.go
@@ -76,8 +76,8 @@ func (c *Column) Path() []string { return c.path[1:] }
 // Name returns the column name.
 func (c *Column) Name() string { return c.schema.Name }
 
-// FieldID returns column field id
-func (c *Column) FieldID() int { return int(c.schema.FieldID) }
+// ID returns column field id
+func (c *Column) ID() int { return int(c.schema.FieldID) }
 
 // Columns returns the list of child columns.
 //

--- a/column.go
+++ b/column.go
@@ -77,7 +77,7 @@ func (c *Column) Path() []string { return c.path[1:] }
 func (c *Column) Name() string { return c.schema.Name }
 
 // FieldID returns column field id
-func (c *Column) FieldID() int32 { return c.schema.FieldID }
+func (c *Column) FieldID() int { return int(c.schema.FieldID) }
 
 // Columns returns the list of child columns.
 //

--- a/node.go
+++ b/node.go
@@ -156,6 +156,20 @@ func (opt *optionalNode) Repeated() bool       { return false }
 func (opt *optionalNode) Required() bool       { return false }
 func (opt *optionalNode) GoType() reflect.Type { return reflect.PtrTo(opt.Node.GoType()) }
 
+// FieldID wraps a node to provide node field id
+func FieldID(node Node, id int32) Node { return &fieldIDNode{Node: node, id: id} }
+
+type fieldIDNode struct {
+	Node
+	id int32
+}
+
+type nodeID interface {
+	ID() int32
+}
+
+func (f *fieldIDNode) ID() int32 { return f.id }
+
 // Repeated wraps the given node to make it repeated.
 func Repeated(node Node) Node { return &repeatedNode{node} }
 

--- a/node.go
+++ b/node.go
@@ -21,7 +21,10 @@ import (
 // Nodes are immutable values and therefore safe to use concurrently from
 // multiple goroutines.
 type Node interface {
-	// Returns field id
+	// The id of this node in its parent node. Zero value is treated as id is not
+	// set. ID only needs to be unique within its parent context.
+	//
+	// This is the same as parquet field_id
 	ID() int
 
 	// Returns a human-readable representation of the parquet node.

--- a/node.go
+++ b/node.go
@@ -21,6 +21,9 @@ import (
 // Nodes are immutable values and therefore safe to use concurrently from
 // multiple goroutines.
 type Node interface {
+	// Returns field id
+	ID() int
+
 	// Returns a human-readable representation of the parquet node.
 	String() string
 
@@ -157,18 +160,14 @@ func (opt *optionalNode) Required() bool       { return false }
 func (opt *optionalNode) GoType() reflect.Type { return reflect.PtrTo(opt.Node.GoType()) }
 
 // FieldID wraps a node to provide node field id
-func FieldID(node Node, id int32) Node { return &fieldIDNode{Node: node, id: id} }
+func FieldID(node Node, id int) Node { return &fieldIDNode{Node: node, id: id} }
 
 type fieldIDNode struct {
 	Node
-	id int32
+	id int
 }
 
-type nodeID interface {
-	ID() int32
-}
-
-func (f *fieldIDNode) ID() int32 { return f.id }
+func (f *fieldIDNode) ID() int { return f.id }
 
 // Repeated wraps the given node to make it repeated.
 func Repeated(node Node) Node { return &repeatedNode{node} }
@@ -198,6 +197,8 @@ func Leaf(typ Type) Node {
 }
 
 type leafNode struct{ typ Type }
+
+func (n *leafNode) ID() int { return 0 }
 
 func (n *leafNode) String() string { return sprint("", n) }
 
@@ -261,6 +262,8 @@ func applyFieldRepetitionType(t format.FieldRepetitionType, repetitionLevel, def
 }
 
 type Group map[string]Node
+
+func (g Group) ID() int { return 0 }
 
 func (g Group) String() string { return sprint("", g) }
 

--- a/print.go
+++ b/print.go
@@ -86,6 +86,13 @@ func printSchemaWithIndent(w io.StringWriter, name string, node Node, indent *pr
 		if name != "" {
 			w.WriteString(" ")
 			w.WriteString(name)
+			if withID, ok := node.(nodeID); ok {
+				id := withID.ID()
+				if id != 0 {
+					w.WriteString(" = ")
+					w.WriteString(strconv.Itoa(int(id)))
+				}
+			}
 		}
 
 		if annotation := annotationOf(node); annotation != "" {

--- a/print.go
+++ b/print.go
@@ -86,12 +86,9 @@ func printSchemaWithIndent(w io.StringWriter, name string, node Node, indent *pr
 		if name != "" {
 			w.WriteString(" ")
 			w.WriteString(name)
-			if withID, ok := node.(nodeID); ok {
-				id := withID.ID()
-				if id != 0 {
-					w.WriteString(" = ")
-					w.WriteString(strconv.Itoa(int(id)))
-				}
+			if id := node.ID(); id != 0 {
+				w.WriteString(" = ")
+				w.WriteString(strconv.Itoa(id))
 			}
 		}
 

--- a/print.go
+++ b/print.go
@@ -86,16 +86,17 @@ func printSchemaWithIndent(w io.StringWriter, name string, node Node, indent *pr
 		if name != "" {
 			w.WriteString(" ")
 			w.WriteString(name)
-			if id := node.ID(); id != 0 {
-				w.WriteString(" = ")
-				w.WriteString(strconv.Itoa(id))
-			}
 		}
 
 		if annotation := annotationOf(node); annotation != "" {
 			w.WriteString(" (")
 			w.WriteString(annotation)
 			w.WriteString(")")
+		}
+
+		if id := node.ID(); id != 0 {
+			w.WriteString(" = ")
+			w.WriteString(strconv.Itoa(id))
 		}
 
 		w.WriteString(";")
@@ -111,6 +112,11 @@ func printSchemaWithIndent(w io.StringWriter, name string, node Node, indent *pr
 			w.WriteString(" (")
 			w.WriteString(annotation)
 			w.WriteString(")")
+		}
+
+		if id := node.ID(); id != 0 {
+			w.WriteString(" = ")
+			w.WriteString(strconv.Itoa(id))
 		}
 
 		w.WriteString(" {")

--- a/schema.go
+++ b/schema.go
@@ -723,7 +723,7 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 		list       bool
 		encoded    encoding.Encoding
 		compressed compress.Codec
-		fieldID    *int
+		fieldID    int
 	)
 
 	setNode := func(n Node) {
@@ -907,7 +907,7 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 			if err != nil {
 				throwInvalidNode(t, "struct field has field id that is not a valid int", name, tag...)
 			}
-			fieldID = &id
+			fieldID = id
 		}
 	})
 
@@ -953,8 +953,8 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 	if optional {
 		node = Optional(node)
 	}
-	if fieldID != nil {
-		node = FieldID(node, *fieldID)
+	if fieldID != 0 {
+		node = FieldID(node, fieldID)
 	}
 	return node
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -181,6 +181,14 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+		{
+			value: new(struct {
+				A string `parquet:"a,id=2"`
+			}),
+			print: `message {
+	required binary a = 2 (STRING);
+}`,
+		},
 	}
 
 	for _, test := range tests {
@@ -188,7 +196,7 @@ func TestSchemaOf(t *testing.T) {
 			schema := parquet.SchemaOf(test.value)
 
 			if s := schema.String(); s != test.print {
-				t.Errorf("\nexpected:\n\n%s\n\nfound:\n\n%s\n", test.print, s)
+				t.Errorf(" \nexpected:\n\n%s\n\nfound:\n\n%s\n", test.print, s)
 			}
 		})
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -183,10 +183,25 @@ func TestSchemaOf(t *testing.T) {
 		},
 		{
 			value: new(struct {
-				A string `parquet:"a,id=2"`
+				A struct {
+					B string `parquet:"b,id(2)"`
+				} `parquet:"a,id(1)"`
+				C map[string]string `parquet:"c,id(3)"`
+				D []string          `parquet:"d,id(4)"`
+				E string            `parquet:"e,optional,id(5)"`
 			}),
 			print: `message {
-	required binary a = 2 (STRING);
+	required group a = 1 {
+		required binary b (STRING) = 2;
+	}
+	required group c (MAP) = 3 {
+		repeated group key_value {
+			required binary key (STRING);
+			required binary value (STRING);
+		}
+	}
+	repeated binary d (STRING) = 4;
+	optional binary e (STRING) = 5;
 }`,
 		},
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -196,7 +196,7 @@ func TestSchemaOf(t *testing.T) {
 			schema := parquet.SchemaOf(test.value)
 
 			if s := schema.String(); s != test.print {
-				t.Errorf(" \nexpected:\n\n%s\n\nfound:\n\n%s\n", test.print, s)
+				t.Errorf("\nexpected:\n\n%s\n\nfound:\n\n%s\n", test.print, s)
 			}
 		})
 	}

--- a/writer.go
+++ b/writer.go
@@ -511,15 +511,11 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 
 	config.Schema.forEachNode(func(name string, node Node) {
 		nodeType := node.Type()
-		fieldID := int32(0)
-		if withID, ok := node.(nodeID); ok {
-			fieldID = withID.ID()
-		}
+
 		repetitionType := (*format.FieldRepetitionType)(nil)
 		if node != config.Schema { // the root has no repetition type
 			repetitionType = fieldRepetitionTypePtrOf(node)
 		}
-
 		// For backward compatibility with older readers, the parquet specification
 		// recommends to set the scale and precision on schema elements when the
 		// column is of logical type decimal.
@@ -544,7 +540,7 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 			ConvertedType:  nodeType.ConvertedType(),
 			Scale:          scale,
 			Precision:      precision,
-			FieldID:        fieldID,
+			FieldID:        int32(node.ID()),
 			LogicalType:    logicalType,
 		})
 	})

--- a/writer.go
+++ b/writer.go
@@ -511,7 +511,10 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 
 	config.Schema.forEachNode(func(name string, node Node) {
 		nodeType := node.Type()
-
+		fieldID := int32(0)
+		if withID, ok := node.(nodeID); ok {
+			fieldID = withID.ID()
+		}
 		repetitionType := (*format.FieldRepetitionType)(nil)
 		if node != config.Schema { // the root has no repetition type
 			repetitionType = fieldRepetitionTypePtrOf(node)
@@ -541,6 +544,7 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 			ConvertedType:  nodeType.ConvertedType(),
 			Scale:          scale,
 			Precision:      precision,
+			FieldID:        fieldID,
 			LogicalType:    logicalType,
 		})
 	})


### PR DESCRIPTION
Closes #20

Part of #44 

This commit adds `id` option on `parquet` tag which is in the form of `id={n}` where n is an `int32` denoting a field it.

The underlying infrastructure was already there. We just add api for users to define and access field id to the parquet schema.

Example

```go
type MySchema struct {
	A string `parquet:"a,id=2"`
}
```

Will set column `a` field id to `2`.

Printing
-----

I wasn't so sure how to show the field id in the printed schema. I settled with showing the id next to the field name. I am open to any suggestions on how to improve field id printing.

The above schema is printed as

```
message {
	required binary a = 2 (STRING);
}
```