### PR TITLE
Fix NumValues for missingColumnChunk

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -457,7 +457,7 @@ func (c *missingColumnChunk) Pages() Pages             { return onePage(missingP
 func (c *missingColumnChunk) ColumnIndex() ColumnIndex { return missingColumnIndex{c} }
 func (c *missingColumnChunk) OffsetIndex() OffsetIndex { return missingOffsetIndex{} }
 func (c *missingColumnChunk) BloomFilter() BloomFilter { return missingBloomFilter{} }
-func (c *missingColumnChunk) NumValues() int64         { return 0 }
+func (c *missingColumnChunk) NumValues() int64         { return c.numValues }
 
 type missingColumnIndex struct{ *missingColumnChunk }
 


### PR DESCRIPTION
A missingColumnChunk can be created during schema conversion when a column does not exist in the target schema. The number of values for the chunk is considered to be equal to the number of rows in the row group, but the value returned by NumValues is currently 0.

Since the page of the chunk returns the number of rows in the group as number of values, it would be consistent for the chunk to do the same.