### PR TITLE
Bug: Respect current page offset in reslice

### DIFF
--- a/page.go
+++ b/page.go
@@ -585,17 +585,20 @@ func (page *booleanPage) Bounds() (min, max Value, ok bool) {
 }
 
 func (page *booleanPage) Slice(i, j int64) Page {
-	off := i / 8
-	end := j / 8
+	lowWithOffset := i + int64(page.offset)
+	highWithOffset := j + int64(page.offset)
 
-	if (j % 8) != 0 {
+	off := lowWithOffset / 8
+	end := highWithOffset / 8
+
+	if (highWithOffset % 8) != 0 {
 		end++
 	}
 
 	return &booleanPage{
 		typ:         page.typ,
 		bits:        page.bits[off:end],
-		offset:      int32(i % 8),
+		offset:      int32(lowWithOffset % 8),
 		numValues:   int32(j - i),
 		columnIndex: page.columnIndex,
 	}

--- a/page_test.go
+++ b/page_test.go
@@ -537,11 +537,16 @@ func TestReslicingBooleanPage(t *testing.T) {
 	}
 
 	// continue reslicing and reading the values
-	for i := 0; i < numValues-1; i += 3 {
+	sliceEvery := 3
+	for i := 0; i < numValues-1; i += sliceEvery {
 		vs := make([]parquet.Value, numValues)
 
-		low := int64(1)
+		low := int64(sliceEvery)
 		high := int64(numValues - i)
+
+		if low >= high {
+			break
+		}
 
 		// slice the page
 		pg = pg.Slice(low, high)


### PR DESCRIPTION
Currently if you reslice a boolean page it will not respect it's internal bit offset into the first byte. The impact is that if you slice a boolean page multiple times on values that are not byte aligned the page will return misaligned values when reading.