### PR TITLE
add tagSource interface for providing parquet tags

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -39,7 +39,7 @@ func NewGenericBuffer[T any](options ...RowGroupOption) *GenericBuffer[T] {
 
 	t := typeOf[T]()
 	if config.Schema == nil && t != nil {
-		config.Schema = schemaOf(dereference(t))
+		config.Schema = schemaOf(dereference(t), defaultTagSource{})
 	}
 
 	if config.Schema == nil {

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -2230,13 +2230,13 @@ func writeRowsFuncOfStruct(t reflect.Type, schema *Schema, path columnPath) writ
 		writeRows writeRowsFunc
 	}
 
-	fields := structFieldsOf(t)
+	fields := structFieldsOf(t, schema.tagSource)
 	columns := make([]column, len(fields))
 
 	for i, f := range fields {
 		optional := false
 		columnPath := path.append(f.Name)
-		forEachStructTagOption(f, func(_ reflect.Type, option, _ string) {
+		forEachStructTagOption(f, schema.tagSource, func(_ reflect.Type, option, _ string) {
 			switch option {
 			case "list":
 				columnPath = columnPath.append("list", "element")

--- a/reader.go
+++ b/reader.go
@@ -44,7 +44,7 @@ func NewGenericReader[T any](input io.ReaderAt, options ...ReaderOption) *Generi
 		if t == nil {
 			c.Schema = rowGroup.Schema()
 		} else {
-			c.Schema = schemaOf(dereference(t))
+			c.Schema = schemaOf(dereference(t), defaultTagSource{})
 		}
 	}
 
@@ -77,7 +77,7 @@ func NewGenericRowGroupReader[T any](rowGroup RowGroup, options ...ReaderOption)
 		if t == nil {
 			c.Schema = rowGroup.Schema()
 		} else {
-			c.Schema = schemaOf(dereference(t))
+			c.Schema = schemaOf(dereference(t), defaultTagSource{})
 		}
 	}
 
@@ -414,7 +414,9 @@ func (r *Reader) Read(row interface{}) error {
 }
 
 func (r *Reader) updateReadSchema(rowType reflect.Type) error {
-	schema := schemaOf(rowType)
+	// Reader is a deprecated api. We won't be supporting other tag provider apart
+	// from the default one.
+	schema := schemaOf(rowType, defaultTagSource{})
 
 	if nodesAreEqual(schema, r.file.schema) {
 		r.read.init(schema, r.file.rowGroup)

--- a/row.go
+++ b/row.go
@@ -407,24 +407,24 @@ type levels struct {
 // individually as the base case.
 type deconstructFunc func([][]Value, levels, reflect.Value)
 
-func deconstructFuncOf(columnIndex int16, node Node) (int16, deconstructFunc) {
+func deconstructFuncOf(columnIndex int16, node Node, source tagSource) (int16, deconstructFunc) {
 	switch {
 	case node.Optional():
-		return deconstructFuncOfOptional(columnIndex, node)
+		return deconstructFuncOfOptional(columnIndex, node, source)
 	case node.Repeated():
-		return deconstructFuncOfRepeated(columnIndex, node)
+		return deconstructFuncOfRepeated(columnIndex, node, source)
 	case isList(node):
-		return deconstructFuncOfList(columnIndex, node)
+		return deconstructFuncOfList(columnIndex, node, source)
 	case isMap(node):
-		return deconstructFuncOfMap(columnIndex, node)
+		return deconstructFuncOfMap(columnIndex, node, source)
 	default:
-		return deconstructFuncOfRequired(columnIndex, node)
+		return deconstructFuncOfRequired(columnIndex, node, source)
 	}
 }
 
 //go:noinline
-func deconstructFuncOfOptional(columnIndex int16, node Node) (int16, deconstructFunc) {
-	columnIndex, deconstruct := deconstructFuncOf(columnIndex, Required(node))
+func deconstructFuncOfOptional(columnIndex int16, node Node, source tagSource) (int16, deconstructFunc) {
+	columnIndex, deconstruct := deconstructFuncOf(columnIndex, Required(node), source)
 	return columnIndex, func(columns [][]Value, levels levels, value reflect.Value) {
 		if value.IsValid() {
 			if value.IsZero() {
@@ -441,8 +441,8 @@ func deconstructFuncOfOptional(columnIndex int16, node Node) (int16, deconstruct
 }
 
 //go:noinline
-func deconstructFuncOfRepeated(columnIndex int16, node Node) (int16, deconstructFunc) {
-	columnIndex, deconstruct := deconstructFuncOf(columnIndex, Required(node))
+func deconstructFuncOfRepeated(columnIndex int16, node Node, source tagSource) (int16, deconstructFunc) {
+	columnIndex, deconstruct := deconstructFuncOf(columnIndex, Required(node), source)
 	return columnIndex, func(columns [][]Value, levels levels, value reflect.Value) {
 		if value.Kind() == reflect.Interface {
 			value = value.Elem()
@@ -463,27 +463,27 @@ func deconstructFuncOfRepeated(columnIndex int16, node Node) (int16, deconstruct
 	}
 }
 
-func deconstructFuncOfRequired(columnIndex int16, node Node) (int16, deconstructFunc) {
+func deconstructFuncOfRequired(columnIndex int16, node Node, source tagSource) (int16, deconstructFunc) {
 	switch {
 	case node.Leaf():
 		return deconstructFuncOfLeaf(columnIndex, node)
 	default:
-		return deconstructFuncOfGroup(columnIndex, node)
+		return deconstructFuncOfGroup(columnIndex, node, source)
 	}
 }
 
-func deconstructFuncOfList(columnIndex int16, node Node) (int16, deconstructFunc) {
-	return deconstructFuncOf(columnIndex, Repeated(listElementOf(node)))
+func deconstructFuncOfList(columnIndex int16, node Node, source tagSource) (int16, deconstructFunc) {
+	return deconstructFuncOf(columnIndex, Repeated(listElementOf(node)), source)
 }
 
 //go:noinline
-func deconstructFuncOfMap(columnIndex int16, node Node) (int16, deconstructFunc) {
+func deconstructFuncOfMap(columnIndex int16, node Node, source tagSource) (int16, deconstructFunc) {
 	keyValue := mapKeyValueOf(node)
 	keyValueType := keyValue.GoType()
 	keyValueElem := keyValueType.Elem()
 	keyType := keyValueElem.Field(0).Type
 	valueType := keyValueElem.Field(1).Type
-	nextColumnIndex, deconstruct := deconstructFuncOf(columnIndex, schemaOf(keyValueElem))
+	nextColumnIndex, deconstruct := deconstructFuncOf(columnIndex, schemaOf(keyValueElem, source), source)
 	return nextColumnIndex, func(columns [][]Value, levels levels, mapValue reflect.Value) {
 		if !mapValue.IsValid() || mapValue.Len() == 0 {
 			deconstruct(columns, levels, reflect.Value{})
@@ -507,11 +507,11 @@ func deconstructFuncOfMap(columnIndex int16, node Node) (int16, deconstructFunc)
 }
 
 //go:noinline
-func deconstructFuncOfGroup(columnIndex int16, node Node) (int16, deconstructFunc) {
+func deconstructFuncOfGroup(columnIndex int16, node Node, source tagSource) (int16, deconstructFunc) {
 	fields := node.Fields()
 	funcs := make([]deconstructFunc, len(fields))
 	for i, field := range fields {
-		columnIndex, funcs[i] = deconstructFuncOf(columnIndex, field)
+		columnIndex, funcs[i] = deconstructFuncOf(columnIndex, field, source)
 	}
 	return columnIndex, func(columns [][]Value, levels levels, value reflect.Value) {
 		if value.IsValid() {
@@ -555,28 +555,28 @@ func deconstructFuncOfLeaf(columnIndex int16, node Node) (int16, deconstructFunc
 
 type reconstructFunc func(reflect.Value, levels, [][]Value) error
 
-func reconstructFuncOf(columnIndex int16, node Node) (int16, reconstructFunc) {
+func reconstructFuncOf(columnIndex int16, node Node, source tagSource) (int16, reconstructFunc) {
 	switch {
 	case node.Optional():
-		return reconstructFuncOfOptional(columnIndex, node)
+		return reconstructFuncOfOptional(columnIndex, node, source)
 	case node.Repeated():
-		return reconstructFuncOfRepeated(columnIndex, node)
+		return reconstructFuncOfRepeated(columnIndex, node, source)
 	case isList(node):
-		return reconstructFuncOfList(columnIndex, node)
+		return reconstructFuncOfList(columnIndex, node, source)
 	case isMap(node):
-		return reconstructFuncOfMap(columnIndex, node)
+		return reconstructFuncOfMap(columnIndex, node, source)
 	default:
-		return reconstructFuncOfRequired(columnIndex, node)
+		return reconstructFuncOfRequired(columnIndex, node, source)
 	}
 }
 
 //go:noinline
-func reconstructFuncOfOptional(columnIndex int16, node Node) (int16, reconstructFunc) {
+func reconstructFuncOfOptional(columnIndex int16, node Node, source tagSource) (int16, reconstructFunc) {
 	// We convert the optional func to required so that we eventually reach the
 	// leaf base-case.  We're still using the heuristics of optional in the
 	// returned closure (see levels.definitionLevel++), but we don't actually do
 	// deserialization here, that happens in the leaf function, hence this line.
-	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node))
+	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node), source)
 
 	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
 		levels.definitionLevel++
@@ -608,8 +608,8 @@ func setMakeSlice(v reflect.Value, n int) reflect.Value {
 }
 
 //go:noinline
-func reconstructFuncOfRepeated(columnIndex int16, node Node) (int16, reconstructFunc) {
-	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node))
+func reconstructFuncOfRepeated(columnIndex int16, node Node, source tagSource) (int16, reconstructFunc) {
+	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node), source)
 	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
 		levels.repetitionDepth++
 		levels.definitionLevel++
@@ -668,26 +668,26 @@ func reconstructFuncOfRepeated(columnIndex int16, node Node) (int16, reconstruct
 	}
 }
 
-func reconstructFuncOfRequired(columnIndex int16, node Node) (int16, reconstructFunc) {
+func reconstructFuncOfRequired(columnIndex int16, node Node, source tagSource) (int16, reconstructFunc) {
 	switch {
 	case node.Leaf():
 		return reconstructFuncOfLeaf(columnIndex, node)
 	default:
-		return reconstructFuncOfGroup(columnIndex, node)
+		return reconstructFuncOfGroup(columnIndex, node, source)
 	}
 }
 
-func reconstructFuncOfList(columnIndex int16, node Node) (int16, reconstructFunc) {
-	return reconstructFuncOf(columnIndex, Repeated(listElementOf(node)))
+func reconstructFuncOfList(columnIndex int16, node Node, source tagSource) (int16, reconstructFunc) {
+	return reconstructFuncOf(columnIndex, Repeated(listElementOf(node)), source)
 }
 
 //go:noinline
-func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc) {
+func reconstructFuncOfMap(columnIndex int16, node Node, source tagSource) (int16, reconstructFunc) {
 	keyValue := mapKeyValueOf(node)
 	keyValueType := keyValue.GoType()
 	keyValueElem := keyValueType.Elem()
 	keyValueZero := reflect.Zero(keyValueElem)
-	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, schemaOf(keyValueElem))
+	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, schemaOf(keyValueElem, source), source)
 	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
 		levels.repetitionDepth++
 		levels.definitionLevel++
@@ -752,14 +752,14 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 }
 
 //go:noinline
-func reconstructFuncOfGroup(columnIndex int16, node Node) (int16, reconstructFunc) {
+func reconstructFuncOfGroup(columnIndex int16, node Node, source tagSource) (int16, reconstructFunc) {
 	fields := node.Fields()
 	funcs := make([]reconstructFunc, len(fields))
 	columnOffsets := make([]int16, len(fields))
 	firstColumnIndex := columnIndex
 
 	for i, field := range fields {
-		columnIndex, funcs[i] = reconstructFuncOf(columnIndex, field)
+		columnIndex, funcs[i] = reconstructFuncOf(columnIndex, field, source)
 		columnOffsets[i] = columnIndex - firstColumnIndex
 	}
 

--- a/row_buffer.go
+++ b/row_buffer.go
@@ -38,7 +38,7 @@ func NewRowBuffer[T any](options ...RowGroupOption) *RowBuffer[T] {
 
 	t := typeOf[T]()
 	if config.Schema == nil && t != nil {
-		config.Schema = schemaOf(dereference(t))
+		config.Schema = schemaOf(dereference(t), defaultTagSource{})
 	}
 
 	if config.Schema == nil {

--- a/writer.go
+++ b/writer.go
@@ -92,7 +92,7 @@ func NewGenericWriter[T any](output io.Writer, options ...WriterOption) *Generic
 	t := typeOf[T]()
 
 	if schema == nil && t != nil {
-		schema = schemaOf(dereference(t))
+		schema = schemaOf(dereference(t), defaultTagSource{})
 		config.Schema = schema
 	}
 


### PR DESCRIPTION
Part of #44

This can be reviewed and merged separately

This commit adds `tagSource` interface that defines api for providing parquet tags from `*reflect.StructField`.

The api is private to avoid user provided implementation. We reserve interpretation and processing of the tags as an implementation detail.

The api explicitly passes `tagSource` instead of variadic `...tagSource` to ensure that processing should not care about where the tags come from.

For now `defaultTagSource` is the only implementation that reads `parquet` `parquet-key` and `parquet-value` tags