### PR TITLE
improve compatiblity and fix issues

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -83,7 +83,7 @@ func convertToSelf(column []Value) error { return nil }
 func convertToType(targetType, sourceType Type) conversionFunc {
 	return func(column []Value) error {
 		for i, v := range column {
-			v, err := sourceType.ConvertValue(v, targetType)
+			v, err := targetType.ConvertValue(v, sourceType)
 			if err != nil {
 				return err
 			}

--- a/type_assign_test.go
+++ b/type_assign_test.go
@@ -1,0 +1,174 @@
+package parquet_test
+
+import (
+	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/deprecated"
+	"reflect"
+	"testing"
+)
+
+func toPtr[T any](obj T) *T {
+	return &obj
+}
+
+func TestAssignValues(t *testing.T) {
+	var (
+		boolType    = reflect.TypeOf(true)
+		int32Type   = reflect.TypeOf(int32(0))
+		int64Type   = reflect.TypeOf(int64(0))
+		int96Type   = reflect.TypeOf(deprecated.Int96{})
+		float32Type = reflect.TypeOf(float32(0))
+		float64Type = reflect.TypeOf(float64(0))
+		stringType  = reflect.TypeOf("")
+	)
+
+	var assignValueTests = [...]struct {
+		scenario  string
+		fromType  parquet.Type
+		fromValue parquet.Value
+		toType    reflect.Type
+		toValue   reflect.Value
+	}{
+		{
+			scenario:  "bool to bool",
+			fromType:  parquet.BooleanType,
+			fromValue: parquet.BooleanValue(true),
+			toType:    boolType,
+			toValue:   reflect.ValueOf(true),
+		},
+		{
+			scenario:  "bool to *bool",
+			fromType:  parquet.BooleanType,
+			fromValue: parquet.BooleanValue(true),
+			toType:    reflect.PtrTo(boolType),
+			toValue:   reflect.ValueOf(toPtr(true)),
+		},
+		{
+			scenario:  "int32 to int32",
+			fromType:  parquet.Int32Type,
+			fromValue: parquet.Int32Value(1254),
+			toType:    int32Type,
+			toValue:   reflect.ValueOf(int32(1254)),
+		},
+		{
+			scenario:  "int32 to *int32",
+			fromType:  parquet.Int32Type,
+			fromValue: parquet.Int32Value(1254),
+			toType:    reflect.PtrTo(int32Type),
+			toValue:   reflect.ValueOf(toPtr(int32(1254))),
+		},
+		{
+			scenario:  "int64 to int64",
+			fromType:  parquet.Int64Type,
+			fromValue: parquet.Int64Value(1254),
+			toType:    int64Type,
+			toValue:   reflect.ValueOf(int64(1254)),
+		},
+		{
+			scenario:  "int64 to *int64",
+			fromType:  parquet.Int64Type,
+			fromValue: parquet.Int32Value(1254),
+			toType:    reflect.PtrTo(int64Type),
+			toValue:   reflect.ValueOf(toPtr(int64(1254))),
+		},
+		{
+			scenario:  "int96 to int96",
+			fromType:  parquet.Int96Type,
+			fromValue: parquet.Int96Value(deprecated.Int96{0: 1254}),
+			toType:    int96Type,
+			toValue:   reflect.ValueOf(deprecated.Int96{0: 1254}),
+		},
+		{
+			scenario:  "int96 to *int96",
+			fromType:  parquet.Int96Type,
+			fromValue: parquet.Int96Value(deprecated.Int96{0: 1254}),
+			toType:    reflect.PtrTo(int96Type),
+			toValue:   reflect.ValueOf(toPtr(deprecated.Int96{0: 1254})),
+		},
+		{
+			scenario:  "float32 to float32",
+			fromType:  parquet.FloatType,
+			fromValue: parquet.FloatValue(float32(12.54)),
+			toType:    float32Type,
+			toValue:   reflect.ValueOf(float32(12.54)),
+		},
+		{
+			scenario:  "float32 to *float32",
+			fromType:  parquet.FloatType,
+			fromValue: parquet.FloatValue(float32(12.54)),
+			toType:    reflect.PtrTo(float32Type),
+			toValue:   reflect.ValueOf(toPtr(float32(12.54))),
+		},
+		{
+			scenario:  "float64 to float64",
+			fromType:  parquet.DoubleType,
+			fromValue: parquet.DoubleValue(12.54),
+			toType:    float64Type,
+			toValue:   reflect.ValueOf(12.54),
+		},
+		{
+			scenario:  "float64 to *float64",
+			fromType:  parquet.DoubleType,
+			fromValue: parquet.DoubleValue(12.54),
+			toType:    reflect.PtrTo(float64Type),
+			toValue:   reflect.ValueOf(toPtr(12.54)),
+		},
+		{
+			scenario:  "byteArray to string",
+			fromType:  parquet.ByteArrayType,
+			fromValue: parquet.ByteArrayValue([]byte("test value")),
+			toType:    stringType,
+			toValue:   reflect.ValueOf("test value"),
+		},
+		{
+			scenario:  "byteArray to *string",
+			fromType:  parquet.ByteArrayType,
+			fromValue: parquet.ByteArrayValue([]byte("test value")),
+			toType:    reflect.PtrTo(stringType),
+			toValue:   reflect.ValueOf(toPtr("test value")),
+		},
+		// type conversion tests
+		{
+			scenario:  "int32 to *int64",
+			fromType:  parquet.Int32Type,
+			fromValue: parquet.Int32Value(1254),
+			toType:    reflect.PtrTo(int64Type),
+			toValue:   reflect.ValueOf(toPtr(int64(1254))),
+		},
+		{
+			scenario:  "int64 to *int32",
+			fromType:  parquet.Int64Type,
+			fromValue: parquet.Int64Value(1254),
+			toType:    reflect.PtrTo(int32Type),
+			toValue:   reflect.ValueOf(toPtr(int32(1254))),
+		},
+		{
+			scenario:  "float64 to *float32",
+			fromType:  parquet.DoubleType,
+			fromValue: parquet.DoubleValue(12.54),
+			toType:    reflect.PtrTo(float32Type),
+			toValue:   reflect.ValueOf(toPtr(float32(12.54))),
+		},
+		// testing float32 to float64 is not viable, as it is prone to value mismatch due to precision errors
+	}
+
+	for _, testCase := range assignValueTests {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			got := reflect.New(testCase.toType)
+
+			err := testCase.fromType.AssignValue(got.Elem(), testCase.fromValue)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got.Elem().Kind() != testCase.toValue.Kind() {
+				t.Errorf("assigned kinds not equal: \nwant = %+v\ngot  = %+v", testCase.toValue.Kind(),
+					got.Elem().Kind())
+			}
+			if !reflect.Indirect(got.Elem()).Equal(reflect.Indirect(testCase.toValue)) {
+				t.Errorf("assigned values not equal: \nwant = %+v\ngot  = %+v", reflect.Indirect(testCase.toValue),
+					reflect.Indirect(got.Elem()))
+			}
+		})
+	}
+}

--- a/value.go
+++ b/value.go
@@ -793,6 +793,10 @@ func (v Value) Clone() Value {
 }
 
 func makeInt96(bits []byte) (i96 deprecated.Int96) {
+	if len(bits) < 12 {
+		buf := [12]byte{}
+		bits = append(buf[:0], bits...)
+	}
 	return deprecated.Int96{
 		2: binary.LittleEndian.Uint32(bits[8:12]),
 		1: binary.LittleEndian.Uint32(bits[4:8]),


### PR DESCRIPTION
Hello and thank you for your great project! While I was trying to use this project to migrate data from parquet files to another DB, I encountered few problems and fixed them using the commits in this PR.

1: to better distinguish between 0 values and null pointers I had a struct in which fields were of types *int32, *int64 etc. since parquet-go was unable to fill the fields and was throwing out panics, I made changes to allow such conversions, so now we can store values in their pointer counterpart IF the value type and the pointer's underlying type are castable to each other.

2: Regarding Int96 value, I had a problem that sometimes the length of the read bytes was less than 12, or even when it was nil it was still being processed and resulted in golang "unexpected fault" error which is quite the fatal error! I decided that checking whether the initial address of our data was valid before making the byte array was a solution for this problem, and also appending extra 0s to the byte array to compensate for the lack of missing bytes allowed for going forward while keeping the original data intact.

3: I had to read tons of parquet files, some of which were broken! The panic in generic reader made it really hard for me to go forward ignoring broken files, so I changed the function to return an error instead of panicking, therefore I was able to ignore broken files and keep going on.

I believe there is a problem regarding reading NULL Int96 values which results in the unexpected fault error mentioned above, since the type was deprecated I didn't dig deep into it and simply checked for validity of the read value (the initial byte pointer) and compensated for lack of tailing 0s by adding them myself, if development of Int96 is still of interest, maybe fixing this in the future can help!