### PR TITLE
Error when uncompressed page size exceeds the max int32 value

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -21,7 +21,7 @@ import (
 const (
 	// The uncompressed page size is stored as int32 and must not be larger than the
 	// maximum int32 value (see format.PageHeader).
-	maxUncompressedPageSize = int(^uint32(0) >> 1)
+	maxUncompressedPageSize = math.MaxInt32
 )
 
 // GenericWriter is similar to a Writer but uses a type parameter to define the
@@ -1370,7 +1370,7 @@ func (c *writerColumn) writeDataPage(page Page) (int64, error) {
 
 	uncompressedPageSize := buf.size()
 	if uncompressedPageSize > maxUncompressedPageSize {
-		return 0, fmt.Errorf("page size must not be larger than %d but was %d", maxUncompressedPageSize, uncompressedPageSize)
+		return 0, fmt.Errorf("page size limit exceeded: %d>%d", uncompressedPageSize, maxUncompressedPageSize)
 	}
 	if c.isCompressed {
 		if err := buf.compress(c.compression); err != nil {
@@ -1468,7 +1468,7 @@ func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 
 	uncompressedPageSize := buf.size()
 	if uncompressedPageSize > maxUncompressedPageSize {
-		return fmt.Errorf("page size must not be larger than %d but was %d", maxUncompressedPageSize, uncompressedPageSize)
+		return fmt.Errorf("page size limit exceeded: %d>%d", maxUncompressedPageSize, uncompressedPageSize)
 	}
 	if isCompressed(c.compression) {
 		if err := buf.compress(c.compression); err != nil {

--- a/writer.go
+++ b/writer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"math/bits"
 	"reflect"
 	"sort"
@@ -1468,7 +1469,7 @@ func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 
 	uncompressedPageSize := buf.size()
 	if uncompressedPageSize > maxUncompressedPageSize {
-		return fmt.Errorf("page size limit exceeded: %d>%d", maxUncompressedPageSize, uncompressedPageSize)
+		return fmt.Errorf("page size limit exceeded: %d>%d", uncompressedPageSize, maxUncompressedPageSize)
 	}
 	if isCompressed(c.compression) {
 		if err := buf.compress(c.compression); err != nil {


### PR DESCRIPTION
This prevents writing corrupted files due to integer overflows in cases where the uncompressed page size get's too large.

The PR helps to mitigate #79