### PR TITLE
List-type columns are able distinguish between nil and empty slice

### DIFF
--- a/parquet_test.go
+++ b/parquet_test.go
@@ -763,6 +763,28 @@ type nestedListColumn struct {
 	Level2 []utf8string        `parquet:"level2"`
 }
 
+type optionalListColumn struct {
+	OptionalList []int `parquet:",list,optional"`
+}
+
+func (optionalListColumn) Generate(rand *rand.Rand, size int) reflect.Value {
+	var ints []int
+	switch rand.Intn(3) {
+	case 0:
+		// test for non-empty slice
+		n := rand.Intn(size)
+		for i := 0; i < n; i++ {
+			ints = append(ints, rand.Intn(1000))
+		}
+	case 1:
+		// test for empty slice
+		ints = []int{}
+	default:
+		// test for nil slice
+	}
+	return reflect.ValueOf(optionalListColumn{OptionalList: ints})
+}
+
 type utf8string string
 
 func (utf8string) Generate(rand *rand.Rand, size int) reflect.Value {

--- a/reader_test.go
+++ b/reader_test.go
@@ -38,6 +38,7 @@ func TestGenericReader(t *testing.T) {
 	testGenericReader[listColumn0](t)
 	testGenericReader[nestedListColumn1](t)
 	testGenericReader[nestedListColumn](t)
+	testGenericReader[optionalListColumn](t)
 	testGenericReader[*contact](t)
 	testGenericReader[paddedBooleanColumn](t)
 	testGenericReader[optionalInt32Column](t)

--- a/sparse/array.go
+++ b/sparse/array.go
@@ -12,6 +12,7 @@ func UnsafeArray(base unsafe.Pointer, length int, offset uintptr) Array {
 }
 
 func (a Array) Len() int                   { return int(a.len) }
+func (a Array) Nil() bool                  { return a.ptr == nil }
 func (a Array) Index(i int) unsafe.Pointer { return a.index(i) }
 func (a Array) Slice(i, j int) Array       { return Array{a.slice(i, j)} }
 func (a Array) Offset(off uintptr) Array   { return Array{a.offset(off)} }


### PR DESCRIPTION
Schemata with columns that are labeled as optional lists can distinguish between nil and empty slice values. Given the following schema:

```go
type Row struct {
   List []string `parquet:",list,optional"`
}
```

It is now possible to write the following data using `GenericWriter` and retrieve it back with `GenericReader`:

```go
data := []Row{{List: []string{}}, {List: nil}, List: []string{"foo", "bar"}}
```

This fixes #7