### PR TITLE
Allow specifying delta on field of type time.Time

### DIFF
--- a/parquet_test.go
+++ b/parquet_test.go
@@ -402,7 +402,6 @@ func TestIssue423(t *testing.T) {
 	}
 
 	schema := parquet.SchemaOf(new(Outer))
-	fmt.Println(schema.String())
 	buf := new(bytes.Buffer)
 	w := parquet.NewGenericWriter[Outer](buf, schema)
 	_, err := w.Write(writeRows)

--- a/schema.go
+++ b/schema.go
@@ -818,7 +818,12 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 					throwInvalidTag(t, name, option)
 				}
 			default:
-				throwInvalidTag(t, name, option)
+				switch t {
+				case reflect.TypeOf(time.Time{}):
+					setEncoding(&DeltaBinaryPacked)
+				default:
+					throwInvalidTag(t, name, option)
+				}
 			}
 
 		case "split":

--- a/schema_test.go
+++ b/schema_test.go
@@ -2,6 +2,7 @@ package parquet_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/parquet-go/parquet-go"
 )
@@ -202,6 +203,14 @@ func TestSchemaOf(t *testing.T) {
 	}
 	repeated binary d (STRING) = 4;
 	optional binary e (STRING) = 5;
+}`,
+		},
+		{
+			value: new(struct {
+				Time time.Time `parquet:"time,delta"`
+			}),
+			print: `message {
+	required int64 time (TIMESTAMP(isAdjustedToUTC=true,unit=NANOS));
 }`,
 		},
 	}


### PR DESCRIPTION
Fixes #112 

This allows specifying the delta tag on a `time.Time`.

I added a test to verify that it successfully creates a schema object, but have not verified that it actually uses the delta encoding.