### PR TITLE
Fix dictionary compression overflow

### DIFF
--- a/column.go
+++ b/column.go
@@ -539,7 +539,14 @@ func schemaRepetitionTypeOf(s *format.SchemaElement) format.FieldRepetitionType 
 }
 
 func (c *Column) decompress(compressedPageData []byte, uncompressedPageSize int32) (page *buffer, err error) {
-	page = buffers.get(int(uncompressedPageSize))
+	nSize := int(uncompressedPageSize)
+	if nSize < 0 {
+		// this size overflowed int32.
+		convert32 := uint32(uncompressedPageSize)
+		nSize = int(convert32)
+	}
+
+	page = buffers.get(nSize)
 	page.data, err = c.compression.Decode(page.data, compressedPageData)
 	if err != nil {
 		page.unref()


### PR DESCRIPTION
Posting this PR to show a solution that technically works to fix #79 but is not necessarily a good one :). Obviously this will only work on systems where the int width is 64 bits.

Also, since the snappy decompression library correctly resizes the buffer it receives this technically works as well:
```
	nSize := int(uncompressedPageSize)
	if nSize < 0 {
            nSize = 1
	}

	page = buffers.get(nSize)
```

There's a lot of options here. This just protects from the panic and will allow the library to move forward under certain circumstances. We should also address this on the write side.

We could
- return an error on write if the size overflows an int32?
- change the pageheader from storing the value in an int32 to unsigned int32?