### PR TITLE
Enable parquet package support on s390x

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -1,16 +1,16 @@
 package parquet
 
 import (
-	"io"
 	"encoding/binary"
+	"io"
 
-	"golang.org/x/sys/cpu"
 	"github.com/parquet-go/parquet-go/bloom"
 	"github.com/parquet-go/parquet-go/bloom/xxhash"
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
+	"golang.org/x/sys/cpu"
 )
 
 // BloomFilter is an interface allowing applications to test whether a key
@@ -174,15 +174,15 @@ func (splitBlockEncoding) EncodeInt64(dst []byte, src []int64) ([]byte, error) {
 }
 
 func (e splitBlockEncoding) EncodeInt96(dst []byte, src []deprecated.Int96) ([]byte, error) {
-        if cpu.IsBigEndian {
-                srcLen := len(src)
-                buf := make([]byte, srcLen*12)
-                for idx := range srcLen {
-                        binary.LittleEndian.PutUint32(buf[(idx*12):4+(idx*12)], uint32(src[idx][0]))
-                        binary.LittleEndian.PutUint32(buf[4+(idx*12):8+(idx*12)], uint32(src[idx][1]))
-                        binary.LittleEndian.PutUint32(buf[8+(idx*12):12+(idx*12)], uint32(src[idx][2]))
-                }
-	        splitBlockEncodeFixedLenByteArray(bloom.MakeSplitBlockFilter(dst), buf, 12)
+	if cpu.IsBigEndian {
+		srcLen := len(src)
+		buf := make([]byte, srcLen*12)
+		for idx := range srcLen {
+			binary.LittleEndian.PutUint32(buf[(idx*12):4+(idx*12)], uint32(src[idx][0]))
+			binary.LittleEndian.PutUint32(buf[4+(idx*12):8+(idx*12)], uint32(src[idx][1]))
+			binary.LittleEndian.PutUint32(buf[8+(idx*12):12+(idx*12)], uint32(src[idx][2]))
+		}
+		splitBlockEncodeFixedLenByteArray(bloom.MakeSplitBlockFilter(dst), buf, 12)
 	} else {
 		splitBlockEncodeFixedLenByteArray(bloom.MakeSplitBlockFilter(dst), unsafecast.Slice[byte](src), 12)
 	}

--- a/bloom.go
+++ b/bloom.go
@@ -177,7 +177,7 @@ func (e splitBlockEncoding) EncodeInt96(dst []byte, src []deprecated.Int96) ([]b
         if cpu.IsBigEndian {
                 srcLen := len(src)
                 buf := make([]byte, srcLen*12)
-                for idx := 0; idx < srcLen; idx++ {
+                for idx := range srcLen {
                         binary.LittleEndian.PutUint32(buf[(idx*12):4+(idx*12)], uint32(src[idx][0]))
                         binary.LittleEndian.PutUint32(buf[4+(idx*12):8+(idx*12)], uint32(src[idx][1]))
                         binary.LittleEndian.PutUint32(buf[8+(idx*12):12+(idx*12)], uint32(src[idx][2]))

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/parquet-go/parquet-go/internal/bitpack"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
 	"github.com/parquet-go/parquet-go/sparse"
+	"golang.org/x/sys/cpu"
 )
 
 // ColumnBuffer is an interface representing columns of a row group.
@@ -829,7 +830,11 @@ func (col *booleanColumnBuffer) WriteBooleans(values []bool) (int, error) {
 
 func (col *booleanColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+        if cpu.IsBigEndian {
+                col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)+7), columnLevels{})
+        } else {
+                col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+        }
 	return len(values), nil
 }
 
@@ -969,7 +974,11 @@ func (col *int32ColumnBuffer) WriteInt32s(values []int32) (int, error) {
 
 func (col *int32ColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	if cpu.IsBigEndian {
+		col.writeValues(makeArrayValue(values, (unsafe.Offsetof(model.u64)+4)), columnLevels{})
+	} else {
+		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	}
 	return len(values), nil
 }
 
@@ -1263,7 +1272,11 @@ func (col *floatColumnBuffer) WriteFloats(values []float32) (int, error) {
 
 func (col *floatColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	if cpu.IsBigEndian {
+		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)+4), columnLevels{})
+	} else {
+		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	}
 	return len(values), nil
 }
 
@@ -1753,7 +1766,11 @@ func (col *uint32ColumnBuffer) WriteUint32s(values []uint32) (int, error) {
 
 func (col *uint32ColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	if cpu.IsBigEndian {
+		col.writeValues(makeArrayValue(values, (unsafe.Offsetof(model.u64)+4)), columnLevels{})
+	} else {
+		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	}
 	return len(values), nil
 }
 

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -19,6 +19,9 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
+const offsetOfU64 = unsafe.Offsetof(Value{}.u64)
+const offsetOfPtr = unsafe.Offsetof(Value{}.ptr)
+
 // ColumnBuffer is an interface representing columns of a row group.
 //
 // ColumnBuffer implements sort.Interface as a way to support reordering the
@@ -102,6 +105,29 @@ func columnIndexOfNullable(base ColumnBuffer, maxDefinitionLevel byte, definitio
 		maxDefinitionLevel: maxDefinitionLevel,
 		definitionLevels:   definitionLevels,
 	}, nil
+}
+
+// On a big endian system, a boolean/byte value, which is in little endian byte format, is byte aligned
+// to the 7th byte in a u64 (8 bytes) variable.. Hence the data will be available at 7th byte when
+// interpreted as a little endian byte format. So, in order to access a boolean/byte value out of u64 variable,
+// we need to add an offset of "7"...
+// In the same way, an int32/uint32/float value, which is in little endian byte format, is byte aligned
+// to the 4th byte in a u64 (8 bytes) variable.. Hence the data will be available at 4th byte when
+// interpreted as a little endian byte format. So, in order to access an int32/uint32/float value out of u64 variable,
+// we need to add an offset of "4"
+func getOffset(colDict interface{}) uintptr {
+	var offset uintptr = 0
+
+	if cpu.IsBigEndian {
+		switch colDict.(type) {
+		case booleanColumnBuffer, booleanDictionary:
+			offset = 7
+
+		case int32ColumnBuffer, uint32ColumnBuffer, floatColumnBuffer, int32Dictionary, floatDictionary, uint32Dictionary:
+			offset = 4
+		}
+	}
+	return offset
 }
 
 type nullableColumnIndex struct {
@@ -829,17 +855,8 @@ func (col *booleanColumnBuffer) WriteBooleans(values []bool) (int, error) {
 }
 
 func (col *booleanColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-
-        //On a big endian system, a boolean/byte value, which is in little endian format, is byte aligned
-        //to the 7th byte in a u64 (8 bytes) variable.. Hence the data will be available at 7th byte when 
-        //interpreted as a little endian byte format. So, in order to access a boolean/byte value out of u64 variable, 
-        //we need to add an offset of "7"
-        if cpu.IsBigEndian {
-                col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)+7), columnLevels{})
-        } else {
-                col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
-        }
+	offset := getOffset(*col)
+	col.writeValues(makeArrayValue(values, offsetOfU64+offset), columnLevels{})
 	return len(values), nil
 }
 
@@ -978,17 +995,8 @@ func (col *int32ColumnBuffer) WriteInt32s(values []int32) (int, error) {
 }
 
 func (col *int32ColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-
-	//On a big endian system, an int32/uint32 value, which is in little endian format, is byte aligned
-	//to the 4th byte in a u64 (8 bytes) variable.. Hence the data will be available at 4th byte when 
-	//interpreted as a little endian byte format. So, in order to access an int32/uint32 value out of u64 variable, 
-	//we need to add an offset of "4"
-	if cpu.IsBigEndian {
-		col.writeValues(makeArrayValue(values, (unsafe.Offsetof(model.u64)+4)), columnLevels{})
-	} else {
-		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
-	}
+	offset := getOffset(*col)
+	col.writeValues(makeArrayValue(values, offsetOfU64+offset), columnLevels{})
 	return len(values), nil
 }
 
@@ -1086,8 +1094,7 @@ func (col *int64ColumnBuffer) WriteInt64s(values []int64) (int, error) {
 }
 
 func (col *int64ColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	col.writeValues(makeArrayValue(values, offsetOfU64), columnLevels{})
 	return len(values), nil
 }
 
@@ -1281,17 +1288,8 @@ func (col *floatColumnBuffer) WriteFloats(values []float32) (int, error) {
 }
 
 func (col *floatColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-
-        //On a big endian system, an int32/uint32 value, which is in little endian format, is byte aligned
-        //to the 4th byte in a u64 (8 bytes) variable.. Hence the data will be available at 4th byte when 
-        //interpreted as a little endian byte format. So, in order to access an int32/uint32 value out of u64 variable, 
-        //we need to add an offset of "4"
-	if cpu.IsBigEndian {
-		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)+4), columnLevels{})
-	} else {
-		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
-	}
+	offset := getOffset(*col)
+	col.writeValues(makeArrayValue(values, offsetOfU64+offset), columnLevels{})
 	return len(values), nil
 }
 
@@ -1388,8 +1386,7 @@ func (col *doubleColumnBuffer) WriteDoubles(values []float64) (int, error) {
 }
 
 func (col *doubleColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	col.writeValues(makeArrayValue(values, offsetOfU64), columnLevels{})
 	return len(values), nil
 }
 
@@ -1543,8 +1540,7 @@ func (col *byteArrayColumnBuffer) writeByteArrays(values []byte) (count, bytes i
 }
 
 func (col *byteArrayColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.ptr)), columnLevels{})
+	col.writeValues(makeArrayValue(values, offsetOfPtr), columnLevels{})
 	return len(values), nil
 }
 
@@ -1780,17 +1776,8 @@ func (col *uint32ColumnBuffer) WriteUint32s(values []uint32) (int, error) {
 }
 
 func (col *uint32ColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-
-        //On a big endian system, an int32/uint32 value, which is in little endian format, is byte aligned
-        //to the 4th byte in a u64 (8 bytes) variable.. Hence the data will be available at 4th byte when 
-        //interpreted as a little endian byte format. So, in order to access an int32/uint32 value out of u64 variable, 
-        //we need to add an offset of "4"
-	if cpu.IsBigEndian {
-		col.writeValues(makeArrayValue(values, (unsafe.Offsetof(model.u64)+4)), columnLevels{})
-	} else {
-		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
-	}
+	offset := getOffset(*col)
+	col.writeValues(makeArrayValue(values, offsetOfU64+offset), columnLevels{})
 	return len(values), nil
 }
 
@@ -1887,8 +1874,7 @@ func (col *uint64ColumnBuffer) WriteUint64s(values []uint64) (int, error) {
 }
 
 func (col *uint64ColumnBuffer) WriteValues(values []Value) (int, error) {
-	var model Value
-	col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)), columnLevels{})
+	col.writeValues(makeArrayValue(values, offsetOfU64), columnLevels{})
 	return len(values), nil
 }
 

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -830,6 +830,11 @@ func (col *booleanColumnBuffer) WriteBooleans(values []bool) (int, error) {
 
 func (col *booleanColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
+
+        //On a big endian system, a boolean/byte value, which is in little endian format, is byte aligned
+        //to the 7th byte in a u64 (8 bytes) variable.. Hence the data will be available at 7th byte when 
+        //interpreted as a little endian byte format. So, in order to access a boolean/byte value out of u64 variable, 
+        //we need to add an offset of "7"
         if cpu.IsBigEndian {
                 col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)+7), columnLevels{})
         } else {
@@ -974,6 +979,11 @@ func (col *int32ColumnBuffer) WriteInt32s(values []int32) (int, error) {
 
 func (col *int32ColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
+
+	//On a big endian system, an int32/uint32 value, which is in little endian format, is byte aligned
+	//to the 4th byte in a u64 (8 bytes) variable.. Hence the data will be available at 4th byte when 
+	//interpreted as a little endian byte format. So, in order to access an int32/uint32 value out of u64 variable, 
+	//we need to add an offset of "4"
 	if cpu.IsBigEndian {
 		col.writeValues(makeArrayValue(values, (unsafe.Offsetof(model.u64)+4)), columnLevels{})
 	} else {
@@ -1272,6 +1282,11 @@ func (col *floatColumnBuffer) WriteFloats(values []float32) (int, error) {
 
 func (col *floatColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
+
+        //On a big endian system, an int32/uint32 value, which is in little endian format, is byte aligned
+        //to the 4th byte in a u64 (8 bytes) variable.. Hence the data will be available at 4th byte when 
+        //interpreted as a little endian byte format. So, in order to access an int32/uint32 value out of u64 variable, 
+        //we need to add an offset of "4"
 	if cpu.IsBigEndian {
 		col.writeValues(makeArrayValue(values, unsafe.Offsetof(model.u64)+4), columnLevels{})
 	} else {
@@ -1766,6 +1781,11 @@ func (col *uint32ColumnBuffer) WriteUint32s(values []uint32) (int, error) {
 
 func (col *uint32ColumnBuffer) WriteValues(values []Value) (int, error) {
 	var model Value
+
+        //On a big endian system, an int32/uint32 value, which is in little endian format, is byte aligned
+        //to the 4th byte in a u64 (8 bytes) variable.. Hence the data will be available at 4th byte when 
+        //interpreted as a little endian byte format. So, in order to access an int32/uint32 value out of u64 variable, 
+        //we need to add an offset of "4"
 	if cpu.IsBigEndian {
 		col.writeValues(makeArrayValue(values, (unsafe.Offsetof(model.u64)+4)), columnLevels{})
 	} else {

--- a/column_index_be.go
+++ b/column_index_be.go
@@ -1,0 +1,846 @@
+// This file gets added on all the big-endian CPU architectures.
+
+//go:build armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64
+
+package parquet
+
+import (
+	"encoding/binary"
+	"github.com/parquet-go/parquet-go/deprecated"
+	"github.com/parquet-go/parquet-go/encoding/plain"
+	"github.com/parquet-go/parquet-go/format"
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
+	"math"
+)
+
+type ColumnIndex interface {
+	// NumPages returns the number of paged in the column index.
+	NumPages() int
+
+	// Returns the number of null values in the page at the given index.
+	NullCount(int) int64
+
+	// Tells whether the page at the given index contains null values only.
+	NullPage(int) bool
+
+	// PageIndex return min/max bounds for the page at the given index in the
+	// column.
+	MinValue(int) Value
+	MaxValue(int) Value
+
+	// IsAscending returns true if the column index min/max values are sorted
+	// in ascending order (based on the ordering rules of the column's logical
+	// type).
+	IsAscending() bool
+
+	// IsDescending returns true if the column index min/max values are sorted
+	// in descending order (based on the ordering rules of the column's logical
+	// type).
+	IsDescending() bool
+}
+
+// NewColumnIndex constructs a ColumnIndex instance from the given parquet
+// format column index. The kind argument configures the type of values
+func NewColumnIndex(kind Kind, index *format.ColumnIndex) ColumnIndex {
+	return &formatColumnIndex{
+		kind:  kind,
+		index: index,
+	}
+}
+
+type formatColumnIndex struct {
+	kind  Kind
+	index *format.ColumnIndex
+}
+
+func (f *formatColumnIndex) NumPages() int {
+	return len(f.index.MinValues)
+}
+
+func (f *formatColumnIndex) NullCount(i int) int64 {
+	if len(f.index.NullCounts) > 0 {
+		return f.index.NullCounts[i]
+	}
+	return 0
+}
+
+func (f *formatColumnIndex) NullPage(i int) bool {
+	return len(f.index.NullPages) > 0 && f.index.NullPages[i]
+}
+
+func (f *formatColumnIndex) MinValue(i int) Value {
+	if f.NullPage(i) {
+		return Value{}
+	}
+	return f.kind.Value(f.index.MinValues[i])
+}
+
+func (f *formatColumnIndex) MaxValue(i int) Value {
+	if f.NullPage(i) {
+		return Value{}
+	}
+	return f.kind.Value(f.index.MaxValues[i])
+}
+
+func (f *formatColumnIndex) IsAscending() bool {
+	return f.index.BoundaryOrder == format.Ascending
+}
+
+func (f *formatColumnIndex) IsDescending() bool {
+	return f.index.BoundaryOrder == format.Descending
+}
+
+type fileColumnIndex struct{ chunk *fileColumnChunk }
+
+func (i fileColumnIndex) NumPages() int {
+	return len(i.chunk.columnIndex.NullPages)
+}
+
+func (i fileColumnIndex) NullCount(j int) int64 {
+	if len(i.chunk.columnIndex.NullCounts) > 0 {
+		return i.chunk.columnIndex.NullCounts[j]
+	}
+	return 0
+}
+
+func (i fileColumnIndex) NullPage(j int) bool {
+	return len(i.chunk.columnIndex.NullPages) > 0 && i.chunk.columnIndex.NullPages[j]
+}
+
+func (i fileColumnIndex) MinValue(j int) Value {
+	if i.NullPage(j) {
+		return Value{}
+	}
+	return i.makeValue(i.chunk.columnIndex.MinValues[j])
+}
+
+func (i fileColumnIndex) MaxValue(j int) Value {
+	if i.NullPage(j) {
+		return Value{}
+	}
+	return i.makeValue(i.chunk.columnIndex.MaxValues[j])
+}
+
+func (i fileColumnIndex) IsAscending() bool {
+	return i.chunk.columnIndex.BoundaryOrder == format.Ascending
+}
+
+func (i fileColumnIndex) IsDescending() bool {
+	return i.chunk.columnIndex.BoundaryOrder == format.Descending
+}
+
+func (i *fileColumnIndex) makeValue(b []byte) Value {
+	return i.chunk.column.typ.Kind().Value(b)
+}
+
+type emptyColumnIndex struct{}
+
+func (emptyColumnIndex) NumPages() int       { return 0 }
+func (emptyColumnIndex) NullCount(int) int64 { return 0 }
+func (emptyColumnIndex) NullPage(int) bool   { return false }
+func (emptyColumnIndex) MinValue(int) Value  { return Value{} }
+func (emptyColumnIndex) MaxValue(int) Value  { return Value{} }
+func (emptyColumnIndex) IsAscending() bool   { return false }
+func (emptyColumnIndex) IsDescending() bool  { return false }
+
+type booleanColumnIndex struct{ page *booleanPage }
+
+func (i booleanColumnIndex) NumPages() int       { return 1 }
+func (i booleanColumnIndex) NullCount(int) int64 { return 0 }
+func (i booleanColumnIndex) NullPage(int) bool   { return false }
+func (i booleanColumnIndex) MinValue(int) Value  { return makeValueBoolean(i.page.min()) }
+func (i booleanColumnIndex) MaxValue(int) Value  { return makeValueBoolean(i.page.max()) }
+func (i booleanColumnIndex) IsAscending() bool   { return false }
+func (i booleanColumnIndex) IsDescending() bool  { return false }
+
+type int32ColumnIndex struct{ page *int32Page }
+
+func (i int32ColumnIndex) NumPages() int       { return 1 }
+func (i int32ColumnIndex) NullCount(int) int64 { return 0 }
+func (i int32ColumnIndex) NullPage(int) bool   { return false }
+func (i int32ColumnIndex) MinValue(int) Value  { return makeValueInt32(i.page.min()) }
+func (i int32ColumnIndex) MaxValue(int) Value  { return makeValueInt32(i.page.max()) }
+func (i int32ColumnIndex) IsAscending() bool   { return false }
+func (i int32ColumnIndex) IsDescending() bool  { return false }
+
+type int64ColumnIndex struct{ page *int64Page }
+
+func (i int64ColumnIndex) NumPages() int       { return 1 }
+func (i int64ColumnIndex) NullCount(int) int64 { return 0 }
+func (i int64ColumnIndex) NullPage(int) bool   { return false }
+func (i int64ColumnIndex) MinValue(int) Value  { return makeValueInt64(i.page.min()) }
+func (i int64ColumnIndex) MaxValue(int) Value  { return makeValueInt64(i.page.max()) }
+func (i int64ColumnIndex) IsAscending() bool   { return false }
+func (i int64ColumnIndex) IsDescending() bool  { return false }
+
+type int96ColumnIndex struct{ page *int96Page }
+
+func (i int96ColumnIndex) NumPages() int       { return 1 }
+func (i int96ColumnIndex) NullCount(int) int64 { return 0 }
+func (i int96ColumnIndex) NullPage(int) bool   { return false }
+func (i int96ColumnIndex) MinValue(int) Value  { return makeValueInt96(i.page.min()) }
+func (i int96ColumnIndex) MaxValue(int) Value  { return makeValueInt96(i.page.max()) }
+func (i int96ColumnIndex) IsAscending() bool   { return false }
+func (i int96ColumnIndex) IsDescending() bool  { return false }
+
+type floatColumnIndex struct{ page *floatPage }
+
+func (i floatColumnIndex) NumPages() int       { return 1 }
+func (i floatColumnIndex) NullCount(int) int64 { return 0 }
+func (i floatColumnIndex) NullPage(int) bool   { return false }
+func (i floatColumnIndex) MinValue(int) Value  { return makeValueFloat(i.page.min()) }
+func (i floatColumnIndex) MaxValue(int) Value  { return makeValueFloat(i.page.max()) }
+func (i floatColumnIndex) IsAscending() bool   { return false }
+func (i floatColumnIndex) IsDescending() bool  { return false }
+
+type doubleColumnIndex struct{ page *doublePage }
+
+func (i doubleColumnIndex) NumPages() int       { return 1 }
+func (i doubleColumnIndex) NullCount(int) int64 { return 0 }
+func (i doubleColumnIndex) NullPage(int) bool   { return false }
+func (i doubleColumnIndex) MinValue(int) Value  { return makeValueDouble(i.page.min()) }
+func (i doubleColumnIndex) MaxValue(int) Value  { return makeValueDouble(i.page.max()) }
+func (i doubleColumnIndex) IsAscending() bool   { return false }
+func (i doubleColumnIndex) IsDescending() bool  { return false }
+
+type byteArrayColumnIndex struct{ page *byteArrayPage }
+
+func (i byteArrayColumnIndex) NumPages() int       { return 1 }
+func (i byteArrayColumnIndex) NullCount(int) int64 { return 0 }
+func (i byteArrayColumnIndex) NullPage(int) bool   { return false }
+func (i byteArrayColumnIndex) MinValue(int) Value  { return makeValueBytes(ByteArray, i.page.min()) }
+func (i byteArrayColumnIndex) MaxValue(int) Value  { return makeValueBytes(ByteArray, i.page.max()) }
+func (i byteArrayColumnIndex) IsAscending() bool   { return false }
+func (i byteArrayColumnIndex) IsDescending() bool  { return false }
+
+type fixedLenByteArrayColumnIndex struct{ page *fixedLenByteArrayPage }
+
+func (i fixedLenByteArrayColumnIndex) NumPages() int       { return 1 }
+func (i fixedLenByteArrayColumnIndex) NullCount(int) int64 { return 0 }
+func (i fixedLenByteArrayColumnIndex) NullPage(int) bool   { return false }
+func (i fixedLenByteArrayColumnIndex) MinValue(int) Value {
+	return makeValueBytes(FixedLenByteArray, i.page.min())
+}
+func (i fixedLenByteArrayColumnIndex) MaxValue(int) Value {
+	return makeValueBytes(FixedLenByteArray, i.page.max())
+}
+func (i fixedLenByteArrayColumnIndex) IsAscending() bool  { return false }
+func (i fixedLenByteArrayColumnIndex) IsDescending() bool { return false }
+
+type uint32ColumnIndex struct{ page *uint32Page }
+
+func (i uint32ColumnIndex) NumPages() int       { return 1 }
+func (i uint32ColumnIndex) NullCount(int) int64 { return 0 }
+func (i uint32ColumnIndex) NullPage(int) bool   { return false }
+func (i uint32ColumnIndex) MinValue(int) Value  { return makeValueUint32(i.page.min()) }
+func (i uint32ColumnIndex) MaxValue(int) Value  { return makeValueUint32(i.page.max()) }
+func (i uint32ColumnIndex) IsAscending() bool   { return false }
+func (i uint32ColumnIndex) IsDescending() bool  { return false }
+
+type uint64ColumnIndex struct{ page *uint64Page }
+
+func (i uint64ColumnIndex) NumPages() int       { return 1 }
+func (i uint64ColumnIndex) NullCount(int) int64 { return 0 }
+func (i uint64ColumnIndex) NullPage(int) bool   { return false }
+func (i uint64ColumnIndex) MinValue(int) Value  { return makeValueUint64(i.page.min()) }
+func (i uint64ColumnIndex) MaxValue(int) Value  { return makeValueUint64(i.page.max()) }
+func (i uint64ColumnIndex) IsAscending() bool   { return false }
+func (i uint64ColumnIndex) IsDescending() bool  { return false }
+
+type be128ColumnIndex struct{ page *be128Page }
+
+func (i be128ColumnIndex) NumPages() int       { return 1 }
+func (i be128ColumnIndex) NullCount(int) int64 { return 0 }
+func (i be128ColumnIndex) NullPage(int) bool   { return false }
+func (i be128ColumnIndex) MinValue(int) Value  { return makeValueBytes(FixedLenByteArray, i.page.min()) }
+func (i be128ColumnIndex) MaxValue(int) Value  { return makeValueBytes(FixedLenByteArray, i.page.max()) }
+func (i be128ColumnIndex) IsAscending() bool   { return false }
+func (i be128ColumnIndex) IsDescending() bool  { return false }
+
+// The ColumnIndexer interface is implemented by types that support generating
+// parquet column indexes.
+//
+// The package does not export any types that implement this interface, programs
+// must call NewColumnIndexer on a Type instance to construct column indexers.
+type ColumnIndexer interface {
+	// Resets the column indexer state.
+	Reset()
+
+	// Add a page to the column indexer.
+	IndexPage(numValues, numNulls int64, min, max Value)
+
+	// Generates a format.ColumnIndex value from the current state of the
+	// column indexer.
+	//
+	// The returned value may reference internal buffers, in which case the
+	// values remain valid until the next call to IndexPage or Reset on the
+	// column indexer.
+	ColumnIndex() format.ColumnIndex
+}
+
+type baseColumnIndexer struct {
+	nullPages  []bool
+	nullCounts []int64
+}
+
+func (i *baseColumnIndexer) reset() {
+	i.nullPages = i.nullPages[:0]
+	i.nullCounts = i.nullCounts[:0]
+}
+
+func (i *baseColumnIndexer) observe(numValues, numNulls int64) {
+	i.nullPages = append(i.nullPages, numValues == numNulls)
+	i.nullCounts = append(i.nullCounts, numNulls)
+}
+
+func (i *baseColumnIndexer) columnIndex(minValues, maxValues [][]byte, minOrder, maxOrder int) format.ColumnIndex {
+	nullPages := make([]bool, len(i.nullPages))
+	copy(nullPages, i.nullPages)
+	nullCounts := make([]int64, len(i.nullCounts))
+	copy(nullCounts, i.nullCounts)
+	return format.ColumnIndex{
+		NullPages:     nullPages,
+		NullCounts:    nullCounts,
+		MinValues:     minValues,
+		MaxValues:     maxValues,
+		BoundaryOrder: boundaryOrderOf(minOrder, maxOrder),
+	}
+}
+
+type booleanColumnIndexer struct {
+	baseColumnIndexer
+	minValues []bool
+	maxValues []bool
+}
+
+func newBooleanColumnIndexer() *booleanColumnIndexer {
+	return new(booleanColumnIndexer)
+}
+
+func (i *booleanColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *booleanColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.boolean())
+	i.maxValues = append(i.maxValues, max.boolean())
+}
+
+func (i *booleanColumnIndexer) ColumnIndex() format.ColumnIndex {
+	return i.columnIndex(
+		splitFixedLenByteArrays(unsafecast.BoolToBytes(i.minValues), 1),
+		splitFixedLenByteArrays(unsafecast.BoolToBytes(i.maxValues), 1),
+		orderOfBool(i.minValues),
+		orderOfBool(i.maxValues),
+	)
+}
+
+type int32ColumnIndexer struct {
+	baseColumnIndexer
+	minValues []int32
+	maxValues []int32
+}
+
+func newInt32ColumnIndexer() *int32ColumnIndexer {
+	return new(int32ColumnIndexer)
+}
+
+func (i *int32ColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *int32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.int32())
+	i.maxValues = append(i.maxValues, max.int32())
+}
+
+func reverseInt32MinMaxValues(mLen int, mVal []int32) []byte {
+	buf := make([]byte, mLen*4)
+	idx := 0
+	for k := range mLen {
+		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], uint32(mVal[k]))
+		idx += 4
+	}
+	return buf
+}
+
+func (i *int32ColumnIndexer) ColumnIndex() format.ColumnIndex {
+	byteMin := reverseInt32MinMaxValues(len(i.minValues), i.minValues)
+	byteMax := reverseInt32MinMaxValues(len(i.maxValues), i.maxValues)
+
+	return i.columnIndex(
+		splitFixedLenByteArrays(byteMin, 4),
+		splitFixedLenByteArrays(byteMax, 4),
+		orderOfInt32(i.minValues),
+		orderOfInt32(i.maxValues),
+	)
+}
+
+type int64ColumnIndexer struct {
+	baseColumnIndexer
+	minValues []int64
+	maxValues []int64
+}
+
+func newInt64ColumnIndexer() *int64ColumnIndexer {
+	return new(int64ColumnIndexer)
+}
+
+func (i *int64ColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *int64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.int64())
+	i.maxValues = append(i.maxValues, max.int64())
+}
+
+func reverseInt64MinMaxValues(mLen int, mVal []int64) []byte {
+	buf := make([]byte, mLen*8)
+	idx := 0
+	for k := range mLen {
+		binary.LittleEndian.PutUint64(buf[idx:(8+idx)], uint64(mVal[k]))
+		idx += 8
+	}
+	return buf
+}
+
+func (i *int64ColumnIndexer) ColumnIndex() format.ColumnIndex {
+	byteMin := reverseInt64MinMaxValues(len(i.minValues), i.minValues)
+	byteMax := reverseInt64MinMaxValues(len(i.maxValues), i.maxValues)
+
+	return i.columnIndex(
+		splitFixedLenByteArrays(byteMin, 8),
+		splitFixedLenByteArrays(byteMax, 8),
+		orderOfInt64(i.minValues),
+		orderOfInt64(i.maxValues),
+	)
+}
+
+type int96ColumnIndexer struct {
+	baseColumnIndexer
+	minValues []deprecated.Int96
+	maxValues []deprecated.Int96
+}
+
+func newInt96ColumnIndexer() *int96ColumnIndexer {
+	return new(int96ColumnIndexer)
+}
+
+func (i *int96ColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *int96ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.Int96())
+	i.maxValues = append(i.maxValues, max.Int96())
+}
+
+func reverseInt96MinMaxValues(mLen int, mVal []deprecated.Int96) []byte {
+	buf := make([]byte, mLen*12)
+	idx := 0
+	for k := range mLen {
+		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], uint32(mVal[k][0]))
+		binary.LittleEndian.PutUint32(buf[(4+idx):(8+idx)], uint32(mVal[k][1]))
+		binary.LittleEndian.PutUint32(buf[(8+idx):(12+idx)], uint32(mVal[k][2]))
+		idx += 12
+	}
+	return buf
+}
+
+func (i *int96ColumnIndexer) ColumnIndex() format.ColumnIndex {
+	byteMin := reverseInt96MinMaxValues(len(i.minValues), i.minValues)
+	byteMax := reverseInt96MinMaxValues(len(i.maxValues), i.maxValues)
+
+	return i.columnIndex(
+		splitFixedLenByteArrays(byteMin, 12),
+		splitFixedLenByteArrays(byteMax, 12),
+		deprecated.OrderOfInt96(i.minValues),
+		deprecated.OrderOfInt96(i.maxValues),
+	)
+}
+
+type floatColumnIndexer struct {
+	baseColumnIndexer
+	minValues []float32
+	maxValues []float32
+}
+
+func newFloatColumnIndexer() *floatColumnIndexer {
+	return new(floatColumnIndexer)
+}
+
+func (i *floatColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *floatColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.float())
+	i.maxValues = append(i.maxValues, max.float())
+}
+
+func reverseFloatMinMaxValues(mLen int, mVal []float32) []byte {
+	buf := make([]byte, mLen*4)
+	idx := 0
+	for k := range mLen {
+		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], math.Float32bits(mVal[k]))
+		idx += 4
+	}
+	return buf
+}
+
+func (i *floatColumnIndexer) ColumnIndex() format.ColumnIndex {
+	byteMin := reverseFloatMinMaxValues(len(i.minValues), i.minValues)
+	byteMax := reverseFloatMinMaxValues(len(i.maxValues), i.maxValues)
+
+	return i.columnIndex(
+		splitFixedLenByteArrays(byteMin, 4),
+		splitFixedLenByteArrays(byteMax, 4),
+		orderOfFloat32(i.minValues),
+		orderOfFloat32(i.maxValues),
+	)
+}
+
+type doubleColumnIndexer struct {
+	baseColumnIndexer
+	minValues []float64
+	maxValues []float64
+}
+
+func newDoubleColumnIndexer() *doubleColumnIndexer {
+	return new(doubleColumnIndexer)
+}
+
+func (i *doubleColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *doubleColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.double())
+	i.maxValues = append(i.maxValues, max.double())
+}
+
+func reverseDoubleMinMaxValues(mLen int, mVal []float64) []byte {
+	buf := make([]byte, mLen*8)
+	idx := 0
+	for k := range mLen {
+		binary.LittleEndian.PutUint64(buf[idx:(8+idx)], math.Float64bits(mVal[k]))
+		idx += 8
+	}
+	return buf
+}
+
+func (i *doubleColumnIndexer) ColumnIndex() format.ColumnIndex {
+	byteMin := reverseDoubleMinMaxValues(len(i.minValues), i.minValues)
+	byteMax := reverseDoubleMinMaxValues(len(i.maxValues), i.maxValues)
+
+	return i.columnIndex(
+		splitFixedLenByteArrays(byteMin, 8),
+		splitFixedLenByteArrays(byteMax, 8),
+		orderOfFloat64(i.minValues),
+		orderOfFloat64(i.maxValues),
+	)
+}
+
+type byteArrayColumnIndexer struct {
+	baseColumnIndexer
+	sizeLimit int
+	minValues []byte
+	maxValues []byte
+}
+
+func newByteArrayColumnIndexer(sizeLimit int) *byteArrayColumnIndexer {
+	return &byteArrayColumnIndexer{sizeLimit: sizeLimit}
+}
+
+func (i *byteArrayColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *byteArrayColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = plain.AppendByteArray(i.minValues, min.byteArray())
+	i.maxValues = plain.AppendByteArray(i.maxValues, max.byteArray())
+}
+
+func (i *byteArrayColumnIndexer) ColumnIndex() format.ColumnIndex {
+	minValues := splitByteArrays(i.minValues)
+	maxValues := splitByteArrays(i.maxValues)
+	if sizeLimit := i.sizeLimit; sizeLimit > 0 {
+		for i, v := range minValues {
+			minValues[i] = truncateLargeMinByteArrayValue(v, sizeLimit)
+		}
+		for i, v := range maxValues {
+			maxValues[i] = truncateLargeMaxByteArrayValue(v, sizeLimit)
+		}
+	}
+	return i.columnIndex(
+		minValues,
+		maxValues,
+		orderOfBytes(minValues),
+		orderOfBytes(maxValues),
+	)
+}
+
+type fixedLenByteArrayColumnIndexer struct {
+	baseColumnIndexer
+	size      int
+	sizeLimit int
+	minValues []byte
+	maxValues []byte
+}
+
+func newFixedLenByteArrayColumnIndexer(size, sizeLimit int) *fixedLenByteArrayColumnIndexer {
+	return &fixedLenByteArrayColumnIndexer{
+		size:      size,
+		sizeLimit: sizeLimit,
+	}
+}
+
+func (i *fixedLenByteArrayColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *fixedLenByteArrayColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.byteArray()...)
+	i.maxValues = append(i.maxValues, max.byteArray()...)
+}
+
+func (i *fixedLenByteArrayColumnIndexer) ColumnIndex() format.ColumnIndex {
+	minValues := splitFixedLenByteArrays(i.minValues, i.size)
+	maxValues := splitFixedLenByteArrays(i.maxValues, i.size)
+	if sizeLimit := i.sizeLimit; sizeLimit > 0 {
+		for i, v := range minValues {
+			minValues[i] = truncateLargeMinByteArrayValue(v, sizeLimit)
+		}
+		for i, v := range maxValues {
+			maxValues[i] = truncateLargeMaxByteArrayValue(v, sizeLimit)
+		}
+	}
+	return i.columnIndex(
+		minValues,
+		maxValues,
+		orderOfBytes(minValues),
+		orderOfBytes(maxValues),
+	)
+}
+
+type uint32ColumnIndexer struct {
+	baseColumnIndexer
+	minValues []uint32
+	maxValues []uint32
+}
+
+func newUint32ColumnIndexer() *uint32ColumnIndexer {
+	return new(uint32ColumnIndexer)
+}
+
+func (i *uint32ColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *uint32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.uint32())
+	i.maxValues = append(i.maxValues, max.uint32())
+}
+
+func reverseUint32MinMaxValues(mLen int, mVal []uint32) []byte {
+	buf := make([]byte, mLen*4)
+	idx := 0
+	for k := range mLen {
+		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], mVal[k])
+		idx += 4
+	}
+	return buf
+}
+
+func (i *uint32ColumnIndexer) ColumnIndex() format.ColumnIndex {
+	byteMin := reverseUint32MinMaxValues(len(i.minValues), i.minValues)
+	byteMax := reverseUint32MinMaxValues(len(i.maxValues), i.maxValues)
+
+	return i.columnIndex(
+		splitFixedLenByteArrays(byteMin, 4),
+		splitFixedLenByteArrays(byteMax, 4),
+		orderOfUint32(i.minValues),
+		orderOfUint32(i.maxValues),
+	)
+}
+
+type uint64ColumnIndexer struct {
+	baseColumnIndexer
+	minValues []uint64
+	maxValues []uint64
+}
+
+func newUint64ColumnIndexer() *uint64ColumnIndexer {
+	return new(uint64ColumnIndexer)
+}
+
+func (i *uint64ColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *uint64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, min.uint64())
+	i.maxValues = append(i.maxValues, max.uint64())
+}
+
+func reverseUint64MinMaxValues(mLen int, mVal []uint64) []byte {
+	buf := make([]byte, mLen*8)
+	idx := 0
+	for k := range mLen {
+		binary.LittleEndian.PutUint64(buf[idx:(8+idx)], mVal[k])
+		idx += 8
+	}
+	return buf
+}
+
+func (i *uint64ColumnIndexer) ColumnIndex() format.ColumnIndex {
+	byteMin := reverseUint64MinMaxValues(len(i.minValues), i.minValues)
+	byteMax := reverseUint64MinMaxValues(len(i.maxValues), i.maxValues)
+
+	return i.columnIndex(
+		splitFixedLenByteArrays(byteMin, 8),
+		splitFixedLenByteArrays(byteMax, 8),
+		orderOfUint64(i.minValues),
+		orderOfUint64(i.maxValues),
+	)
+}
+
+type be128ColumnIndexer struct {
+	baseColumnIndexer
+	minValues [][16]byte
+	maxValues [][16]byte
+}
+
+func newBE128ColumnIndexer() *be128ColumnIndexer {
+	return new(be128ColumnIndexer)
+}
+
+func (i *be128ColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *be128ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	if !min.IsNull() {
+		i.minValues = append(i.minValues, *(*[16]byte)(min.byteArray()))
+	}
+	if !max.IsNull() {
+		i.maxValues = append(i.maxValues, *(*[16]byte)(max.byteArray()))
+	}
+}
+
+func (i *be128ColumnIndexer) ColumnIndex() format.ColumnIndex {
+	minValues := splitFixedLenByteArrays(unsafecast.Uint128ToBytes(i.minValues), 16)
+	maxValues := splitFixedLenByteArrays(unsafecast.Uint128ToBytes(i.maxValues), 16)
+	return i.columnIndex(
+		minValues,
+		maxValues,
+		orderOfBytes(minValues),
+		orderOfBytes(maxValues),
+	)
+}
+
+func truncateLargeMinByteArrayValue(value []byte, sizeLimit int) []byte {
+	if len(value) > sizeLimit {
+		value = value[:sizeLimit]
+	}
+	return value
+}
+
+// truncateLargeMaxByteArrayValue truncates the given byte array to the given size limit.
+// If the given byte array is truncated, it is incremented by 1 in place.
+func truncateLargeMaxByteArrayValue(value []byte, sizeLimit int) []byte {
+	if len(value) > sizeLimit {
+		value = value[:sizeLimit]
+		incrementByteArrayInplace(value)
+	}
+	return value
+}
+
+// incrementByteArray increments the given byte array by 1.
+// Reference: https://github.com/apache/parquet-java/blob/master/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BinaryTruncator.java#L124
+func incrementByteArrayInplace(value []byte) {
+	for i := len(value) - 1; i >= 0; i-- {
+		value[i]++
+		if value[i] != 0 { // Did not overflow: 0xFF -> 0x00
+			return
+		}
+	}
+	// Fully overflowed, so restore all to 0xFF
+	for i := range value {
+		value[i] = 0xFF
+	}
+}
+
+func splitByteArrays(data []byte) [][]byte {
+	length := 0
+	plain.RangeByteArray(data, func([]byte) error {
+		length++
+		return nil
+	})
+	buffer := make([]byte, 0, len(data)-(4*length))
+	values := make([][]byte, 0, length)
+	plain.RangeByteArray(data, func(value []byte) error {
+		offset := len(buffer)
+		buffer = append(buffer, value...)
+		values = append(values, buffer[offset:])
+		return nil
+	})
+	return values
+}
+
+func splitFixedLenByteArrays(data []byte, size int) [][]byte {
+	data = copyBytes(data)
+	values := make([][]byte, len(data)/size)
+	for i := range values {
+		j := (i + 0) * size
+		k := (i + 1) * size
+		values[i] = data[j:k:k]
+	}
+	return values
+}
+
+func boundaryOrderOf(minOrder, maxOrder int) format.BoundaryOrder {
+	if minOrder == maxOrder {
+		switch {
+		case minOrder > 0:
+			return format.Ascending
+		case minOrder < 0:
+			return format.Descending
+		}
+	}
+	return format.Unordered
+}

--- a/column_index_le.go
+++ b/column_index_le.go
@@ -1,13 +1,14 @@
+// This file gets added on all the little-endian CPU architectures.
+
+//go:build 386 || amd64 || amd64p32 || alpha || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || nios2 || ppc64le || riscv || riscv64 || sh || wasm
+
 package parquet
 
 import (
-	"encoding/binary"
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding/plain"
 	"github.com/parquet-go/parquet-go/format"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
-	"golang.org/x/sys/cpu"
-	"math"
 )
 
 type ColumnIndex interface {
@@ -357,35 +358,13 @@ func (i *int32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 	i.maxValues = append(i.maxValues, max.int32())
 }
 
-func reverseInt32MinMaxValues(mLen int, mVal []int32) []byte {
-	buf := make([]byte, mLen*4)
-	idx := 0
-	for k := range mLen {
-		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], uint32(mVal[k]))
-		idx += 4
-	}
-	return buf
-}
-
 func (i *int32ColumnIndexer) ColumnIndex() format.ColumnIndex {
-	if cpu.IsBigEndian {
-		byteMin := reverseInt32MinMaxValues(len(i.minValues), i.minValues)
-		byteMax := reverseInt32MinMaxValues(len(i.maxValues), i.maxValues)
-
-		return i.columnIndex(
-			splitFixedLenByteArrays(byteMin, 4),
-			splitFixedLenByteArrays(byteMax, 4),
-			orderOfInt32(i.minValues),
-			orderOfInt32(i.maxValues),
-		)
-	} else {
-		return i.columnIndex(
-			splitFixedLenByteArrays(unsafecast.Int32ToBytes(i.minValues), 4),
-			splitFixedLenByteArrays(unsafecast.Int32ToBytes(i.maxValues), 4),
-			orderOfInt32(i.minValues),
-			orderOfInt32(i.maxValues),
-		)
-	}
+	return i.columnIndex(
+		splitFixedLenByteArrays(unsafecast.Int32ToBytes(i.minValues), 4),
+		splitFixedLenByteArrays(unsafecast.Int32ToBytes(i.maxValues), 4),
+		orderOfInt32(i.minValues),
+		orderOfInt32(i.maxValues),
+	)
 }
 
 type int64ColumnIndexer struct {
@@ -410,35 +389,13 @@ func (i *int64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 	i.maxValues = append(i.maxValues, max.int64())
 }
 
-func reverseInt64MinMaxValues(mLen int, mVal []int64) []byte {
-	buf := make([]byte, mLen*8)
-	idx := 0
-	for k := range mLen {
-		binary.LittleEndian.PutUint64(buf[idx:(8+idx)], uint64(mVal[k]))
-		idx += 8
-	}
-	return buf
-}
-
 func (i *int64ColumnIndexer) ColumnIndex() format.ColumnIndex {
-	if cpu.IsBigEndian {
-		byteMin := reverseInt64MinMaxValues(len(i.minValues), i.minValues)
-		byteMax := reverseInt64MinMaxValues(len(i.maxValues), i.maxValues)
-
-		return i.columnIndex(
-			splitFixedLenByteArrays(byteMin, 8),
-			splitFixedLenByteArrays(byteMax, 8),
-			orderOfInt64(i.minValues),
-			orderOfInt64(i.maxValues),
-		)
-	} else {
-		return i.columnIndex(
-			splitFixedLenByteArrays(unsafecast.Int64ToBytes(i.minValues), 8),
-			splitFixedLenByteArrays(unsafecast.Int64ToBytes(i.maxValues), 8),
-			orderOfInt64(i.minValues),
-			orderOfInt64(i.maxValues),
-		)
-	}
+	return i.columnIndex(
+		splitFixedLenByteArrays(unsafecast.Int64ToBytes(i.minValues), 8),
+		splitFixedLenByteArrays(unsafecast.Int64ToBytes(i.maxValues), 8),
+		orderOfInt64(i.minValues),
+		orderOfInt64(i.maxValues),
+	)
 }
 
 type int96ColumnIndexer struct {
@@ -463,37 +420,13 @@ func (i *int96ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 	i.maxValues = append(i.maxValues, max.Int96())
 }
 
-func reverseInt96MinMaxValues(mLen int, mVal []deprecated.Int96) []byte {
-	buf := make([]byte, mLen*12)
-	idx := 0
-	for k := range mLen {
-		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], uint32(mVal[k][0]))
-		binary.LittleEndian.PutUint32(buf[(4+idx):(8+idx)], uint32(mVal[k][1]))
-		binary.LittleEndian.PutUint32(buf[(8+idx):(12+idx)], uint32(mVal[k][2]))
-		idx += 12
-	}
-	return buf
-}
-
 func (i *int96ColumnIndexer) ColumnIndex() format.ColumnIndex {
-	if cpu.IsBigEndian {
-		byteMin := reverseInt96MinMaxValues(len(i.minValues), i.minValues)
-		byteMax := reverseInt96MinMaxValues(len(i.maxValues), i.maxValues)
-
-		return i.columnIndex(
-			splitFixedLenByteArrays(byteMin, 12),
-			splitFixedLenByteArrays(byteMax, 12),
-			deprecated.OrderOfInt96(i.minValues),
-			deprecated.OrderOfInt96(i.maxValues),
-		)
-	} else {
-		return i.columnIndex(
-			splitFixedLenByteArrays(deprecated.Int96ToBytes(i.minValues), 12),
-			splitFixedLenByteArrays(deprecated.Int96ToBytes(i.maxValues), 12),
-			deprecated.OrderOfInt96(i.minValues),
-			deprecated.OrderOfInt96(i.maxValues),
-		)
-	}
+	return i.columnIndex(
+		splitFixedLenByteArrays(deprecated.Int96ToBytes(i.minValues), 12),
+		splitFixedLenByteArrays(deprecated.Int96ToBytes(i.maxValues), 12),
+		deprecated.OrderOfInt96(i.minValues),
+		deprecated.OrderOfInt96(i.maxValues),
+	)
 }
 
 type floatColumnIndexer struct {
@@ -518,35 +451,13 @@ func (i *floatColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 	i.maxValues = append(i.maxValues, max.float())
 }
 
-func reverseFloatMinMaxValues(mLen int, mVal []float32) []byte {
-	buf := make([]byte, mLen*4)
-	idx := 0
-	for k := range mLen {
-		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], math.Float32bits(mVal[k]))
-		idx += 4
-	}
-	return buf
-}
-
 func (i *floatColumnIndexer) ColumnIndex() format.ColumnIndex {
-	if cpu.IsBigEndian {
-		byteMin := reverseFloatMinMaxValues(len(i.minValues), i.minValues)
-		byteMax := reverseFloatMinMaxValues(len(i.maxValues), i.maxValues)
-
-		return i.columnIndex(
-			splitFixedLenByteArrays(byteMin, 4),
-			splitFixedLenByteArrays(byteMax, 4),
-			orderOfFloat32(i.minValues),
-			orderOfFloat32(i.maxValues),
-		)
-	} else {
-		return i.columnIndex(
-			splitFixedLenByteArrays(unsafecast.Float32ToBytes(i.minValues), 4),
-			splitFixedLenByteArrays(unsafecast.Float32ToBytes(i.maxValues), 4),
-			orderOfFloat32(i.minValues),
-			orderOfFloat32(i.maxValues),
-		)
-	}
+	return i.columnIndex(
+		splitFixedLenByteArrays(unsafecast.Float32ToBytes(i.minValues), 4),
+		splitFixedLenByteArrays(unsafecast.Float32ToBytes(i.maxValues), 4),
+		orderOfFloat32(i.minValues),
+		orderOfFloat32(i.maxValues),
+	)
 }
 
 type doubleColumnIndexer struct {
@@ -571,35 +482,13 @@ func (i *doubleColumnIndexer) IndexPage(numValues, numNulls int64, min, max Valu
 	i.maxValues = append(i.maxValues, max.double())
 }
 
-func reverseDoubleMinMaxValues(mLen int, mVal []float64) []byte {
-	buf := make([]byte, mLen*8)
-	idx := 0
-	for k := range mLen {
-		binary.LittleEndian.PutUint64(buf[idx:(8+idx)], math.Float64bits(mVal[k]))
-		idx += 8
-	}
-	return buf
-}
-
 func (i *doubleColumnIndexer) ColumnIndex() format.ColumnIndex {
-	if cpu.IsBigEndian {
-		byteMin := reverseDoubleMinMaxValues(len(i.minValues), i.minValues)
-		byteMax := reverseDoubleMinMaxValues(len(i.maxValues), i.maxValues)
-
-		return i.columnIndex(
-			splitFixedLenByteArrays(byteMin, 8),
-			splitFixedLenByteArrays(byteMax, 8),
-			orderOfFloat64(i.minValues),
-			orderOfFloat64(i.maxValues),
-		)
-	} else {
-		return i.columnIndex(
-			splitFixedLenByteArrays(unsafecast.Float64ToBytes(i.minValues), 8),
-			splitFixedLenByteArrays(unsafecast.Float64ToBytes(i.maxValues), 8),
-			orderOfFloat64(i.minValues),
-			orderOfFloat64(i.maxValues),
-		)
-	}
+	return i.columnIndex(
+		splitFixedLenByteArrays(unsafecast.Float64ToBytes(i.minValues), 8),
+		splitFixedLenByteArrays(unsafecast.Float64ToBytes(i.maxValues), 8),
+		orderOfFloat64(i.minValues),
+		orderOfFloat64(i.maxValues),
+	)
 }
 
 type byteArrayColumnIndexer struct {
@@ -712,35 +601,13 @@ func (i *uint32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Valu
 	i.maxValues = append(i.maxValues, max.uint32())
 }
 
-func reverseUint32MinMaxValues(mLen int, mVal []uint32) []byte {
-	buf := make([]byte, mLen*4)
-	idx := 0
-	for k := range mLen {
-		binary.LittleEndian.PutUint32(buf[idx:(4+idx)], mVal[k])
-		idx += 4
-	}
-	return buf
-}
-
 func (i *uint32ColumnIndexer) ColumnIndex() format.ColumnIndex {
-	if cpu.IsBigEndian {
-		byteMin := reverseUint32MinMaxValues(len(i.minValues), i.minValues)
-		byteMax := reverseUint32MinMaxValues(len(i.maxValues), i.maxValues)
-
-		return i.columnIndex(
-			splitFixedLenByteArrays(byteMin, 4),
-			splitFixedLenByteArrays(byteMax, 4),
-			orderOfUint32(i.minValues),
-			orderOfUint32(i.maxValues),
-		)
-	} else {
-		return i.columnIndex(
-			splitFixedLenByteArrays(unsafecast.Uint32ToBytes(i.minValues), 4),
-			splitFixedLenByteArrays(unsafecast.Uint32ToBytes(i.maxValues), 4),
-			orderOfUint32(i.minValues),
-			orderOfUint32(i.maxValues),
-		)
-	}
+	return i.columnIndex(
+		splitFixedLenByteArrays(unsafecast.Uint32ToBytes(i.minValues), 4),
+		splitFixedLenByteArrays(unsafecast.Uint32ToBytes(i.maxValues), 4),
+		orderOfUint32(i.minValues),
+		orderOfUint32(i.maxValues),
+	)
 }
 
 type uint64ColumnIndexer struct {
@@ -765,35 +632,13 @@ func (i *uint64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Valu
 	i.maxValues = append(i.maxValues, max.uint64())
 }
 
-func reverseUint64MinMaxValues(mLen int, mVal []uint64) []byte {
-	buf := make([]byte, mLen*8)
-	idx := 0
-	for k := range mLen {
-		binary.LittleEndian.PutUint64(buf[idx:(8+idx)], mVal[k])
-		idx += 8
-	}
-	return buf
-}
-
 func (i *uint64ColumnIndexer) ColumnIndex() format.ColumnIndex {
-	if cpu.IsBigEndian {
-		byteMin := reverseUint64MinMaxValues(len(i.minValues), i.minValues)
-		byteMax := reverseUint64MinMaxValues(len(i.maxValues), i.maxValues)
-
-		return i.columnIndex(
-			splitFixedLenByteArrays(byteMin, 8),
-			splitFixedLenByteArrays(byteMax, 8),
-			orderOfUint64(i.minValues),
-			orderOfUint64(i.maxValues),
-		)
-	} else {
-		return i.columnIndex(
-			splitFixedLenByteArrays(unsafecast.Uint64ToBytes(i.minValues), 8),
-			splitFixedLenByteArrays(unsafecast.Uint64ToBytes(i.maxValues), 8),
-			orderOfUint64(i.minValues),
-			orderOfUint64(i.maxValues),
-		)
-	}
+	return i.columnIndex(
+		splitFixedLenByteArrays(unsafecast.Uint64ToBytes(i.minValues), 8),
+		splitFixedLenByteArrays(unsafecast.Uint64ToBytes(i.maxValues), 8),
+		orderOfUint64(i.minValues),
+		orderOfUint64(i.maxValues),
+	)
 }
 
 type be128ColumnIndexer struct {

--- a/convert.go
+++ b/convert.go
@@ -14,6 +14,7 @@ import (
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
+	"golang.org/x/sys/cpu"
 )
 
 // ConvertError is an error type returned by calls to Convert when the conversion
@@ -912,6 +913,14 @@ func convertStringToInt96(v Value) (Value, error) {
 	b := i.Bytes()
 	c := make([]byte, 12)
 	copy(c, b)
+	if cpu.IsBigEndian {
+		bufLen := len(c)
+		for idx := 0; idx < bufLen; idx = idx + 4 {
+			for m, n := (idx + 0), (idx + 3); m < n; m, n = m+1, n-1 {
+				c[m], c[n] = c[n], c[m]
+			}
+		}
+	}
 	i96 := deprecated.BytesToInt96(c)
 	return v.convertToInt96(i96[0]), nil
 }

--- a/dictionary.go
+++ b/dictionary.go
@@ -291,8 +291,8 @@ func (d *int32Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *int32Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-        offset := getOffset(*d)
-        d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
+	offset := getOffset(*d)
+	d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *int32Dictionary) Bounds(indexes []int32) (min, max Value) {
@@ -520,8 +520,8 @@ func (d *floatDictionary) Index(i int32) Value { return d.makeValue(d.index(i)) 
 func (d *floatDictionary) index(i int32) float32 { return d.values[i] }
 
 func (d *floatDictionary) Insert(indexes []int32, values []Value) {
-        offset := getOffset(*d)
-        d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
+	offset := getOffset(*d)
+	d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *floatDictionary) init(indexes []int32) {
@@ -560,8 +560,8 @@ func (d *floatDictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *floatDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-        offset := getOffset(*d)
-        d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
+	offset := getOffset(*d)
+	d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *floatDictionary) Bounds(indexes []int32) (min, max Value) {
@@ -930,8 +930,8 @@ func (d *uint32Dictionary) Index(i int32) Value { return d.makeValue(d.index(i))
 func (d *uint32Dictionary) index(i int32) uint32 { return d.values[i] }
 
 func (d *uint32Dictionary) Insert(indexes []int32, values []Value) {
-        offset := getOffset(*d)
-        d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
+	offset := getOffset(*d)
+	d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *uint32Dictionary) init(indexes []int32) {
@@ -970,8 +970,8 @@ func (d *uint32Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *uint32Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-        offset := getOffset(*d)
-        d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
+	offset := getOffset(*d)
+	d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *uint32Dictionary) Bounds(indexes []int32) (min, max Value) {

--- a/dictionary.go
+++ b/dictionary.go
@@ -12,7 +12,6 @@ import (
 	"github.com/parquet-go/parquet-go/internal/bitpack"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
 	"github.com/parquet-go/parquet-go/sparse"
-	"golang.org/x/sys/cpu"
 )
 
 const (
@@ -141,12 +140,8 @@ func (d *booleanDictionary) Index(i int32) Value { return d.makeValue(d.index(i)
 func (d *booleanDictionary) index(i int32) bool { return d.valueAt(int(i)) }
 
 func (d *booleanDictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	if cpu.IsBigEndian {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+7))
-	} else {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
-	}
+	offset := getOffset(*d)
+	d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *booleanDictionary) insert(indexes []int32, rows sparse.Array) {
@@ -176,7 +171,7 @@ func (d *booleanDictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *booleanDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(false)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	d.lookup(indexes, makeArrayValue(values, offsetOfU64))
 }
 
 func (d *booleanDictionary) lookup(indexes []int32, rows sparse.Array) {
@@ -243,12 +238,8 @@ func (d *int32Dictionary) Index(i int32) Value { return d.makeValue(d.index(i)) 
 func (d *int32Dictionary) index(i int32) int32 { return d.values[i] }
 
 func (d *int32Dictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	if cpu.IsBigEndian {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
-	} else {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
-	}
+	offset := getOffset(*d)
+	d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *int32Dictionary) init(indexes []int32) {
@@ -300,11 +291,8 @@ func (d *int32Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *int32Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	if cpu.IsBigEndian {
-		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
-	} else {
-		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
-	}
+        offset := getOffset(*d)
+        d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *int32Dictionary) Bounds(indexes []int32) (min, max Value) {
@@ -351,8 +339,7 @@ func (d *int64Dictionary) Index(i int32) Value { return d.makeValue(d.index(i)) 
 func (d *int64Dictionary) index(i int32) int64 { return d.values[i] }
 
 func (d *int64Dictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	d.insert(indexes, makeArrayValue(values, offsetOfU64))
 }
 
 func (d *int64Dictionary) init(indexes []int32) {
@@ -391,7 +378,7 @@ func (d *int64Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *int64Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	d.lookup(indexes, makeArrayValue(values, offsetOfU64))
 }
 
 func (d *int64Dictionary) Bounds(indexes []int32) (min, max Value) {
@@ -533,12 +520,8 @@ func (d *floatDictionary) Index(i int32) Value { return d.makeValue(d.index(i)) 
 func (d *floatDictionary) index(i int32) float32 { return d.values[i] }
 
 func (d *floatDictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	if cpu.IsBigEndian {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
-	} else {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
-	}
+        offset := getOffset(*d)
+        d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *floatDictionary) init(indexes []int32) {
@@ -577,11 +560,8 @@ func (d *floatDictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *floatDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	if cpu.IsBigEndian {
-		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
-	} else {
-		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
-	}
+        offset := getOffset(*d)
+        d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *floatDictionary) Bounds(indexes []int32) (min, max Value) {
@@ -628,8 +608,7 @@ func (d *doubleDictionary) Index(i int32) Value { return d.makeValue(d.index(i))
 func (d *doubleDictionary) index(i int32) float64 { return d.values[i] }
 
 func (d *doubleDictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	d.insert(indexes, makeArrayValue(values, offsetOfU64))
 }
 
 func (d *doubleDictionary) init(indexes []int32) {
@@ -668,7 +647,7 @@ func (d *doubleDictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *doubleDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	d.lookup(indexes, makeArrayValue(values, offsetOfU64))
 }
 
 func (d *doubleDictionary) Bounds(indexes []int32) (min, max Value) {
@@ -727,8 +706,7 @@ func (d *byteArrayDictionary) Len() int { return d.len() }
 func (d *byteArrayDictionary) Index(i int32) Value { return d.makeValueBytes(d.index(int(i))) }
 
 func (d *byteArrayDictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.ptr)))
+	d.insert(indexes, makeArrayValue(values, offsetOfPtr))
 }
 
 func (d *byteArrayDictionary) init() {
@@ -766,7 +744,7 @@ func (d *byteArrayDictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *byteArrayDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValueString("")
 	memsetValues(values, model)
-	d.lookupString(indexes, makeArrayValue(values, unsafe.Offsetof(model.ptr)))
+	d.lookupString(indexes, makeArrayValue(values, offsetOfPtr))
 }
 
 func (d *byteArrayDictionary) Bounds(indexes []int32) (min, max Value) {
@@ -885,7 +863,7 @@ func (d *fixedLenByteArrayDictionary) insertValues(indexes []int32, count int, v
 func (d *fixedLenByteArrayDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValueString("")
 	memsetValues(values, model)
-	d.lookupString(indexes, makeArrayValue(values, unsafe.Offsetof(model.ptr)))
+	d.lookupString(indexes, makeArrayValue(values, offsetOfPtr))
 }
 
 func (d *fixedLenByteArrayDictionary) Bounds(indexes []int32) (min, max Value) {
@@ -952,12 +930,8 @@ func (d *uint32Dictionary) Index(i int32) Value { return d.makeValue(d.index(i))
 func (d *uint32Dictionary) index(i int32) uint32 { return d.values[i] }
 
 func (d *uint32Dictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	if cpu.IsBigEndian {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
-	} else {
-		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
-	}
+        offset := getOffset(*d)
+        d.insert(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *uint32Dictionary) init(indexes []int32) {
@@ -996,11 +970,8 @@ func (d *uint32Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *uint32Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	if cpu.IsBigEndian {
-		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
-	} else {
-		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
-	}
+        offset := getOffset(*d)
+        d.lookup(indexes, makeArrayValue(values, offsetOfU64+offset))
 }
 
 func (d *uint32Dictionary) Bounds(indexes []int32) (min, max Value) {
@@ -1047,8 +1018,7 @@ func (d *uint64Dictionary) Index(i int32) Value { return d.makeValue(d.index(i))
 func (d *uint64Dictionary) index(i int32) uint64 { return d.values[i] }
 
 func (d *uint64Dictionary) Insert(indexes []int32, values []Value) {
-	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	d.insert(indexes, makeArrayValue(values, offsetOfU64))
 }
 
 func (d *uint64Dictionary) init(indexes []int32) {
@@ -1087,7 +1057,7 @@ func (d *uint64Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *uint64Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	d.lookup(indexes, makeArrayValue(values, offsetOfU64))
 }
 
 func (d *uint64Dictionary) Bounds(indexes []int32) (min, max Value) {
@@ -1205,7 +1175,7 @@ func (d *be128Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *be128Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValueString("")
 	memsetValues(values, model)
-	d.lookupString(indexes, makeArrayValue(values, unsafe.Offsetof(model.ptr)))
+	d.lookupString(indexes, makeArrayValue(values, offsetOfPtr))
 }
 
 func (d *be128Dictionary) Bounds(indexes []int32) (min, max Value) {

--- a/dictionary.go
+++ b/dictionary.go
@@ -12,6 +12,7 @@ import (
 	"github.com/parquet-go/parquet-go/internal/bitpack"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
 	"github.com/parquet-go/parquet-go/sparse"
+	"golang.org/x/sys/cpu"
 )
 
 const (
@@ -141,7 +142,11 @@ func (d *booleanDictionary) index(i int32) bool { return d.valueAt(int(i)) }
 
 func (d *booleanDictionary) Insert(indexes []int32, values []Value) {
 	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	if cpu.IsBigEndian {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+7))
+	} else {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	}
 }
 
 func (d *booleanDictionary) insert(indexes []int32, rows sparse.Array) {
@@ -239,7 +244,11 @@ func (d *int32Dictionary) index(i int32) int32 { return d.values[i] }
 
 func (d *int32Dictionary) Insert(indexes []int32, values []Value) {
 	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	if cpu.IsBigEndian {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
+	} else {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	}
 }
 
 func (d *int32Dictionary) init(indexes []int32) {
@@ -291,7 +300,11 @@ func (d *int32Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *int32Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	if cpu.IsBigEndian {
+		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
+	} else {
+		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	}
 }
 
 func (d *int32Dictionary) Bounds(indexes []int32) (min, max Value) {
@@ -521,7 +534,11 @@ func (d *floatDictionary) index(i int32) float32 { return d.values[i] }
 
 func (d *floatDictionary) Insert(indexes []int32, values []Value) {
 	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	if cpu.IsBigEndian {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
+	} else {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	}
 }
 
 func (d *floatDictionary) init(indexes []int32) {
@@ -560,7 +577,11 @@ func (d *floatDictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *floatDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	if cpu.IsBigEndian {
+		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
+	} else {
+		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	}
 }
 
 func (d *floatDictionary) Bounds(indexes []int32) (min, max Value) {
@@ -932,7 +953,11 @@ func (d *uint32Dictionary) index(i int32) uint32 { return d.values[i] }
 
 func (d *uint32Dictionary) Insert(indexes []int32, values []Value) {
 	model := Value{}
-	d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	if cpu.IsBigEndian {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
+	} else {
+		d.insert(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	}
 }
 
 func (d *uint32Dictionary) init(indexes []int32) {
@@ -971,7 +996,11 @@ func (d *uint32Dictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *uint32Dictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(0)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	if cpu.IsBigEndian {
+		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)+4))
+	} else {
+		d.lookup(indexes, makeArrayValue(values, unsafe.Offsetof(model.u64)))
+	}
 }
 
 func (d *uint32Dictionary) Bounds(indexes []int32) (min, max Value) {

--- a/encoding/plain/plain.go
+++ b/encoding/plain/plain.go
@@ -42,7 +42,7 @@ func (e *Encoding) EncodeInt32(dst []byte, src []int32) ([]byte, error) {
 		srcLen := len(src)
 		byteEnc := make([]byte, (srcLen * 4))
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			binary.LittleEndian.PutUint32(byteEnc[idx:(4+idx)], uint32((src)[k]))
 			idx += 4
 		}
@@ -57,7 +57,7 @@ func (e *Encoding) EncodeInt64(dst []byte, src []int64) ([]byte, error) {
 		srcLen := len(src)
 		byteEnc := make([]byte, (srcLen * 8))
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			binary.LittleEndian.PutUint64(byteEnc[idx:(8+idx)], uint64((src)[k]))
 			idx += 8
 		}
@@ -76,7 +76,7 @@ func (e *Encoding) EncodeFloat(dst []byte, src []float32) ([]byte, error) {
 		srcLen := len(src)
 		byteEnc := make([]byte, (srcLen * 4))
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			binary.LittleEndian.PutUint32(byteEnc[idx:(4+idx)], math.Float32bits((src)[k]))
 			idx += 4
 		}
@@ -91,7 +91,7 @@ func (e *Encoding) EncodeDouble(dst []byte, src []float64) ([]byte, error) {
 		srcLen := len(src)
 		byteEnc := make([]byte, (srcLen * 8))
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			binary.LittleEndian.PutUint64(byteEnc[idx:(8+idx)], math.Float64bits((src)[k]))
 			idx += 8
 		}
@@ -136,7 +136,7 @@ func (e *Encoding) DecodeInt32(dst []int32, src []byte) ([]int32, error) {
 		srcLen := (len(src) / 4)
 		byteDec := make([]int32, srcLen)
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			byteDec[k] = int32(binary.LittleEndian.Uint32((src)[idx:(4 + idx)]))
 			idx += 4
 		}
@@ -155,7 +155,7 @@ func (e *Encoding) DecodeInt64(dst []int64, src []byte) ([]int64, error) {
 		srcLen := (len(src) / 8)
 		byteDec := make([]int64, srcLen)
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			byteDec[k] = int64(binary.LittleEndian.Uint64((src)[idx:(8 + idx)]))
 			idx += 8
 		}
@@ -182,7 +182,7 @@ func (e *Encoding) DecodeFloat(dst []float32, src []byte) ([]float32, error) {
 		srcLen := (len(src) / 4)
 		byteDec := make([]float32, srcLen)
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			byteDec[k] = float32(math.Float32frombits(binary.LittleEndian.Uint32((src)[idx:(4 + idx)])))
 			idx += 4
 		}
@@ -202,7 +202,7 @@ func (e *Encoding) DecodeDouble(dst []float64, src []byte) ([]float64, error) {
 		srcLen := (len(src) / 8)
 		byteDec := make([]float64, srcLen)
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			byteDec[k] = float64(math.Float64frombits(binary.LittleEndian.Uint64((src)[idx:(8 + idx)])))
 			idx += 8
 		}

--- a/encoding/plain/plain.go
+++ b/encoding/plain/plain.go
@@ -6,9 +6,9 @@ package plain
 import (
 	"encoding/binary"
 	"fmt"
+	"golang.org/x/sys/cpu"
 	"io"
 	"math"
-	"golang.org/x/sys/cpu"
 
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding"

--- a/encoding/plain/plain.go
+++ b/encoding/plain/plain.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"golang.org/x/sys/cpu"
 
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding"
@@ -37,11 +38,33 @@ func (e *Encoding) EncodeBoolean(dst []byte, src []byte) ([]byte, error) {
 }
 
 func (e *Encoding) EncodeInt32(dst []byte, src []int32) ([]byte, error) {
-	return append(dst[:0], unsafecast.Int32ToBytes(src)...), nil
+	if cpu.IsBigEndian {
+		srcLen := len(src)
+		byteEnc := make([]byte, (srcLen * 4))
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			binary.LittleEndian.PutUint32(byteEnc[idx:(4+idx)], uint32((src)[k]))
+			idx += 4
+		}
+		return append(dst[:0], (byteEnc)...), nil
+	} else {
+		return append(dst[:0], unsafecast.Int32ToBytes(src)...), nil
+	}
 }
 
 func (e *Encoding) EncodeInt64(dst []byte, src []int64) ([]byte, error) {
-	return append(dst[:0], unsafecast.Int64ToBytes(src)...), nil
+	if cpu.IsBigEndian {
+		srcLen := len(src)
+		byteEnc := make([]byte, (srcLen * 8))
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			binary.LittleEndian.PutUint64(byteEnc[idx:(8+idx)], uint64((src)[k]))
+			idx += 8
+		}
+		return append(dst[:0], (byteEnc)...), nil
+	} else {
+		return append(dst[:0], unsafecast.Int64ToBytes(src)...), nil
+	}
 }
 
 func (e *Encoding) EncodeInt96(dst []byte, src []deprecated.Int96) ([]byte, error) {
@@ -49,11 +72,33 @@ func (e *Encoding) EncodeInt96(dst []byte, src []deprecated.Int96) ([]byte, erro
 }
 
 func (e *Encoding) EncodeFloat(dst []byte, src []float32) ([]byte, error) {
-	return append(dst[:0], unsafecast.Float32ToBytes(src)...), nil
+	if cpu.IsBigEndian {
+		srcLen := len(src)
+		byteEnc := make([]byte, (srcLen * 4))
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			binary.LittleEndian.PutUint32(byteEnc[idx:(4+idx)], math.Float32bits((src)[k]))
+			idx += 4
+		}
+		return append(dst[:0], (byteEnc)...), nil
+	} else {
+		return append(dst[:0], unsafecast.Float32ToBytes(src)...), nil
+	}
 }
 
 func (e *Encoding) EncodeDouble(dst []byte, src []float64) ([]byte, error) {
-	return append(dst[:0], unsafecast.Float64ToBytes(src)...), nil
+	if cpu.IsBigEndian {
+		srcLen := len(src)
+		byteEnc := make([]byte, (srcLen * 8))
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			binary.LittleEndian.PutUint64(byteEnc[idx:(8+idx)], math.Float64bits((src)[k]))
+			idx += 8
+		}
+		return append(dst[:0], (byteEnc)...), nil
+	} else {
+		return append(dst[:0], unsafecast.Float64ToBytes(src)...), nil
+	}
 }
 
 func (e *Encoding) EncodeByteArray(dst []byte, src []byte, offsets []uint32) ([]byte, error) {
@@ -86,14 +131,39 @@ func (e *Encoding) DecodeInt32(dst []int32, src []byte) ([]int32, error) {
 	if (len(src) % 4) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "INT32", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToInt32(src)...), nil
+
+	if cpu.IsBigEndian {
+		srcLen := (len(src) / 4)
+		byteDec := make([]int32, srcLen)
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			byteDec[k] = int32(binary.LittleEndian.Uint32((src)[idx:(4 + idx)]))
+			idx += 4
+		}
+		return append(dst[:0], (byteDec)...), nil
+	} else {
+		return append(dst[:0], unsafecast.BytesToInt32(src)...), nil
+	}
 }
 
 func (e *Encoding) DecodeInt64(dst []int64, src []byte) ([]int64, error) {
 	if (len(src) % 8) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "INT64", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToInt64(src)...), nil
+
+	if cpu.IsBigEndian {
+		srcLen := (len(src) / 8)
+		byteDec := make([]int64, srcLen)
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			byteDec[k] = int64(binary.LittleEndian.Uint64((src)[idx:(8 + idx)]))
+			idx += 8
+		}
+
+		return append(dst[:0], (byteDec)...), nil
+	} else {
+		return append(dst[:0], unsafecast.BytesToInt64(src)...), nil
+	}
 }
 
 func (e *Encoding) DecodeInt96(dst []deprecated.Int96, src []byte) ([]deprecated.Int96, error) {
@@ -107,14 +177,40 @@ func (e *Encoding) DecodeFloat(dst []float32, src []byte) ([]float32, error) {
 	if (len(src) % 4) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "FLOAT", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToFloat32(src)...), nil
+
+	if cpu.IsBigEndian {
+		srcLen := (len(src) / 4)
+		byteDec := make([]float32, srcLen)
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			byteDec[k] = float32(math.Float32frombits(binary.LittleEndian.Uint32((src)[idx:(4 + idx)])))
+			idx += 4
+		}
+
+		return append(dst[:0], (byteDec)...), nil
+	} else {
+		return append(dst[:0], unsafecast.BytesToFloat32(src)...), nil
+	}
 }
 
 func (e *Encoding) DecodeDouble(dst []float64, src []byte) ([]float64, error) {
 	if (len(src) % 8) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "DOUBLE", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToFloat64(src)...), nil
+
+	if cpu.IsBigEndian {
+		srcLen := (len(src) / 8)
+		byteDec := make([]float64, srcLen)
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			byteDec[k] = float64(math.Float64frombits(binary.LittleEndian.Uint64((src)[idx:(8 + idx)])))
+			idx += 8
+		}
+
+		return append(dst[:0], (byteDec)...), nil
+	} else {
+		return append(dst[:0], unsafecast.BytesToFloat64(src)...), nil
+	}
 }
 
 func (e *Encoding) DecodeByteArray(dst []byte, src []byte, offsets []uint32) ([]byte, []uint32, error) {

--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"unsafe"
+	"golang.org/x/sys/cpu"
 
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
@@ -151,7 +152,17 @@ func encodeBytes(dst, src []byte, bitWidth uint) ([]byte, error) {
 	}
 
 	if len(src) >= 8 {
-		words := unsafe.Slice((*uint64)(unsafe.Pointer(&src[0])), len(src)/8)
+		srcLen := (len(src) / 8)
+		words := make([]uint64, srcLen)
+		if cpu.IsBigEndian {
+			idx := 0
+			for k := 0; k < srcLen; k++ {
+				words[k] = binary.LittleEndian.Uint64((src)[idx:(8 + idx)])
+				idx += 8
+			}
+		} else {
+			words = unsafe.Slice((*uint64)(unsafe.Pointer(&src[0])), len(src)/8)
+		}
 
 		for i := 0; i < len(words); {
 			j := i
@@ -385,6 +396,13 @@ func decodeInt32(dst, src []byte, bitWidth uint) ([]byte, error) {
 
 			bits := [4]byte{}
 			copy(bits[:], src[i:j])
+
+			//swap the bytes in the "bits" array to take care of big endian arch
+			if cpu.IsBigEndian {
+				for m, n := 0, 3; m < n; m, n = m+1, n-1 {
+					bits[m], bits[n] = bits[n], bits[m]
+				}
+			}
 			dst = appendRepeat(dst, bits[:], count)
 			i = j
 		}

--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -8,9 +8,9 @@ package rle
 import (
 	"encoding/binary"
 	"fmt"
+	"golang.org/x/sys/cpu"
 	"io"
 	"unsafe"
-	"golang.org/x/sys/cpu"
 
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"

--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -156,7 +156,7 @@ func encodeBytes(dst, src []byte, bitWidth uint) ([]byte, error) {
 		words := make([]uint64, srcLen)
 		if cpu.IsBigEndian {
 			idx := 0
-			for k := 0; k < srcLen; k++ {
+			for k := range srcLen {
 				words[k] = binary.LittleEndian.Uint64((src)[idx:(8 + idx)])
 				idx += 8
 			}

--- a/internal/bitpack/unpack_int32_purego.go
+++ b/internal/bitpack/unpack_int32_purego.go
@@ -3,11 +3,24 @@
 package bitpack
 
 import (
+	"encoding/binary"
+	"golang.org/x/sys/cpu"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 func unpackInt32(dst []int32, src []byte, bitWidth uint) {
-	bits := unsafecast.BytesToUint32(src)
+	srcLen := (len(src) / 4)
+	bits := make([]uint32, srcLen)
+	if cpu.IsBigEndian {
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			bits[k] = binary.LittleEndian.Uint32((src)[idx:(4 + idx)])
+			idx += 4
+		}
+	} else {
+		bits = unsafecast.BytesToUint32(src)
+	}
+
 	bitMask := uint32(1<<bitWidth) - 1
 	bitOffset := uint(0)
 

--- a/internal/bitpack/unpack_int32_purego.go
+++ b/internal/bitpack/unpack_int32_purego.go
@@ -13,7 +13,7 @@ func unpackInt32(dst []int32, src []byte, bitWidth uint) {
 	bits := make([]uint32, srcLen)
 	if cpu.IsBigEndian {
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			bits[k] = binary.LittleEndian.Uint32((src)[idx:(4 + idx)])
 			idx += 4
 		}

--- a/internal/bitpack/unpack_int32_purego.go
+++ b/internal/bitpack/unpack_int32_purego.go
@@ -4,8 +4,8 @@ package bitpack
 
 import (
 	"encoding/binary"
-	"golang.org/x/sys/cpu"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
+	"golang.org/x/sys/cpu"
 )
 
 func unpackInt32(dst []int32, src []byte, bitWidth uint) {

--- a/internal/bitpack/unpack_int64_purego.go
+++ b/internal/bitpack/unpack_int64_purego.go
@@ -4,8 +4,8 @@ package bitpack
 
 import (
 	"encoding/binary"
-	"golang.org/x/sys/cpu"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
+	"golang.org/x/sys/cpu"
 )
 
 func unpackInt64(dst []int64, src []byte, bitWidth uint) {

--- a/internal/bitpack/unpack_int64_purego.go
+++ b/internal/bitpack/unpack_int64_purego.go
@@ -2,10 +2,25 @@
 
 package bitpack
 
-import "github.com/parquet-go/parquet-go/internal/unsafecast"
+import (
+	"encoding/binary"
+	"golang.org/x/sys/cpu"
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
+)
 
 func unpackInt64(dst []int64, src []byte, bitWidth uint) {
-	bits := unsafecast.BytesToUint32(src)
+	srcLen := (len(src) / 4)
+	bits := make([]uint32, srcLen)
+	if cpu.IsBigEndian {
+		idx := 0
+		for k := 0; k < srcLen; k++ {
+			bits[k] = binary.LittleEndian.Uint32((src)[idx:(4 + idx)])
+			idx += 4
+		}
+	} else {
+		bits = unsafecast.BytesToUint32(src)
+	}
+
 	bitMask := uint64(1<<bitWidth) - 1
 	bitOffset := uint(0)
 

--- a/internal/bitpack/unpack_int64_purego.go
+++ b/internal/bitpack/unpack_int64_purego.go
@@ -13,7 +13,7 @@ func unpackInt64(dst []int64, src []byte, bitWidth uint) {
 	bits := make([]uint32, srcLen)
 	if cpu.IsBigEndian {
 		idx := 0
-		for k := 0; k < srcLen; k++ {
+		for k := range srcLen {
 			bits[k] = binary.LittleEndian.Uint32((src)[idx:(4 + idx)])
 			idx += 4
 		}


### PR DESCRIPTION
This is to support parquet on s390x. Due to endianness issues, parquet was never supported on s390x.
This CL is to enable the required support.