### PR TITLE
Fix minimum Go version in README documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dependency on and install with the following command:
 go get github.com/parquet-go/parquet-go
 ```
 
-Go 1.18 or later is required to use the package.
+Go 1.20 or later is required to use the package.
 
 ### Compatibility Guarantees
 


### PR DESCRIPTION
According to https://go.dev/ref/mod#go-mod-file
the line in go.mod denoting:
`go 1.20`
means Go 1.20+ is required to use with this module (since Go 1.21+ which is current it is no longer only advisory)
I think it makes sense to update this in documentation.