### PR TITLE
Avoid panic in reconstructFuncOfRepeated

### DIFF
--- a/row.go
+++ b/row.go
@@ -581,6 +581,14 @@ func reconstructFuncOfOptional(columnIndex int16, node Node) (int16, reconstruct
 	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
 		levels.definitionLevel++
 
+		if len(columns) == 0 {
+			return nil
+		}
+
+		if len(columns[0]) == 0 {
+			return nil
+		}
+
 		if columns[0][0].definitionLevel < levels.definitionLevel {
 			value.Set(reflect.Zero(value.Type()))
 			return nil
@@ -699,6 +707,14 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
 		levels.repetitionDepth++
 		levels.definitionLevel++
+
+		if len(columns) == 0 {
+			return nil
+		}
+
+		if len(columns[0]) == 0 {
+			return nil
+		}
 
 		if columns[0][0].definitionLevel < levels.definitionLevel {
 			value.Set(reflect.MakeMap(value.Type()))

--- a/row.go
+++ b/row.go
@@ -614,6 +614,14 @@ func reconstructFuncOfRepeated(columnIndex int16, node Node) (int16, reconstruct
 		levels.repetitionDepth++
 		levels.definitionLevel++
 
+		if len(columns) == 0 {
+			return nil
+		}
+
+		if len(columns[0]) == 0 {
+			return nil
+		}
+
 		if columns[0][0].definitionLevel < levels.definitionLevel {
 			setMakeSlice(value, 0)
 			return nil


### PR DESCRIPTION
Hello, 

I came across an issue where I would occasionally get a panic when reading files created by AWS Kinesis firehose, seemed to be when a nested array was nil, unfortunately I'm unable to provide example files.

Checking for empty arrays then returning nil seemed to fix my issues.