### PR TITLE
Use buffer pool for dictionary pages

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -648,6 +648,43 @@ func (p *bufferedPage) Release() {
 	bufferUnref(p.repetitionLevels)
 }
 
+type bufferedDictionary struct {
+	Dictionary
+	values  *buffer
+	offsets *buffer
+}
+
+func newBufferedDictionary(dict Dictionary, values, offsets *buffer) Dictionary {
+	p := &bufferedDictionary{
+		Dictionary: dict,
+		values:     values,
+		offsets:    offsets,
+	}
+	bufferRef(values)
+	bufferRef(offsets)
+	return p
+}
+
+func (d *bufferedDictionary) Page() Page {
+	return newBufferedPage(
+		d.Dictionary.Page(),
+		d.values,
+		d.offsets,
+		nil,
+		nil,
+	)
+}
+
+func (d *bufferedDictionary) Retain() {
+	bufferRef(d.values)
+	bufferRef(d.offsets)
+}
+
+func (d *bufferedDictionary) Release() {
+	bufferUnref(d.values)
+	bufferUnref(d.offsets)
+}
+
 func bufferRef(buf *buffer) {
 	if buf != nil {
 		buf.ref()
@@ -699,6 +736,12 @@ func Retain(page Page) {
 func Release(page Page) {
 	if p, _ := page.(releasable); p != nil {
 		p.Release()
+	}
+}
+
+func ReleaseDictionary(d Dictionary) {
+	if d, _ := d.(releasable); d != nil {
+		d.Release()
 	}
 }
 

--- a/file.go
+++ b/file.go
@@ -781,6 +781,7 @@ func (f *filePages) Close() error {
 	f.dictOffset = 0
 	f.index = 0
 	f.skip = 0
+	ReleaseDictionary(f.dictionary)
 	f.dictionary = nil
 	return nil
 }

--- a/writer.go
+++ b/writer.go
@@ -1207,7 +1207,9 @@ func (c *writerColumn) flushFilterPages() error {
 		// be reused after resetting which would have reset the length of
 		// the filter to 0.
 		c.resizeBloomFilter(int64(dict.Len()))
-		return c.writePageToFilter(dict.Page())
+		dictPage := dict.Page()
+		defer Release(dictPage)
+		return c.writePageToFilter(dictPage)
 	}
 
 	// When the filter was already allocated, pages have been written to it as
@@ -1463,6 +1465,8 @@ func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 	buf := c.buffers
 	buf.reset()
 
+	dictPage := dict.Page()
+	defer Release(dictPage)
 	if err := buf.encode(dict.Page(), &Plain); err != nil {
 		return fmt.Errorf("writing parquet dictionary page: %w", err)
 	}


### PR DESCRIPTION
This commit reduces allocations by introducing the bufferedDictionary object, which is the equivalent of bufferedPage for the Dictionary interface. This new object uses the existing buffer pool.