### PR TITLE
hashprobe: remove dependency on runtime.aeskeysched

### DIFF
--- a/hashprobe/aeshash/aeshash_amd64.s
+++ b/hashprobe/aeshash/aeshash_amd64.s
@@ -7,9 +7,9 @@ TEXT ·Hash32(SB), NOSPLIT, $0-24
     MOVL value+0(FP), AX
     MOVQ seed+8(FP), BX
 
-    MOVOU runtime·aeskeysched+0(SB), X1
-    MOVOU runtime·aeskeysched+16(SB), X2
-    MOVOU runtime·aeskeysched+32(SB), X3
+    MOVOU ·aeskeysched+0(SB), X1
+    MOVOU ·aeskeysched+16(SB), X2
+    MOVOU ·aeskeysched+32(SB), X3
 
     MOVQ BX, X0
     PINSRD $2, AX, X0
@@ -26,9 +26,9 @@ TEXT ·Hash64(SB), NOSPLIT, $0-24
     MOVQ value+0(FP), AX
     MOVQ seed+8(FP), BX
 
-    MOVOU runtime·aeskeysched+0(SB), X1
-    MOVOU runtime·aeskeysched+16(SB), X2
-    MOVOU runtime·aeskeysched+32(SB), X3
+    MOVOU ·aeskeysched+0(SB), X1
+    MOVOU ·aeskeysched+16(SB), X2
+    MOVOU ·aeskeysched+32(SB), X3
 
     MOVQ BX, X0
     PINSRQ $1, AX, X0
@@ -49,7 +49,7 @@ TEXT ·Hash128(SB), NOSPLIT, $0-32
     MOVQ BX, X0                      // 64 bits of per-table hash seed
     PINSRW $4, CX, X0                // 16 bits of length
     PSHUFHW $0, X0, X0               // repeat length 4 times total
-    PXOR runtime·aeskeysched(SB), X0 // xor in per-process seed
+    PXOR ·aeskeysched(SB), X0        // xor in per-process seed
     AESENC X0, X0                    // scramble seed
 
     MOVOU (AX), X1
@@ -69,9 +69,9 @@ TEXT ·MultiHashUint32Array(SB), NOSPLIT, $0-56
     MOVQ values_array_off+40(FP), R8
     MOVQ seed+48(FP), DX
 
-    MOVOU runtime·aeskeysched+0(SB), X1
-    MOVOU runtime·aeskeysched+16(SB), X2
-    MOVOU runtime·aeskeysched+32(SB), X3
+    MOVOU ·aeskeysched+0(SB), X1
+    MOVOU ·aeskeysched+16(SB), X2
+    MOVOU ·aeskeysched+32(SB), X3
 
     XORQ SI, SI
     JMP test
@@ -99,9 +99,9 @@ TEXT ·MultiHashUint64Array(SB), NOSPLIT, $0-56
     MOVQ values_array_off+40(FP), R8
     MOVQ seed+48(FP), DX
 
-    MOVOU runtime·aeskeysched+0(SB), X1
-    MOVOU runtime·aeskeysched+16(SB), X2
-    MOVOU runtime·aeskeysched+32(SB), X3
+    MOVOU ·aeskeysched+0(SB), X1
+    MOVOU ·aeskeysched+16(SB), X2
+    MOVOU ·aeskeysched+32(SB), X3
 
     XORQ SI, SI
     JMP test
@@ -133,7 +133,7 @@ TEXT ·MultiHashUint128Array(SB), NOSPLIT, $0-56
     MOVQ DX, X0
     PINSRW $4, DI, X0
     PSHUFHW $0, X0, X0
-    PXOR runtime·aeskeysched(SB), X0
+    PXOR ·aeskeysched(SB), X0
     AESENC X0, X0
 
     XORQ SI, SI

--- a/hashprobe/aeshash/aeshash_test.go
+++ b/hashprobe/aeshash/aeshash_test.go
@@ -4,31 +4,10 @@ import (
 	"encoding/binary"
 	"testing"
 	"time"
-	"unsafe"
 )
 
-//go:noescape
-//go:linkname runtime_memhash32 runtime.memhash32
-func runtime_memhash32(data unsafe.Pointer, seed uintptr) uintptr
-
-//go:noescape
-//go:linkname runtime_memhash64 runtime.memhash64
-func runtime_memhash64(data unsafe.Pointer, seed uintptr) uintptr
-
-//go:noescape
-//go:linkname runtime_memhash runtime.memhash
-func runtime_memhash(data unsafe.Pointer, seed, size uintptr) uintptr
-
-func memhash32(data uint32, seed uintptr) uintptr {
-	return runtime_memhash32(unsafe.Pointer(&data), seed)
-}
-
-func memhash64(data uint64, seed uintptr) uintptr {
-	return runtime_memhash64(unsafe.Pointer(&data), seed)
-}
-
-func memhash128(data [16]byte, seed uintptr) uintptr {
-	return runtime_memhash(unsafe.Pointer(&data), seed, 16)
+func init() {
+	testingInitAesKeySched()
 }
 
 func TestHash32(t *testing.T) {
@@ -36,11 +15,11 @@ func TestHash32(t *testing.T) {
 		t.Skip("AES hash not supported on this platform")
 	}
 
-	h0 := memhash32(42, 1)
-	h1 := Hash32(42, 1)
+	h := Hash32(42, 1)
 
-	if h0 != h1 {
-		t.Errorf("want=%016x got=%016x", h0, h1)
+	expected := uintptr(0x5e6ec6d2d7f7e0a0)
+	if h != expected {
+		t.Errorf("want=%016x got=%016x", expected, h)
 	}
 }
 
@@ -74,11 +53,11 @@ func TestHash64(t *testing.T) {
 		t.Skip("AES hash not supported on this platform")
 	}
 
-	h0 := memhash64(42, 1)
-	h1 := Hash64(42, 1)
+	h := Hash64(42, 1)
 
-	if h0 != h1 {
-		t.Errorf("want=%016x got=%016x", h0, h1)
+	expected := uintptr(0x5e6ec6d2d7f7e0a0)
+	if h != expected {
+		t.Errorf("want=%016x got=%016x", expected, h)
 	}
 }
 
@@ -126,11 +105,11 @@ func TestHash128(t *testing.T) {
 		t.Skip("AES hash not supported on this platform")
 	}
 
-	h0 := memhash128([16]byte{0: 42}, 1)
-	h1 := Hash128([16]byte{0: 42}, 1)
+	h := Hash128([16]byte{0: 42}, 1)
 
-	if h0 != h1 {
-		t.Errorf("want=%016x got=%016x", h0, h1)
+	expected := uintptr(0x5db3281d2806690a)
+	if h != expected {
+		t.Errorf("want=%016x got=%016x", expected, h)
 	}
 }
 

--- a/hashprobe/aeshash/export_amd64_test.go
+++ b/hashprobe/aeshash/export_amd64_test.go
@@ -1,0 +1,11 @@
+//go:build !purego && amd64
+
+package aeshash
+
+// testingInitAesKeySched initializes the aes seed to a deterministic value for
+// test purposes.
+func testingInitAesKeySched() {
+	for i := range aeskeysched {
+		aeskeysched[i] = byte(i)
+	}
+}

--- a/hashprobe/aeshash/export_test.go
+++ b/hashprobe/aeshash/export_test.go
@@ -1,0 +1,5 @@
+//go:build purego || !amd64
+
+package aeshash
+
+func testingInitAesKeySched() {}


### PR DESCRIPTION
This is used to seed the AES hash function. This commit reimplements aeskeysched locally to the package to avoid a dependency on runtime internals. In Go1.23 (yet to be released), runtime internals will require an explicit go:linkname directive to allow external packages to use them in order to lock down dependencies on runtime internals. runtime.aeskeysched is not currently exported so parquet-go builds are broken on Go1.23.

We could create a CL to add go:linkname to aeskeysched, but I don't think there's a good reason we can't remove the runtime dependency here.