### PR TITLE
Return errors for missing page indices

### DIFF
--- a/column_chunk.go
+++ b/column_chunk.go
@@ -1,7 +1,13 @@
 package parquet
 
 import (
+	"errors"
 	"io"
+)
+
+var (
+	ErrMissingColumnIndex = errors.New("missing column index")
+	ErrMissingOffsetIndex = errors.New("missing offset index")
 )
 
 // The ColumnChunk interface represents individual columns of a row group.
@@ -22,7 +28,8 @@ type ColumnChunk interface {
 	// Note that the returned value may be the same across calls to these
 	// methods, programs must treat those as read-only.
 	//
-	// If the column chunk does not have a page index, the methods return nil.
+	// If the column chunk does not have a column or offset index, the methods return
+	// ErrMissingColumnIndex or ErrMissingOffsetIndex respectively.
 	//
 	// Prior to v0.20, these methods did not return an error because the page index
 	// for a file was either fully read when the file was opened, or skipped

--- a/file.go
+++ b/file.go
@@ -465,8 +465,8 @@ func (c *fileColumnChunk) ColumnIndex() (ColumnIndex, error) {
 	if err := c.readColumnIndex(); err != nil {
 		return nil, err
 	}
-	if c.columnIndex == nil {
-		return nil, nil
+	if c.columnIndex == nil || c.chunk.ColumnIndexOffset == 0 {
+		return nil, ErrMissingColumnIndex
 	}
 	return fileColumnIndex{c}, nil
 }
@@ -475,8 +475,8 @@ func (c *fileColumnChunk) OffsetIndex() (OffsetIndex, error) {
 	if err := c.readOffsetIndex(); err != nil {
 		return nil, err
 	}
-	if c.offsetIndex == nil {
-		return nil, nil
+	if c.offsetIndex == nil || c.chunk.OffsetIndexOffset == 0 {
+		return nil, ErrMissingOffsetIndex
 	}
 	return (*fileOffsetIndex)(c.offsetIndex), nil
 }
@@ -499,7 +499,6 @@ func (c *fileColumnChunk) readColumnIndex() error {
 	chunkMeta := c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
 	offset, length := chunkMeta.ColumnIndexOffset, chunkMeta.ColumnIndexLength
 	if offset == 0 {
-		c.columnIndex = &format.ColumnIndex{}
 		return nil
 	}
 
@@ -522,7 +521,6 @@ func (c *fileColumnChunk) readOffsetIndex() error {
 	chunkMeta := c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
 	offset, length := chunkMeta.OffsetIndexOffset, chunkMeta.OffsetIndexLength
 	if offset == 0 {
-		c.offsetIndex = &format.OffsetIndex{}
 		return nil
 	}
 


### PR DESCRIPTION
As a result of https://github.com/parquet-go/parquet-go/pull/84, we can now return a `nil` column or offset index when the `SkipPageIndex` option is set. Furthermore, if the page index is not skipped when opening a file, the return value for missing indices will be a zero-value struct instead of nil.

This commit reconciles this inconsistency by returning `ErrMissingColumnIndex` and `ErrMissingOffsetIndex` respectively when either index is missing.

Follow up to https://github.com/parquet-go/parquet-go/pull/85#discussion_r1400269216.