### PR TITLE
Fix s/condution/conduct/

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ for the full interface documentation.
 
 While initial design and development occurred at Twilio Segment, the project is now maintained by the open source community. We welcome external contributors.
 to participate in the form of discussions or code changes. Please review to the
-[Contribution](./CONTRIBUTING.md) guidelines as well as the [Code of Condution](./CODE_OF_CONDUCT.md)
+[Contribution](./CONTRIBUTING.md) guidelines as well as the [Code of Conduct](./CODE_OF_CONDUCT.md)
 before submitting contributions.
 
 ### Continuous Integration


### PR DESCRIPTION
I happened to come across this somewhat odd typo.