### PR TITLE
fix(config): allow MaxRowsPerRowGroup and DataPageStatistics fields to be set

### DIFF
--- a/config.go
+++ b/config.go
@@ -270,8 +270,8 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 		PageBufferSize:       coalesceInt(c.PageBufferSize, config.PageBufferSize),
 		WriteBufferSize:      coalesceInt(c.WriteBufferSize, config.WriteBufferSize),
 		DataPageVersion:      coalesceInt(c.DataPageVersion, config.DataPageVersion),
-		DataPageStatistics:   config.DataPageStatistics,
-		MaxRowsPerRowGroup:   config.MaxRowsPerRowGroup,
+		DataPageStatistics:   coalesceBool(c.DataPageStatistics, config.DataPageStatistics),
+		MaxRowsPerRowGroup:   coalesceInt64(c.MaxRowsPerRowGroup, config.MaxRowsPerRowGroup),
 		KeyValueMetadata:     keyValueMetadata,
 		Schema:               coalesceSchema(c.Schema, config.Schema),
 		BloomFilters:         coalesceBloomFilters(c.BloomFilters, config.BloomFilters),
@@ -691,6 +691,10 @@ func (opt rowGroupOption) ConfigureRowGroup(config *RowGroupConfig) { opt(config
 type sortingOption func(*SortingConfig)
 
 func (opt sortingOption) ConfigureSorting(config *SortingConfig) { opt(config) }
+
+func coalesceBool(i1, i2 bool) bool {
+	return i1 || i2
+}
 
 func coalesceInt(i1, i2 int) int {
 	if i1 != 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,44 @@
+package parquet
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	type RowType struct {
+		Id        string
+		FirstName string
+		LastName  string
+	}
+	tcs := []struct {
+		name string
+		cfg  *WriterConfig
+	}{
+		{
+			name: "Check MaxRowsPerRowGroup Coalesces",
+			cfg: func() *WriterConfig {
+				conf := DefaultWriterConfig()
+				conf.MaxRowsPerRowGroup = 10
+				return conf
+			}(),
+		},
+		{
+			name: "Check DataPageStatistics Coalesces",
+			cfg: func() *WriterConfig {
+				conf := DefaultWriterConfig()
+				conf.DataPageStatistics = true
+				return conf
+			}(),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			writer := NewGenericWriter[RowType](os.Stdout, tc.cfg)
+			if reflect.DeepEqual(tc.cfg, writer.base.config) {
+				t.Fatalf("expected %+v, got %+v\n", tc.cfg, writer.base.config)
+			}
+		})
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -34,7 +34,10 @@ func TestConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			writer := NewGenericWriter[RowType](os.Stdout, tc.cfg)
 			if reflect.DeepEqual(tc.cfg, writer.base.config) {
 				t.Fatalf("expected %+v, got %+v\n", tc.cfg, writer.base.config)


### PR DESCRIPTION
## Problem 

This PR solves the following issues: 

Fixes https://github.com/parquet-go/parquet-go/issues/107

A user reported to be unable to override the `MaxRowsPerRowGroup` field's default value even when explicitly passing the config as an option to the `GenericWriter` constructor.

## Context 

`WriteConfig` implements the `WriterOption` interface so it should override the config when passed to `GenericWriter`, but the code was ignoring the `MaxRowsPerRowGroup` field from the `WriterOption`. Looking closer it was also ignoring the `DataPageStatistics` field. 

## Solution 

Adding coalesce functions for both fields did the job. Tests were added to verify the fix. 