### PR TITLE
Estimate dictionary decode size

### DIFF
--- a/column.go
+++ b/column.go
@@ -784,8 +784,10 @@ func (c *Column) decodeDictionary(header DictionaryPageHeader, page *buffer, siz
 		pageEncoding = format.Plain
 	}
 
+	// Dictionaries always have PLAIN encoding, so we need to allocate offsets for the decoded page.
 	numValues := int(header.NumValues())
-	values := pageType.NewValues(nil, nil)
+	dictBufferSize := pageType.EstimateDecodeSize(numValues, pageData, LookupEncoding(pageEncoding))
+	values := pageType.NewValues(make([]byte, dictBufferSize), make([]uint32, numValues))
 	values, err := pageType.Decode(values, pageData, LookupEncoding(pageEncoding))
 	if err != nil {
 		return nil, err

--- a/column.go
+++ b/column.go
@@ -787,7 +787,7 @@ func (c *Column) decodeDictionary(header DictionaryPageHeader, page *buffer, siz
 	// Dictionaries always have PLAIN encoding, so we need to allocate offsets for the decoded page.
 	numValues := int(header.NumValues())
 	dictBufferSize := pageType.EstimateDecodeSize(numValues, pageData, LookupEncoding(pageEncoding))
-	values := pageType.NewValues(make([]byte, dictBufferSize), make([]uint32, numValues))
+	values := pageType.NewValues(make([]byte, 0, dictBufferSize), make([]uint32, 0, numValues))
 	values, err := pageType.Decode(values, pageData, LookupEncoding(pageEncoding))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As originally described in https://github.com/parquet-go/parquet-go/pull/96, column dictionaries are not properly sized befored decoding which leads to many small allocations in a loop.

This PR extracts the part of #96 which does buffer size estimation for dictionaries until we figure out a safe way to pool those buffers.

@asubiotto let me know what you think.