### PR TITLE
rm min/max funcs in favor of built-ins

### DIFF
--- a/bloom/xxhash/sum64uint_purego.go
+++ b/bloom/xxhash/sum64uint_purego.go
@@ -51,10 +51,3 @@ func MultiSum64Uint128(h []uint64, v [][16]byte) int {
 	}
 	return n
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/encoding/delta/delta.go
+++ b/encoding/delta/delta.go
@@ -82,13 +82,6 @@ func grow(buf []byte, size int) []byte {
 	return newBuf
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func errPrefixAndSuffixLengthMismatch(prefixLength, suffixLength int) error {
 	return fmt.Errorf("length of prefix and suffix mismatch: %d != %d", prefixLength, suffixLength)
 }

--- a/parquet.go
+++ b/parquet.go
@@ -103,20 +103,6 @@ func atLeast(size, least int) int {
 	return size
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func typeNameOf(t reflect.Type) string {
 	s1 := t.String()
 	s2 := t.Kind().String()

--- a/sparse/gather.go
+++ b/sparse/gather.go
@@ -35,10 +35,3 @@ func GatherString(dst []string, src StringArray) int {
 
 	return n
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
Poking around yesterday, I saw these repeated a few times, and now that we're upgraded to v1.21, the built-in mix/max funcs are available.