### PR TITLE
CI: parquet-mr => parquet-java

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Setup Parquet CLI
         run: |
           set -ex
-          wget https://github.com/apache/parquet-mr/archive/refs/tags/apache-parquet-1.13.1.tar.gz
+          wget https://github.com/apache/parquet-java/archive/refs/tags/apache-parquet-1.13.1.tar.gz
           tar -xf apache-parquet-1.13.1.tar.gz
-          mvn --file parquet-mr-apache-parquet-1.13.1/parquet-cli/pom.xml install -DskipTests
-          mvn --file parquet-mr-apache-parquet-1.13.1/parquet-cli/pom.xml dependency:copy-dependencies
+          mvn --file parquet-java-apache-parquet-1.13.1/parquet-cli/pom.xml install -DskipTests
+          mvn --file parquet-java-apache-parquet-1.13.1/parquet-cli/pom.xml dependency:copy-dependencies
 
       - name: Setup Go ${{ matrix.go }}
         uses: actions/setup-go@v3
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run Tests
         env:
-          TARGET: parquet-mr-apache-parquet-1.13.1/parquet-cli/target
+          TARGET: parquet-java-apache-parquet-1.13.1/parquet-cli/target
         run: >
           PARQUET_GO_TEST_CLI="java -cp $TARGET/parquet-cli-1.13.1.jar:$TARGET/dependency/* org.apache.parquet.cli.Main"
           go test -trimpath -race -tags=${{ matrix.tags }} ./...

--- a/column_index.go
+++ b/column_index.go
@@ -692,7 +692,7 @@ func truncateLargeMaxByteArrayValue(value []byte, sizeLimit int) []byte {
 }
 
 // incrementByteArray increments the given byte array by 1.
-// Reference: https://github.com/apache/parquet-mr/blob/master/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BinaryTruncator.java#L124
+// Reference: https://github.com/apache/parquet-java/blob/master/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BinaryTruncator.java#L124
 func incrementByteArrayInplace(value []byte) {
 	for i := len(value) - 1; i >= 0; i-- {
 		value[i]++

--- a/encoding/delta/byte_array.go
+++ b/encoding/delta/byte_array.go
@@ -81,7 +81,7 @@ func (e *ByteArrayEncoding) EncodeFixedLenByteArray(dst []byte, src []byte, size
 	// The parquet specs say that this encoding is only supported for BYTE_ARRAY
 	// values, but the reference Java implementation appears to support
 	// FIXED_LEN_BYTE_ARRAY as well:
-	// https://github.com/apache/parquet-mr/blob/5608695f5777de1eb0899d9075ec9411cfdf31d3/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java#L211
+	// https://github.com/apache/parquet-java/blob/5608695f5777de1eb0899d9075ec9411cfdf31d3/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java#L211
 	if size < 0 || size > encoding.MaxFixedLenByteArraySize {
 		return dst[:0], encoding.Error(e, encoding.ErrInvalidArgument)
 	}

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -134,7 +134,7 @@ type DecimalType struct {
 }
 
 func (t *DecimalType) String() string {
-	// Matching parquet-cli's decimal string format: https://github.com/apache/parquet-mr/blob/d057b39d93014fe40f5067ee4a33621e65c91552/parquet-column/src/test/java/org/apache/parquet/parser/TestParquetParser.java#L249-L265
+	// Matching parquet-cli's decimal string format: https://github.com/apache/parquet-java/blob/d057b39d93014fe40f5067ee4a33621e65c91552/parquet-column/src/test/java/org/apache/parquet/parser/TestParquetParser.java#L249-L265
 	return fmt.Sprintf("DECIMAL(%d,%d)", t.Precision, t.Scale)
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -840,7 +840,7 @@ Column: value
 // TestWriter uses the Apache parquet-cli tool to validate generated parquet files.
 // On MacOS systems using brew, this can be installed with `brew install parquet-cli`.
 // For more information on installing and running this tool, see:
-// https://github.com/apache/parquet-mr/blob/ef9929c130f8f2e24fca1c7b42b0742a4d9d5e61/parquet-cli/README.md
+// https://github.com/apache/parquet-java/blob/ef9929c130f8f2e24fca1c7b42b0742a4d9d5e61/parquet-cli/README.md
 // This test expects the parquet-cli command to exist in the environment path as `parquet`
 // and to require no additional arguments before the primary command. If you need to run
 // it in some other way on your system, you can configure the environment variable


### PR DESCRIPTION
The parquet-mr repository was renamed to parquet-java (see https://github.com/apache/parquet-java/pull/1357).

This PR updates our links to resources hosted in that repository.

Unblocks #140 