### PR TITLE
Read logical maps as go maps in Read[any]()

### DIFF
--- a/column.go
+++ b/column.go
@@ -350,6 +350,9 @@ func (cl *columnLoader) open(file *File, path []string) (*Column, error) {
 	}
 
 	c.typ = &groupType{}
+	if lt := c.schema.LogicalType; lt != nil && lt.Map != nil {
+		c.typ = &mapType{}
+	}
 	c.columns = make([]*Column, numChildren)
 
 	for i := range c.columns {

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -1265,7 +1265,8 @@ func TestReadMapAsAny(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	recs, err := parquet.Read[rec](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	data, size := bytes.NewReader(buf.Bytes()), int64(buf.Len())
+	recs, err := parquet.Read[rec](data, size)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1273,11 +1274,22 @@ func TestReadMapAsAny(t *testing.T) {
 		t.Errorf("value mismatch: want=%+v got=%+v", typed, recs)
 	}
 
-	anys, err := parquet.Read[any](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	anys, err := parquet.Read[any](data, size)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(anys, anyd) {
+		t.Errorf("value mismatch: want=%+v got=%+v", anyd, anys)
+	}
+
+	vals, err := parquet.Read[any](data, size, parquet.NewSchema("", parquet.Group{
+		"n": parquet.Int(64),
+		"m": parquet.Map(parquet.String(), parquet.Int(64)),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(vals, anyd) {
 		t.Errorf("value mismatch: want=%+v got=%+v", anyd, anys)
 	}
 }

--- a/row.go
+++ b/row.go
@@ -700,6 +700,9 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 		values := make([][]Value, len(columns))
 		column := columns[0]
 		t := value.Type()
+		if t.Kind() == reflect.Interface {
+			t = reflect.TypeFor[map[string]any]()
+		}
 		k := t.Key()
 		v := t.Elem()
 		n := 0
@@ -718,7 +721,9 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 		}
 
 		if value.IsNil() {
-			value.Set(reflect.MakeMapWithSize(t, n))
+			m := reflect.MakeMapWithSize(t, n)
+			value.Set(m)
+			value = m // track map instead of interface{} for read[any]()
 		}
 
 		elem := reflect.New(keyValueElem).Elem()

--- a/row.go
+++ b/row.go
@@ -701,7 +701,7 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 		column := columns[0]
 		t := value.Type()
 		if t.Kind() == reflect.Interface {
-			t = reflect.TypeFor[map[string]any]()
+			t = reflect.TypeOf((map[string]any)(nil))
 		}
 		k := t.Key()
 		v := t.Elem()

--- a/schema.go
+++ b/schema.go
@@ -949,11 +949,10 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 	}
 
 	if node.Repeated() && !list {
-		elemKind := node.GoType().Elem().Kind()
-		if elemKind == reflect.Slice {
-			// Special case: allow strings in a logical map
-			isUint8 := node.GoType().Elem().Elem().Kind() == reflect.Uint8
-			if !isUint8 {
+		repeated := node.GoType().Elem()
+		if repeated.Kind() == reflect.Slice {
+			// Special case: allow [][]uint as seen in a logical map of strings
+			if repeated.Elem().Kind() != reflect.Uint8 {
 				panic("unhandled nested slice on parquet schema without list tag")
 			}
 		}

--- a/schema.go
+++ b/schema.go
@@ -951,7 +951,11 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 	if node.Repeated() && !list {
 		elemKind := node.GoType().Elem().Kind()
 		if elemKind == reflect.Slice {
-			panic("unhandled nested slice on parquet schema without list tag")
+			// Special case: allow strings in a logical map
+			isUint8 := node.GoType().Elem().Elem().Kind() == reflect.Uint8
+			if !isUint8 {
+				panic("unhandled nested slice on parquet schema without list tag")
+			}
 		}
 	}
 


### PR DESCRIPTION
As reported on #103, logical maps are currently read as the nested repeated structure used for their physical storage. This appears to be due to discarding the logical map in favor of a logical group. Attempting to work around this by providing a schema results in panics, as reported on #40, #57. This change adds a test for and fixes both of those cases. It also masks or fixes a resulting test panic; a deeper review is required for that.

- (*columnLoader).open: use mapType instead of groupType when the schema indicates a logical map
- reconstructFuncOfMap: handle map types and instantiation correctly when operating on an interface{} value
- makeNodeOf: questionable: don't panic for [][]uint8 case assuming it's actually []string

The makeNodeOf change is meant to address the panic in TestReader's map_of_repeated_values case that started with the change to (*columnLoader).open. While I'm fairly confident in the other changes, I'm very shaky here. However all tests passed for me, so I've included it as a potential fix.

There may be compatibility concerns here. This change alters visible behavior change for the described scenario, as Read[any] will now return a map `{k: v, ...}` equivalent to the one written, instead of the surprising, thus arguably buggy, `{"key_value": []{{"key": k, "value": v}, ...}}`.