### PR TITLE
Fix slicing a missing page

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -490,12 +490,22 @@ func (p missingPage) NumRows() int64                    { return p.numRows }
 func (p missingPage) NumValues() int64                  { return p.numValues }
 func (p missingPage) NumNulls() int64                   { return p.numNulls }
 func (p missingPage) Bounds() (min, max Value, ok bool) { return }
-func (p missingPage) Slice(i, j int64) Page             { return p }
-func (p missingPage) Size() int64                       { return 0 }
-func (p missingPage) RepetitionLevels() []byte          { return nil }
-func (p missingPage) DefinitionLevels() []byte          { return nil }
-func (p missingPage) Data() encoding.Values             { return p.typ.NewValues(nil, nil) }
-func (p missingPage) Values() ValueReader               { return &missingPageValues{page: p} }
+func (p missingPage) Slice(i, j int64) Page {
+	return missingPage{
+		&missingColumnChunk{
+			typ:       p.typ,
+			column:    p.column,
+			numRows:   j - i,
+			numValues: j - i,
+			numNulls:  j - i,
+		},
+	}
+}
+func (p missingPage) Size() int64              { return 0 }
+func (p missingPage) RepetitionLevels() []byte { return nil }
+func (p missingPage) DefinitionLevels() []byte { return nil }
+func (p missingPage) Data() encoding.Values    { return p.typ.NewValues(nil, nil) }
+func (p missingPage) Values() ValueReader      { return &missingPageValues{page: p} }
 
 type missingPageValues struct {
 	page missingPage


### PR DESCRIPTION
Slicing a missing page returns a new page with the same number of values. This causes issues when reading rows because columns end up with a different number of values.

This commit fixes that by setting the number of values in the page to the range of the slice.