### PR TITLE
maintenance: reduce the amount of unsafe constructs

### DIFF
--- a/allocator.go
+++ b/allocator.go
@@ -1,6 +1,10 @@
 package parquet
 
-import "github.com/parquet-go/parquet-go/internal/unsafecast"
+import (
+	"unsafe"
+
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
+)
 
 type allocator struct{ buffer []byte }
 
@@ -54,7 +58,7 @@ func (a *rowAllocator) capture(row Row) {
 	for i, v := range row {
 		switch v.Kind() {
 		case ByteArray, FixedLenByteArray:
-			row[i].ptr = unsafecast.AddressOfBytes(a.copyBytes(v.byteArray()))
+			row[i].ptr = unsafe.SliceData(a.copyBytes(v.byteArray()))
 		}
 	}
 }

--- a/allocator.go
+++ b/allocator.go
@@ -35,7 +35,7 @@ func (a *allocator) copyBytes(v []byte) []byte {
 func (a *allocator) copyString(v string) string {
 	b := a.makeBytes(len(v))
 	copy(b, v)
-	return unsafecast.BytesToString(b)
+	return unsafecast.String(b)
 }
 
 func (a *allocator) reset() {

--- a/array.go
+++ b/array.go
@@ -3,23 +3,22 @@ package parquet
 import (
 	"unsafe"
 
-	"github.com/parquet-go/parquet-go/internal/unsafecast"
 	"github.com/parquet-go/parquet-go/sparse"
 )
 
 func makeArrayValue(values []Value, offset uintptr) sparse.Array {
-	ptr := unsafecast.PointerOf(values)
+	ptr := sliceData(values)
 	return sparse.UnsafeArray(unsafe.Add(ptr, offset), len(values), unsafe.Sizeof(Value{}))
 }
 
 func makeArrayString(values []string) sparse.Array {
 	str := ""
-	ptr := unsafecast.PointerOf(values)
+	ptr := sliceData(values)
 	return sparse.UnsafeArray(ptr, len(values), unsafe.Sizeof(str))
 }
 
 func makeArrayBE128(values []*[16]byte) sparse.Array {
-	ptr := unsafecast.PointerOf(values)
+	ptr := sliceData(values)
 	return sparse.UnsafeArray(ptr, len(values), unsafe.Sizeof((*[16]byte)(nil)))
 }
 
@@ -29,7 +28,7 @@ func makeArray(base unsafe.Pointer, length int, offset uintptr) sparse.Array {
 
 func makeArrayOf[T any](s []T) sparse.Array {
 	var model T
-	return makeArray(unsafecast.PointerOf(s), len(s), unsafe.Sizeof(model))
+	return makeArray(sliceData(s), len(s), unsafe.Sizeof(model))
 }
 
 func makeSlice[T any](a sparse.Array) []T {
@@ -38,6 +37,10 @@ func makeSlice[T any](a sparse.Array) []T {
 
 func slice[T any](p unsafe.Pointer, n int) []T {
 	return unsafe.Slice((*T)(p), n)
+}
+
+func sliceData[T any](s []T) unsafe.Pointer {
+	return unsafe.Pointer(unsafe.SliceData(s))
 }
 
 type sliceHeader struct {

--- a/array.go
+++ b/array.go
@@ -8,18 +8,18 @@ import (
 )
 
 func makeArrayValue(values []Value, offset uintptr) sparse.Array {
-	ptr := *(*unsafe.Pointer)(unsafe.Pointer(&values))
+	ptr := unsafecast.PointerOf(values)
 	return sparse.UnsafeArray(unsafe.Add(ptr, offset), len(values), unsafe.Sizeof(Value{}))
 }
 
 func makeArrayString(values []string) sparse.Array {
 	str := ""
-	ptr := *(*unsafe.Pointer)(unsafe.Pointer(&values))
+	ptr := unsafecacst.PointerOf(values)
 	return sparse.UnsafeArray(ptr, len(values), unsafe.Sizeof(str))
 }
 
 func makeArrayBE128(values []*[16]byte) sparse.Array {
-	ptr := *(*unsafe.Pointer)(unsafe.Pointer(&values))
+	ptr := unsafecast.PointerOf(values)
 	return sparse.UnsafeArray(ptr, len(values), unsafe.Sizeof((*[16]byte)(nil)))
 }
 

--- a/array.go
+++ b/array.go
@@ -14,7 +14,7 @@ func makeArrayValue(values []Value, offset uintptr) sparse.Array {
 
 func makeArrayString(values []string) sparse.Array {
 	str := ""
-	ptr := unsafecacst.PointerOf(values)
+	ptr := unsafecast.PointerOf(values)
 	return sparse.UnsafeArray(ptr, len(values), unsafe.Sizeof(str))
 }
 

--- a/bloom.go
+++ b/bloom.go
@@ -162,27 +162,27 @@ func (splitBlockEncoding) EncodeBoolean(dst []byte, src []byte) ([]byte, error) 
 }
 
 func (splitBlockEncoding) EncodeInt32(dst []byte, src []int32) ([]byte, error) {
-	splitBlockEncodeUint32(bloom.MakeSplitBlockFilter(dst), unsafecast.Int32ToUint32(src))
+	splitBlockEncodeUint32(bloom.MakeSplitBlockFilter(dst), unsafecast.Slice[uint32](src))
 	return dst, nil
 }
 
 func (splitBlockEncoding) EncodeInt64(dst []byte, src []int64) ([]byte, error) {
-	splitBlockEncodeUint64(bloom.MakeSplitBlockFilter(dst), unsafecast.Int64ToUint64(src))
+	splitBlockEncodeUint64(bloom.MakeSplitBlockFilter(dst), unsafecast.Slice[uint64](src))
 	return dst, nil
 }
 
 func (e splitBlockEncoding) EncodeInt96(dst []byte, src []deprecated.Int96) ([]byte, error) {
-	splitBlockEncodeFixedLenByteArray(bloom.MakeSplitBlockFilter(dst), deprecated.Int96ToBytes(src), 12)
+	splitBlockEncodeFixedLenByteArray(bloom.MakeSplitBlockFilter(dst), unsafecast.Slice[byte](src), 12)
 	return dst, nil
 }
 
 func (splitBlockEncoding) EncodeFloat(dst []byte, src []float32) ([]byte, error) {
-	splitBlockEncodeUint32(bloom.MakeSplitBlockFilter(dst), unsafecast.Float32ToUint32(src))
+	splitBlockEncodeUint32(bloom.MakeSplitBlockFilter(dst), unsafecast.Slice[uint32](src))
 	return dst, nil
 }
 
 func (splitBlockEncoding) EncodeDouble(dst []byte, src []float64) ([]byte, error) {
-	splitBlockEncodeUint64(bloom.MakeSplitBlockFilter(dst), unsafecast.Float64ToUint64(src))
+	splitBlockEncodeUint64(bloom.MakeSplitBlockFilter(dst), unsafecast.Slice[uint64](src))
 	return dst, nil
 }
 
@@ -210,7 +210,7 @@ func (splitBlockEncoding) EncodeByteArray(dst []byte, src []byte, offsets []uint
 func (splitBlockEncoding) EncodeFixedLenByteArray(dst []byte, src []byte, size int) ([]byte, error) {
 	filter := bloom.MakeSplitBlockFilter(dst)
 	if size == 16 {
-		splitBlockEncodeUint128(filter, unsafecast.BytesToUint128(src))
+		splitBlockEncodeUint128(filter, unsafecast.Slice[[16]byte](src))
 	} else {
 		splitBlockEncodeFixedLenByteArray(filter, src, size)
 	}

--- a/bloom/filter.go
+++ b/bloom/filter.go
@@ -3,7 +3,8 @@ package bloom
 import (
 	"io"
 	"sync"
-	"unsafe"
+
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 // Filter is an interface representing read-only bloom filters where programs
@@ -21,9 +22,7 @@ type SplitBlockFilter []Block
 // MakeSplitBlockFilter constructs a SplitBlockFilter value from the data byte
 // slice.
 func MakeSplitBlockFilter(data []byte) SplitBlockFilter {
-	p := *(*unsafe.Pointer)(unsafe.Pointer(&data))
-	n := len(data) / BlockSize
-	return unsafe.Slice((*Block)(p), n)
+	return unsafecast.Slice[Block](data)
 }
 
 // NumSplitBlocksOf returns the number of blocks in a filter intended to hold
@@ -64,7 +63,7 @@ func (f SplitBlockFilter) Check(x uint64) bool { return filterCheck(f, x) }
 // The returned slice shares the memory of f. The method is intended to be used
 // to serialize the bloom filter to a storage medium.
 func (f SplitBlockFilter) Bytes() []byte {
-	return unsafe.Slice(*(**byte)(unsafe.Pointer(&f)), len(f)*BlockSize)
+	return unsafecast.Slice[byte](f)
 }
 
 // CheckSplitBlock is similar to bloom.SplitBlockFilter.Check but reads the

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -29,7 +29,7 @@ func TestSplitBlockFilter(t *testing.T) {
 			scenario: "BOOLEAN",
 			function: func(values []bool) bool {
 				filter := newFilter(len(values))
-				enc.EncodeBoolean(filter.Bytes(), unsafecast.BoolToBytes(values))
+				enc.EncodeBoolean(filter.Bytes(), unsafecast.Slice[byte](values))
 				for _, v := range values {
 					if !check(filter, ValueOf(v)) {
 						return false

--- a/column.go
+++ b/column.go
@@ -691,7 +691,7 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 	if pageType.Kind() == ByteArray && !isDictionaryEncoding(pageEncoding) {
 		obuf = buffers.get(4 * (numValues + 1))
 		defer obuf.unref()
-		pageOffsets = unsafecast.BytesToUint32(obuf.data)
+		pageOffsets = unsafecast.Slice[uint32](obuf.data)
 	}
 
 	values := pageType.NewValues(pageValues, pageOffsets)

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -1505,7 +1505,7 @@ func (col *byteArrayColumnBuffer) writeByteArrays(values []byte) (count, bytes i
 	baseBytes := len(col.values) + (plain.ByteArrayLengthSize * len(col.lengths))
 
 	err = plain.RangeByteArray(values, func(value []byte) error {
-		col.append(unsafecast.BytesToString(value))
+		col.append(unsafecast.String(value))
 		return nil
 	})
 
@@ -2356,8 +2356,8 @@ func writeRowsFuncOfMap(t reflect.Type, schema *Schema, path columnPath) writeRo
 					mapKey.SetIterKey(it)
 					mapValue.SetIterValue(it)
 
-					k := makeArray(unsafecast.PointerOfValue(mapKey), 1, keySize)
-					v := makeArray(unsafecast.PointerOfValue(mapValue), 1, valueSize)
+					k := makeArray(reflectValueData(mapKey), 1, keySize)
+					v := makeArray(reflectValueData(mapValue), 1, valueSize)
 
 					if err := writeKeyValues(columns, k, v, elemLevels); err != nil {
 						return err
@@ -2440,7 +2440,7 @@ func writeRowsFuncOfTime(_ reflect.Type, schema *Schema, path columnPath) writeR
 				val = t.UnixNano()
 			}
 
-			a := makeArray(unsafecast.PointerOfValue(reflect.ValueOf(val)), 1, elemSize)
+			a := makeArray(reflectValueData(reflect.ValueOf(val)), 1, elemSize)
 			if err := writeRows(columns, a, levels); err != nil {
 				return err
 			}

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -958,7 +958,7 @@ func (col *int32ColumnBuffer) Write(b []byte) (int, error) {
 	if (len(b) % 4) != 0 {
 		return 0, fmt.Errorf("cannot write INT32 values from input of size %d", len(b))
 	}
-	col.values = append(col.values, unsafecast.BytesToInt32(b)...)
+	col.values = append(col.values, unsafecast.Slice[int32](b)...)
 	return len(b), nil
 }
 
@@ -1057,7 +1057,7 @@ func (col *int64ColumnBuffer) Write(b []byte) (int, error) {
 	if (len(b) % 8) != 0 {
 		return 0, fmt.Errorf("cannot write INT64 values from input of size %d", len(b))
 	}
-	col.values = append(col.values, unsafecast.BytesToInt64(b)...)
+	col.values = append(col.values, unsafecast.Slice[int64](b)...)
 	return len(b), nil
 }
 
@@ -1155,7 +1155,7 @@ func (col *int96ColumnBuffer) Write(b []byte) (int, error) {
 	if (len(b) % 12) != 0 {
 		return 0, fmt.Errorf("cannot write INT96 values from input of size %d", len(b))
 	}
-	col.values = append(col.values, deprecated.BytesToInt96(b)...)
+	col.values = append(col.values, unsafecast.Slice[deprecated.Int96](b)...)
 	return len(b), nil
 }
 
@@ -1252,7 +1252,7 @@ func (col *floatColumnBuffer) Write(b []byte) (int, error) {
 	if (len(b) % 4) != 0 {
 		return 0, fmt.Errorf("cannot write FLOAT values from input of size %d", len(b))
 	}
-	col.values = append(col.values, unsafecast.BytesToFloat32(b)...)
+	col.values = append(col.values, unsafecast.Slice[float32](b)...)
 	return len(b), nil
 }
 
@@ -1350,7 +1350,7 @@ func (col *doubleColumnBuffer) Write(b []byte) (int, error) {
 	if (len(b) % 8) != 0 {
 		return 0, fmt.Errorf("cannot write DOUBLE values from input of size %d", len(b))
 	}
-	col.values = append(col.values, unsafecast.BytesToFloat64(b)...)
+	col.values = append(col.values, unsafecast.Slice[float64](b)...)
 	return len(b), nil
 }
 
@@ -1742,7 +1742,7 @@ func (col *uint32ColumnBuffer) Write(b []byte) (int, error) {
 	if (len(b) % 4) != 0 {
 		return 0, fmt.Errorf("cannot write INT32 values from input of size %d", len(b))
 	}
-	col.values = append(col.values, unsafecast.BytesToUint32(b)...)
+	col.values = append(col.values, unsafecast.Slice[uint32](b)...)
 	return len(b), nil
 }
 
@@ -1840,7 +1840,7 @@ func (col *uint64ColumnBuffer) Write(b []byte) (int, error) {
 	if (len(b) % 8) != 0 {
 		return 0, fmt.Errorf("cannot write INT64 values from input of size %d", len(b))
 	}
-	col.values = append(col.values, unsafecast.BytesToUint64(b)...)
+	col.values = append(col.values, unsafecast.Slice[uint64](b)...)
 	return len(b), nil
 }
 

--- a/column_buffer_amd64.go
+++ b/column_buffer_amd64.go
@@ -10,7 +10,7 @@ import (
 )
 
 func broadcastValueInt32(dst []int32, src int8) {
-	bytealg.Broadcast(unsafecast.Int32ToBytes(dst), byte(src))
+	bytealg.Broadcast(unsafecast.Slice[byte](dst), byte(src))
 }
 
 //go:noescape

--- a/column_index.go
+++ b/column_index.go
@@ -325,8 +325,8 @@ func (i *booleanColumnIndexer) IndexPage(numValues, numNulls int64, min, max Val
 
 func (i *booleanColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(unsafecast.BoolToBytes(i.minValues), 1),
-		splitFixedLenByteArrays(unsafecast.BoolToBytes(i.maxValues), 1),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 1),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 1),
 		orderOfBool(i.minValues),
 		orderOfBool(i.maxValues),
 	)
@@ -356,8 +356,8 @@ func (i *int32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 
 func (i *int32ColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(unsafecast.Int32ToBytes(i.minValues), 4),
-		splitFixedLenByteArrays(unsafecast.Int32ToBytes(i.maxValues), 4),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 4),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 4),
 		orderOfInt32(i.minValues),
 		orderOfInt32(i.maxValues),
 	)
@@ -387,8 +387,8 @@ func (i *int64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 
 func (i *int64ColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(unsafecast.Int64ToBytes(i.minValues), 8),
-		splitFixedLenByteArrays(unsafecast.Int64ToBytes(i.maxValues), 8),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 8),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 8),
 		orderOfInt64(i.minValues),
 		orderOfInt64(i.maxValues),
 	)
@@ -418,8 +418,8 @@ func (i *int96ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 
 func (i *int96ColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(deprecated.Int96ToBytes(i.minValues), 12),
-		splitFixedLenByteArrays(deprecated.Int96ToBytes(i.maxValues), 12),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 12),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 12),
 		deprecated.OrderOfInt96(i.minValues),
 		deprecated.OrderOfInt96(i.maxValues),
 	)
@@ -449,8 +449,8 @@ func (i *floatColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 
 func (i *floatColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(unsafecast.Float32ToBytes(i.minValues), 4),
-		splitFixedLenByteArrays(unsafecast.Float32ToBytes(i.maxValues), 4),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 4),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 4),
 		orderOfFloat32(i.minValues),
 		orderOfFloat32(i.maxValues),
 	)
@@ -480,8 +480,8 @@ func (i *doubleColumnIndexer) IndexPage(numValues, numNulls int64, min, max Valu
 
 func (i *doubleColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(unsafecast.Float64ToBytes(i.minValues), 8),
-		splitFixedLenByteArrays(unsafecast.Float64ToBytes(i.maxValues), 8),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 8),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 8),
 		orderOfFloat64(i.minValues),
 		orderOfFloat64(i.maxValues),
 	)
@@ -599,8 +599,8 @@ func (i *uint32ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Valu
 
 func (i *uint32ColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(unsafecast.Uint32ToBytes(i.minValues), 4),
-		splitFixedLenByteArrays(unsafecast.Uint32ToBytes(i.maxValues), 4),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 4),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 4),
 		orderOfUint32(i.minValues),
 		orderOfUint32(i.maxValues),
 	)
@@ -630,8 +630,8 @@ func (i *uint64ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Valu
 
 func (i *uint64ColumnIndexer) ColumnIndex() format.ColumnIndex {
 	return i.columnIndex(
-		splitFixedLenByteArrays(unsafecast.Uint64ToBytes(i.minValues), 8),
-		splitFixedLenByteArrays(unsafecast.Uint64ToBytes(i.maxValues), 8),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 8),
+		splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 8),
 		orderOfUint64(i.minValues),
 		orderOfUint64(i.maxValues),
 	)
@@ -664,8 +664,8 @@ func (i *be128ColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value
 }
 
 func (i *be128ColumnIndexer) ColumnIndex() format.ColumnIndex {
-	minValues := splitFixedLenByteArrays(unsafecast.Uint128ToBytes(i.minValues), 16)
-	maxValues := splitFixedLenByteArrays(unsafecast.Uint128ToBytes(i.maxValues), 16)
+	minValues := splitFixedLenByteArrays(unsafecast.Slice[byte](i.minValues), 16)
+	maxValues := splitFixedLenByteArrays(unsafecast.Slice[byte](i.maxValues), 16)
 	return i.columnIndex(
 		minValues,
 		maxValues,

--- a/convert.go
+++ b/convert.go
@@ -14,6 +14,7 @@ import (
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 // ConvertError is an error type returned by calls to Convert when the conversion
@@ -912,7 +913,7 @@ func convertStringToInt96(v Value) (Value, error) {
 	b := i.Bytes()
 	c := make([]byte, 12)
 	copy(c, b)
-	i96 := deprecated.BytesToInt96(c)
+	i96 := unsafecast.Slice[deprecated.Int96](c)
 	return v.convertToInt96(i96[0]), nil
 }
 

--- a/deprecated/int96.go
+++ b/deprecated/int96.go
@@ -3,7 +3,8 @@ package deprecated
 import (
 	"math/big"
 	"math/bits"
-	"unsafe"
+
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 // Int96 is an implementation of the deprecated INT96 parquet type.
@@ -101,7 +102,7 @@ func (i Int96) Len() int {
 // Int96ToBytes converts the slice of Int96 values to a slice of bytes sharing
 // the same backing array.
 func Int96ToBytes(data []Int96) []byte {
-	return unsafe.Slice(*(**byte)(unsafe.Pointer(&data)), 12*len(data))
+	return unsafecast.Slice[byte](data)
 }
 
 // BytesToInt96 converts the byte slice passed as argument to a slice of Int96
@@ -110,7 +111,7 @@ func Int96ToBytes(data []Int96) []byte {
 // When the number of bytes in the input is not a multiple of 12, the function
 // truncates it in the returned slice.
 func BytesToInt96(data []byte) []Int96 {
-	return unsafe.Slice(*(**Int96)(unsafe.Pointer(&data)), len(data)/12)
+	return unsafecast.Slice[Int96](data)
 }
 
 func MaxLenInt96(data []Int96) int {

--- a/deprecated/int96.go
+++ b/deprecated/int96.go
@@ -3,8 +3,6 @@ package deprecated
 import (
 	"math/big"
 	"math/bits"
-
-	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 // Int96 is an implementation of the deprecated INT96 parquet type.
@@ -97,21 +95,6 @@ func (i Int96) Len() int {
 	default:
 		return bits.Len32(i[0])
 	}
-}
-
-// Int96ToBytes converts the slice of Int96 values to a slice of bytes sharing
-// the same backing array.
-func Int96ToBytes(data []Int96) []byte {
-	return unsafecast.Slice[byte](data)
-}
-
-// BytesToInt96 converts the byte slice passed as argument to a slice of Int96
-// sharing the same backing array.
-//
-// When the number of bytes in the input is not a multiple of 12, the function
-// truncates it in the returned slice.
-func BytesToInt96(data []byte) []Int96 {
-	return unsafecast.Slice[Int96](data)
 }
 
 func MaxLenInt96(data []Int96) int {

--- a/dictionary.go
+++ b/dictionary.go
@@ -751,7 +751,7 @@ func (d *byteArrayDictionary) Lookup(indexes []int32, values []Value) {
 func (d *byteArrayDictionary) Bounds(indexes []int32) (min, max Value) {
 	if len(indexes) > 0 {
 		base := d.index(int(indexes[0]))
-		minValue := unsafecast.BytesToString(base)
+		minValue := unsafecast.String(base)
 		maxValue := minValue
 		values := [64]string{}
 
@@ -870,7 +870,7 @@ func (d *fixedLenByteArrayDictionary) Lookup(indexes []int32, values []Value) {
 func (d *fixedLenByteArrayDictionary) Bounds(indexes []int32) (min, max Value) {
 	if len(indexes) > 0 {
 		base := d.index(indexes[0])
-		minValue := unsafecast.BytesToString(base)
+		minValue := unsafecast.String(base)
 		maxValue := minValue
 		values := [64]string{}
 

--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -47,25 +47,25 @@ func dictionaryLookupFixedLenByteArrayPointer(dict []byte, len int, indexes []in
 
 func (d *int32Dictionary) lookup(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
-	dict := unsafecast.Int32ToUint32(d.values)
+	dict := unsafecast.Slice[uint32](d.values)
 	dictionaryLookup32(dict, indexes, rows).check()
 }
 
 func (d *int64Dictionary) lookup(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
-	dict := unsafecast.Int64ToUint64(d.values)
+	dict := unsafecast.Slice[uint64](d.values)
 	dictionaryLookup64(dict, indexes, rows).check()
 }
 
 func (d *floatDictionary) lookup(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
-	dict := unsafecast.Float32ToUint32(d.values)
+	dict := unsafecast.Slice[uint32](d.values)
 	dictionaryLookup32(dict, indexes, rows).check()
 }
 
 func (d *doubleDictionary) lookup(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
-	dict := unsafecast.Float64ToUint64(d.values)
+	dict := unsafecast.Slice[uint64](d.values)
 	dictionaryLookup64(dict, indexes, rows).check()
 }
 
@@ -107,7 +107,7 @@ func (d *uint64Dictionary) lookup(indexes []int32, rows sparse.Array) {
 
 func (d *be128Dictionary) lookupString(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
-	//dict := unsafecast.Uint128ToBytes(d.values)
+	//dict := unsafecast.Slice[byte](d.values)
 	//dictionaryLookupFixedLenByteArrayString(dict, 16, indexes, rows).check()
 	s := "0123456789ABCDEF"
 	for i, j := range indexes {
@@ -118,7 +118,7 @@ func (d *be128Dictionary) lookupString(indexes []int32, rows sparse.Array) {
 
 func (d *be128Dictionary) lookupPointer(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
-	//dict := unsafecast.Uint128ToBytes(d.values)
+	//dict := unsafecast.Slice[byte](d.values)
 	//dictionaryLookupFixedLenByteArrayPointer(dict, 16, indexes, rows).check()
 	for i, j := range indexes {
 		*(**[16]byte)(rows.Index(i)) = d.index(j)

--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -83,8 +83,7 @@ func (d *byteArrayDictionary) lookupString(indexes []int32, rows sparse.Array) {
 	//
 	//dictionaryLookupByteArrayString(d.offsets, d.values, indexes, rows).check()
 	for i, j := range indexes {
-		v := d.index(int(j))
-		*(*string)(rows.Index(i)) = *(*string)(unsafe.Pointer(&v))
+		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(int(j)))
 	}
 }
 
@@ -92,8 +91,7 @@ func (d *fixedLenByteArrayDictionary) lookupString(indexes []int32, rows sparse.
 	checkLookupIndexBounds(indexes, rows)
 	//dictionaryLookupFixedLenByteArrayString(d.data, d.size, indexes, rows).check()
 	for i, j := range indexes {
-		v := d.index(j)
-		*(*string)(rows.Index(i)) = *(*string)(unsafe.Pointer(&v))
+		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(j))
 	}
 }
 

--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -83,7 +83,7 @@ func (d *byteArrayDictionary) lookupString(indexes []int32, rows sparse.Array) {
 	//
 	//dictionaryLookupByteArrayString(d.offsets, d.values, indexes, rows).check()
 	for i, j := range indexes {
-		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(int(j)))
+		*(*string)(rows.Index(i)) = unsafecast.String(d.index(int(j)))
 	}
 }
 
@@ -91,7 +91,7 @@ func (d *fixedLenByteArrayDictionary) lookupString(indexes []int32, rows sparse.
 	checkLookupIndexBounds(indexes, rows)
 	//dictionaryLookupFixedLenByteArrayString(d.data, d.size, indexes, rows).check()
 	for i, j := range indexes {
-		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(j))
+		*(*string)(rows.Index(i)) = unsafecast.String(d.index(j))
 	}
 }
 

--- a/dictionary_purego.go
+++ b/dictionary_purego.go
@@ -5,6 +5,7 @@ package parquet
 import (
 	"unsafe"
 
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 	"github.com/parquet-go/parquet-go/sparse"
 )
 
@@ -39,16 +40,14 @@ func (d *doubleDictionary) lookup(indexes []int32, rows sparse.Array) {
 func (d *byteArrayDictionary) lookupString(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
 	for i, j := range indexes {
-		v := d.index(int(j))
-		*(*string)(rows.Index(i)) = *(*string)(unsafe.Pointer(&v))
+		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(int(j)))
 	}
 }
 
 func (d *fixedLenByteArrayDictionary) lookupString(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
 	for i, j := range indexes {
-		v := d.index(j)
-		*(*string)(rows.Index(i)) = *(*string)(unsafe.Pointer(&v))
+		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(j))
 	}
 }
 

--- a/dictionary_purego.go
+++ b/dictionary_purego.go
@@ -40,14 +40,14 @@ func (d *doubleDictionary) lookup(indexes []int32, rows sparse.Array) {
 func (d *byteArrayDictionary) lookupString(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
 	for i, j := range indexes {
-		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(int(j)))
+		*(*string)(rows.Index(i)) = unsafecast.String(d.index(int(j)))
 	}
 }
 
 func (d *fixedLenByteArrayDictionary) lookupString(indexes []int32, rows sparse.Array) {
 	checkLookupIndexBounds(indexes, rows)
 	for i, j := range indexes {
-		*(*string)(rows.Index(i)) = unsafecast.BytesToString(d.index(j))
+		*(*string)(rows.Index(i)) = unsafecast.String(d.index(j))
 	}
 }
 

--- a/encoding/bytestreamsplit/bytestreamsplit.go
+++ b/encoding/bytestreamsplit/bytestreamsplit.go
@@ -22,13 +22,13 @@ func (e *Encoding) Encoding() format.Encoding {
 
 func (e *Encoding) EncodeFloat(dst []byte, src []float32) ([]byte, error) {
 	dst = resize(dst, 4*len(src))
-	encodeFloat(dst, unsafecast.Float32ToBytes(src))
+	encodeFloat(dst, unsafecast.Slice[byte](src))
 	return dst, nil
 }
 
 func (e *Encoding) EncodeDouble(dst []byte, src []float64) ([]byte, error) {
 	dst = resize(dst, 8*len(src))
-	encodeDouble(dst, unsafecast.Float64ToBytes(src))
+	encodeDouble(dst, unsafecast.Slice[byte](src))
 	return dst, nil
 }
 
@@ -36,18 +36,18 @@ func (e *Encoding) DecodeFloat(dst []float32, src []byte) ([]float32, error) {
 	if (len(src) % 4) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "FLOAT", len(src))
 	}
-	buf := resize(unsafecast.Float32ToBytes(dst), len(src))
+	buf := resize(unsafecast.Slice[byte](dst), len(src))
 	decodeFloat(buf, src)
-	return unsafecast.BytesToFloat32(buf), nil
+	return unsafecast.Slice[float32](buf), nil
 }
 
 func (e *Encoding) DecodeDouble(dst []float64, src []byte) ([]float64, error) {
 	if (len(src) % 8) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "DOUBLE", len(src))
 	}
-	buf := resize(unsafecast.Float64ToBytes(dst), len(src))
+	buf := resize(unsafecast.Slice[byte](dst), len(src))
 	decodeDouble(buf, src)
-	return unsafecast.BytesToFloat64(buf), nil
+	return unsafecast.Slice[float64](buf), nil
 }
 
 func resize(buf []byte, size int) []byte {

--- a/encoding/bytestreamsplit/bytestreamsplit_purego.go
+++ b/encoding/bytestreamsplit/bytestreamsplit_purego.go
@@ -11,7 +11,7 @@ func encodeFloat(dst, src []byte) {
 	b2 := dst[2*n : 3*n]
 	b3 := dst[3*n : 4*n]
 
-	for i, v := range unsafecast.BytesToUint32(src) {
+	for i, v := range unsafecast.Slice[uint32](src) {
 		b0[i] = byte(v >> 0)
 		b1[i] = byte(v >> 8)
 		b2[i] = byte(v >> 16)
@@ -30,7 +30,7 @@ func encodeDouble(dst, src []byte) {
 	b6 := dst[6*n : 7*n]
 	b7 := dst[7*n : 8*n]
 
-	for i, v := range unsafecast.BytesToUint64(src) {
+	for i, v := range unsafecast.Slice[uint64](src) {
 		b0[i] = byte(v >> 0)
 		b1[i] = byte(v >> 8)
 		b2[i] = byte(v >> 16)
@@ -49,7 +49,7 @@ func decodeFloat(dst, src []byte) {
 	b2 := src[2*n : 3*n]
 	b3 := src[3*n : 4*n]
 
-	dst32 := unsafecast.BytesToUint32(dst)
+	dst32 := unsafecast.Slice[uint32](dst)
 	for i := range dst32 {
 		dst32[i] = uint32(b0[i]) |
 			uint32(b1[i])<<8 |
@@ -69,7 +69,7 @@ func decodeDouble(dst, src []byte) {
 	b6 := src[6*n : 7*n]
 	b7 := src[7*n : 8*n]
 
-	dst64 := unsafecast.BytesToUint64(dst)
+	dst64 := unsafecast.Slice[uint64](dst)
 	for i := range dst64 {
 		dst64[i] = uint64(b0[i]) |
 			uint64(b1[i])<<8 |

--- a/encoding/delta/binary_packed.go
+++ b/encoding/delta/binary_packed.go
@@ -34,15 +34,15 @@ func (e *BinaryPackedEncoding) EncodeInt64(dst []byte, src []int64) ([]byte, err
 }
 
 func (e *BinaryPackedEncoding) DecodeInt32(dst []int32, src []byte) ([]int32, error) {
-	buf := unsafecast.Int32ToBytes(dst)
+	buf := unsafecast.Slice[byte](dst)
 	buf, _, err := decodeInt32(buf[:0], src)
-	return unsafecast.BytesToInt32(buf), e.wrap(err)
+	return unsafecast.Slice[int32](buf), e.wrap(err)
 }
 
 func (e *BinaryPackedEncoding) DecodeInt64(dst []int64, src []byte) ([]int64, error) {
-	buf := unsafecast.Int64ToBytes(dst)
+	buf := unsafecast.Slice[byte](dst)
 	buf, _, err := decodeInt64(buf[:0], src)
-	return unsafecast.BytesToInt64(buf), e.wrap(err)
+	return unsafecast.Slice[int64](buf), e.wrap(err)
 }
 
 func (e *BinaryPackedEncoding) wrap(err error) error {
@@ -290,7 +290,7 @@ func decodeInt32(dst, src []byte) ([]byte, []byte, error) {
 
 	writeOffset := len(dst)
 	dst = resize(dst, len(dst)+4*totalValues)
-	out := unsafecast.BytesToInt32(dst)
+	out := unsafecast.Slice[int32](dst)
 	out[writeOffset] = int32(firstValue)
 	writeOffset++
 	totalValues--
@@ -354,7 +354,7 @@ func decodeInt64(dst, src []byte) ([]byte, []byte, error) {
 
 	writeOffset := len(dst)
 	dst = resize(dst, len(dst)+8*totalValues)
-	out := unsafecast.BytesToInt64(dst)
+	out := unsafecast.Slice[int64](dst)
 	out[writeOffset] = firstValue
 	writeOffset++
 	totalValues--

--- a/encoding/delta/binary_packed_amd64.go
+++ b/encoding/delta/binary_packed_amd64.go
@@ -230,7 +230,7 @@ func decodeMiniBlockInt32(dst []int32, src []uint32, bitWidth uint) {
 	case hasAVX2 && bitWidth <= 31:
 		decodeMiniBlockInt32x27to31bitsAVX2(dst, src, bitWidth)
 	case bitWidth == 32:
-		copy(dst, unsafecast.Uint32ToInt32(src))
+		copy(dst, unsafecast.Slice[int32](src))
 	default:
 		decodeMiniBlockInt32Default(dst, src, bitWidth)
 	}
@@ -249,7 +249,7 @@ func decodeMiniBlockInt64Default(dst []int64, src []uint32, bitWidth uint)
 func decodeMiniBlockInt64(dst []int64, src []uint32, bitWidth uint) {
 	switch {
 	case bitWidth == 64:
-		copy(dst, unsafecast.Uint32ToInt64(src))
+		copy(dst, unsafecast.Slice[int64](src))
 	default:
 		decodeMiniBlockInt64Default(dst, src, bitWidth)
 	}

--- a/encoding/delta/delta.go
+++ b/encoding/delta/delta.go
@@ -20,8 +20,8 @@ func (buf *int32Buffer) resize(size int) {
 }
 
 func (buf *int32Buffer) decode(src []byte) ([]byte, error) {
-	values, remain, err := decodeInt32(unsafecast.Int32ToBytes(buf.values[:0]), src)
-	buf.values = unsafecast.BytesToInt32(values)
+	values, remain, err := decodeInt32(unsafecast.Slice[byte](buf.values[:0]), src)
+	buf.values = unsafecast.Slice[int32](values)
 	return remain, err
 }
 

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -307,7 +307,7 @@ func testLevelsEncoding(t *testing.T, e encoding.Encoding) {
 	values := []byte{}
 
 	for _, input := range levelsTests {
-		setBitWidth(e, maxLenInt8(unsafecast.BytesToInt8(input)))
+		setBitWidth(e, maxLenInt8(unsafecast.Slice[int8](input)))
 
 		t.Run("", func(t *testing.T) {
 			var err error
@@ -518,27 +518,27 @@ func assertEqualBytes(t *testing.T, want, got []byte) {
 
 func assertEqualInt32(t *testing.T, want, got []int32) {
 	t.Helper()
-	assertEqualBytes(t, unsafecast.Int32ToBytes(want), unsafecast.Int32ToBytes(got))
+	assertEqualBytes(t, unsafecast.Slice[byte](want), unsafecast.Slice[byte](got))
 }
 
 func assertEqualInt64(t *testing.T, want, got []int64) {
 	t.Helper()
-	assertEqualBytes(t, unsafecast.Int64ToBytes(want), unsafecast.Int64ToBytes(got))
+	assertEqualBytes(t, unsafecast.Slice[byte](want), unsafecast.Slice[byte](got))
 }
 
 func assertEqualInt96(t *testing.T, want, got []deprecated.Int96) {
 	t.Helper()
-	assertEqualBytes(t, deprecated.Int96ToBytes(want), deprecated.Int96ToBytes(got))
+	assertEqualBytes(t, unsafecast.Slice[byte](want), unsafecast.Slice[byte](got))
 }
 
 func assertEqualFloat32(t *testing.T, want, got []float32) {
 	t.Helper()
-	assertEqualBytes(t, unsafecast.Float32ToBytes(want), unsafecast.Float32ToBytes(got))
+	assertEqualBytes(t, unsafecast.Slice[byte](want), unsafecast.Slice[byte](got))
 }
 
 func assertEqualFloat64(t *testing.T, want, got []float64) {
 	t.Helper()
-	assertEqualBytes(t, unsafecast.Float64ToBytes(want), unsafecast.Float64ToBytes(got))
+	assertEqualBytes(t, unsafecast.Slice[byte](want), unsafecast.Slice[byte](got))
 }
 
 const (
@@ -614,7 +614,7 @@ func benchmarkEncodeLevels(b *testing.B, e encoding.Encoding) {
 	testCanEncodeLevels(b, e)
 	buffer := make([]byte, 0)
 	values := generateLevelValues(benchmarkNumValues, newRand())
-	setBitWidth(e, maxLenInt8(unsafecast.BytesToInt8(values)))
+	setBitWidth(e, maxLenInt8(unsafecast.Slice[int8](values)))
 
 	reportThroughput(b, benchmarkNumValues, len(values), func() {
 		benchmarkZeroAllocsPerRun(b, func() {
@@ -763,7 +763,7 @@ func benchmarkDecodeBoolean(b *testing.B, e encoding.Encoding) {
 func benchmarkDecodeLevels(b *testing.B, e encoding.Encoding) {
 	testCanEncodeLevels(b, e)
 	values := generateLevelValues(benchmarkNumValues, newRand())
-	setBitWidth(e, maxLenInt8(unsafecast.BytesToInt8(values)))
+	setBitWidth(e, maxLenInt8(unsafecast.Slice[int8](values)))
 	buffer, _ := e.EncodeLevels(nil, values)
 
 	reportThroughput(b, benchmarkNumValues, len(values), func() {

--- a/encoding/fuzz/fuzz.go
+++ b/encoding/fuzz/fuzz.go
@@ -90,7 +90,7 @@ func EncodeByteArray(f *testing.F, e encoding.Encoding) {
 				baseOffset := offsets[0]
 
 				for _, endOffset := range offsets[1:] {
-					dst = append(dst, unsafecast.BytesToString(values[baseOffset:endOffset]))
+					dst = append(dst, unsafecast.String(values[baseOffset:endOffset]))
 					baseOffset = endOffset
 				}
 			}
@@ -107,7 +107,7 @@ func EncodeByteArray(f *testing.F, e encoding.Encoding) {
 				if n > r {
 					n = r
 				}
-				dst = append(dst, unsafecast.BytesToString(src[i:i+n]))
+				dst = append(dst, unsafecast.String(src[i:i+n]))
 				i += n
 			}
 

--- a/encoding/plain/plain.go
+++ b/encoding/plain/plain.go
@@ -37,23 +37,23 @@ func (e *Encoding) EncodeBoolean(dst []byte, src []byte) ([]byte, error) {
 }
 
 func (e *Encoding) EncodeInt32(dst []byte, src []int32) ([]byte, error) {
-	return append(dst[:0], unsafecast.Int32ToBytes(src)...), nil
+	return append(dst[:0], unsafecast.Slice[byte](src)...), nil
 }
 
 func (e *Encoding) EncodeInt64(dst []byte, src []int64) ([]byte, error) {
-	return append(dst[:0], unsafecast.Int64ToBytes(src)...), nil
+	return append(dst[:0], unsafecast.Slice[byte](src)...), nil
 }
 
 func (e *Encoding) EncodeInt96(dst []byte, src []deprecated.Int96) ([]byte, error) {
-	return append(dst[:0], deprecated.Int96ToBytes(src)...), nil
+	return append(dst[:0], unsafecast.Slice[byte](src)...), nil
 }
 
 func (e *Encoding) EncodeFloat(dst []byte, src []float32) ([]byte, error) {
-	return append(dst[:0], unsafecast.Float32ToBytes(src)...), nil
+	return append(dst[:0], unsafecast.Slice[byte](src)...), nil
 }
 
 func (e *Encoding) EncodeDouble(dst []byte, src []float64) ([]byte, error) {
-	return append(dst[:0], unsafecast.Float64ToBytes(src)...), nil
+	return append(dst[:0], unsafecast.Slice[byte](src)...), nil
 }
 
 func (e *Encoding) EncodeByteArray(dst []byte, src []byte, offsets []uint32) ([]byte, error) {
@@ -86,35 +86,35 @@ func (e *Encoding) DecodeInt32(dst []int32, src []byte) ([]int32, error) {
 	if (len(src) % 4) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "INT32", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToInt32(src)...), nil
+	return append(dst[:0], unsafecast.Slice[int32](src)...), nil
 }
 
 func (e *Encoding) DecodeInt64(dst []int64, src []byte) ([]int64, error) {
 	if (len(src) % 8) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "INT64", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToInt64(src)...), nil
+	return append(dst[:0], unsafecast.Slice[int64](src)...), nil
 }
 
 func (e *Encoding) DecodeInt96(dst []deprecated.Int96, src []byte) ([]deprecated.Int96, error) {
 	if (len(src) % 12) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "INT96", len(src))
 	}
-	return append(dst[:0], deprecated.BytesToInt96(src)...), nil
+	return append(dst[:0], unsafecast.Slice[deprecated.Int96](src)...), nil
 }
 
 func (e *Encoding) DecodeFloat(dst []float32, src []byte) ([]float32, error) {
 	if (len(src) % 4) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "FLOAT", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToFloat32(src)...), nil
+	return append(dst[:0], unsafecast.Slice[float32](src)...), nil
 }
 
 func (e *Encoding) DecodeDouble(dst []float64, src []byte) ([]float64, error) {
 	if (len(src) % 8) != 0 {
 		return dst, encoding.ErrDecodeInvalidInputSize(e, "DOUBLE", len(src))
 	}
-	return append(dst[:0], unsafecast.BytesToFloat64(src)...), nil
+	return append(dst[:0], unsafecast.Slice[float64](src)...), nil
 }
 
 func (e *Encoding) DecodeByteArray(dst []byte, src []byte, offsets []uint32) ([]byte, []uint32, error) {

--- a/encoding/rle/dictionary.go
+++ b/encoding/rle/dictionary.go
@@ -31,9 +31,9 @@ func (e *DictionaryEncoding) DecodeInt32(dst []int32, src []byte) ([]int32, erro
 	if len(src) == 0 {
 		return dst[:0], nil
 	}
-	buf := unsafecast.Int32ToBytes(dst)
+	buf := unsafecast.Slice[byte](dst)
 	buf, err := decodeInt32(buf[:0], src[1:], uint(src[0]))
-	return unsafecast.BytesToInt32(buf), e.wrap(err)
+	return unsafecast.Slice[int32](buf), e.wrap(err)
 }
 
 func (e *DictionaryEncoding) wrap(err error) error {

--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"unsafe"
 
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
@@ -151,7 +150,7 @@ func encodeBytes(dst, src []byte, bitWidth uint) ([]byte, error) {
 	}
 
 	if len(src) >= 8 {
-		words := unsafe.Slice((*uint64)(unsafe.Pointer(&src[0])), len(src)/8)
+		words := unsafecast.Slice[uint64](src)
 
 		for i := 0; i < len(words); {
 			j := i
@@ -203,7 +202,7 @@ func encodeInt32(dst []byte, src []int32, bitWidth uint) ([]byte, error) {
 	}
 
 	if len(src) >= 8 {
-		words := unsafe.Slice((*[8]int32)(unsafe.Pointer(&src[0])), len(src)/8)
+		words := unsafecast.Slice[[8]int32](src)
 
 		for i := 0; i < len(words); {
 			j := i
@@ -500,7 +499,7 @@ func grow(buf []byte, size int) []byte {
 }
 
 func encodeInt32BitpackDefault(dst []byte, src [][8]int32, bitWidth uint) int {
-	bits := unsafe.Slice((*int32)(unsafe.Pointer(&src[0])), len(src)*8)
+	bits := unsafecast.Slice[int32](src)
 	bitpack.PackInt32(dst, bits, bitWidth)
 	return bitpack.ByteCount(uint(len(src)*8) * bitWidth)
 }

--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -82,9 +82,9 @@ func (e *Encoding) DecodeBoolean(dst []byte, src []byte) ([]byte, error) {
 }
 
 func (e *Encoding) DecodeInt32(dst []int32, src []byte) ([]int32, error) {
-	buf := unsafecast.Int32ToBytes(dst)
+	buf := unsafecast.Slice[byte](dst)
 	buf, err := decodeInt32(buf[:0], src, uint(e.BitWidth))
-	return unsafecast.BytesToInt32(buf), e.wrap(err)
+	return unsafecast.Slice[int32](buf), e.wrap(err)
 }
 
 func (e *Encoding) wrap(err error) error {
@@ -195,7 +195,7 @@ func encodeInt32(dst []byte, src []int32, bitWidth uint) ([]byte, error) {
 		return dst, errEncodeInvalidBitWidth("INT32", bitWidth)
 	}
 	if bitWidth == 0 {
-		if !isZero(unsafecast.Int32ToBytes(src)) {
+		if !isZero(unsafecast.Slice[byte](src)) {
 			return dst, errEncodeInvalidBitWidth("INT32", bitWidth)
 		}
 		return appendUvarint(dst, uint64(len(src))<<1), nil
@@ -372,7 +372,7 @@ func decodeInt32(dst, src []byte, bitWidth uint) ([]byte, error) {
 				in = buf
 			}
 
-			out := unsafecast.BytesToInt32(dst[offset:])
+			out := unsafecast.Slice[int32](dst[offset:])
 			bitpack.UnpackInt32(out, in, bitWidth)
 			i += length
 		} else {

--- a/encoding/thrift/binary.go
+++ b/encoding/thrift/binary.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 // BinaryProtocol is a Protocol implementation for the binary thrift protocol.
@@ -96,7 +98,7 @@ func (r *binaryReader) ReadBytes() ([]byte, error) {
 
 func (r *binaryReader) ReadString() (string, error) {
 	b, err := r.ReadBytes()
-	return unsafeBytesToString(b), err
+	return unsafecast.String(b), err
 }
 
 func (r *binaryReader) ReadLength() (int, error) {
@@ -126,7 +128,7 @@ func (r *binaryReader) ReadMessage() (Message, error) {
 		if err != nil {
 			return m, dontExpectEOF(err)
 		}
-		m.Name = unsafeBytesToString(s)
+		m.Name = unsafecast.String(s)
 
 		t, err := r.ReadInt8()
 		if err != nil {

--- a/encoding/thrift/compact.go
+++ b/encoding/thrift/compact.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 // CompactProtocol is a Protocol implementation for the compact thrift protocol.
@@ -77,7 +79,7 @@ func (r *compactReader) ReadBytes() ([]byte, error) {
 
 func (r *compactReader) ReadString() (string, error) {
 	b, err := r.ReadBytes()
-	return unsafeBytesToString(b), err
+	return unsafecast.String(b), err
 }
 
 func (r *compactReader) ReadLength() (int, error) {

--- a/encoding/thrift/unsafe.go
+++ b/encoding/thrift/unsafe.go
@@ -18,7 +18,3 @@ func makeTypeID(t reflect.Type) typeID {
 		ptr: (*[2]unsafe.Pointer)(unsafe.Pointer(&t))[1],
 	}
 }
-
-func unsafeBytesToString(b []byte) string {
-	return unsafe.String(unsafe.SliceData(b), len(b))
-}

--- a/encoding/thrift/unsafe.go
+++ b/encoding/thrift/unsafe.go
@@ -20,5 +20,5 @@ func makeTypeID(t reflect.Type) typeID {
 }
 
 func unsafeBytesToString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }

--- a/encoding/values.go
+++ b/encoding/values.go
@@ -82,27 +82,27 @@ func (v *Values) Boolean() []byte {
 
 func (v *Values) Int32() []int32 {
 	v.assertKind(Int32)
-	return unsafecast.BytesToInt32(v.data)
+	return unsafecast.Slice[int32](v.data)
 }
 
 func (v *Values) Int64() []int64 {
 	v.assertKind(Int64)
-	return unsafecast.BytesToInt64(v.data)
+	return unsafecast.Slice[int64](v.data)
 }
 
 func (v *Values) Int96() []deprecated.Int96 {
 	v.assertKind(Int96)
-	return deprecated.BytesToInt96(v.data)
+	return unsafecast.Slice[deprecated.Int96](v.data)
 }
 
 func (v *Values) Float() []float32 {
 	v.assertKind(Float)
-	return unsafecast.BytesToFloat32(v.data)
+	return unsafecast.Slice[float32](v.data)
 }
 
 func (v *Values) Double() []float64 {
 	v.assertKind(Double)
-	return unsafecast.BytesToFloat64(v.data)
+	return unsafecast.Slice[float64](v.data)
 }
 
 func (v *Values) ByteArray() (data []byte, offsets []uint32) {
@@ -117,123 +117,86 @@ func (v *Values) FixedLenByteArray() (data []byte, size int) {
 
 func (v *Values) Uint32() []uint32 {
 	v.assertKind(Int32)
-	return unsafecast.BytesToUint32(v.data)
+	return unsafecast.Slice[uint32](v.data)
 }
 
 func (v *Values) Uint64() []uint64 {
 	v.assertKind(Int64)
-	return unsafecast.BytesToUint64(v.data)
+	return unsafecast.Slice[uint64](v.data)
 }
 
 func (v *Values) Uint128() [][16]byte {
 	v.assertKind(FixedLenByteArray)
 	v.assertSize(16)
-	return unsafecast.BytesToUint128(v.data)
+	return unsafecast.Slice[[16]byte](v.data)
+}
+
+func makeValues[T any](kind Kind, values []T) Values {
+	return Values{kind: kind, data: unsafecast.Slice[byte](values)}
 }
 
 func BooleanValues(values []byte) Values {
-	return Values{
-		kind: Boolean,
-		data: values,
-	}
+	return makeValues(Boolean, values)
 }
 
 func Int32Values(values []int32) Values {
-	return Values{
-		kind: Int32,
-		data: unsafecast.Int32ToBytes(values),
-	}
+	return makeValues(Int32, values)
 }
 
 func Int64Values(values []int64) Values {
-	return Values{
-		kind: Int64,
-		data: unsafecast.Int64ToBytes(values),
-	}
+	return makeValues(Int64, values)
 }
 
 func Int96Values(values []deprecated.Int96) Values {
-	return Values{
-		kind: Int96,
-		data: deprecated.Int96ToBytes(values),
-	}
+	return makeValues(Int96, values)
 }
 
 func FloatValues(values []float32) Values {
-	return Values{
-		kind: Float,
-		data: unsafecast.Float32ToBytes(values),
-	}
+	return makeValues(Float, values)
 }
 
 func DoubleValues(values []float64) Values {
-	return Values{
-		kind: Double,
-		data: unsafecast.Float64ToBytes(values),
-	}
+	return makeValues(Double, values)
 }
 
 func ByteArrayValues(values []byte, offsets []uint32) Values {
-	return Values{
-		kind:    ByteArray,
-		data:    values,
-		offsets: offsets,
-	}
+	return Values{kind: ByteArray, data: values, offsets: offsets}
 }
 
 func FixedLenByteArrayValues(values []byte, size int) Values {
-	return Values{
-		kind: FixedLenByteArray,
-		size: int32(size),
-		data: values,
-	}
+	return Values{kind: FixedLenByteArray, size: int32(size), data: values}
 }
 
 func Uint32Values(values []uint32) Values {
-	return Int32Values(unsafecast.Uint32ToInt32(values))
+	return Int32Values(unsafecast.Slice[int32](values))
 }
 
 func Uint64Values(values []uint64) Values {
-	return Int64Values(unsafecast.Uint64ToInt64(values))
+	return Int64Values(unsafecast.Slice[int64](values))
 }
 
 func Uint128Values(values [][16]byte) Values {
-	return FixedLenByteArrayValues(unsafecast.Uint128ToBytes(values), 16)
+	return FixedLenByteArrayValues(unsafecast.Slice[byte](values), 16)
 }
 
 func Int32ValuesFromBytes(values []byte) Values {
-	return Values{
-		kind: Int32,
-		data: values,
-	}
+	return Values{kind: Int32, data: values}
 }
 
 func Int64ValuesFromBytes(values []byte) Values {
-	return Values{
-		kind: Int64,
-		data: values,
-	}
+	return Values{kind: Int64, data: values}
 }
 
 func Int96ValuesFromBytes(values []byte) Values {
-	return Values{
-		kind: Int96,
-		data: values,
-	}
+	return Values{kind: Int96, data: values}
 }
 
 func FloatValuesFromBytes(values []byte) Values {
-	return Values{
-		kind: Float,
-		data: values,
-	}
+	return Values{kind: Float, data: values}
 }
 
 func DoubleValuesFromBytes(values []byte) Values {
-	return Values{
-		kind: Double,
-		data: values,
-	}
+	return Values{kind: Double, data: values}
 }
 
 func EncodeBoolean(dst []byte, src Values, enc Encoding) ([]byte, error) {

--- a/hashprobe/hashprobe.go
+++ b/hashprobe/hashprobe.go
@@ -98,7 +98,7 @@ func (t *Int32Table) Len() int { return t.len }
 func (t *Int32Table) Cap() int { return t.size() }
 
 func (t *Int32Table) Probe(keys, values []int32) int {
-	return t.probe(unsafecast.Int32ToUint32(keys), values)
+	return t.probe(unsafecast.Slice[uint32](keys), values)
 }
 
 func (t *Int32Table) ProbeArray(keys sparse.Int32Array, values []int32) int {
@@ -118,7 +118,7 @@ func (t *Float32Table) Len() int { return t.len }
 func (t *Float32Table) Cap() int { return t.size() }
 
 func (t *Float32Table) Probe(keys []float32, values []int32) int {
-	return t.probe(unsafecast.Float32ToUint32(keys), values)
+	return t.probe(unsafecast.Slice[uint32](keys), values)
 }
 
 func (t *Float32Table) ProbeArray(keys sparse.Float32Array, values []int32) int {
@@ -342,7 +342,7 @@ func (t *Int64Table) Len() int { return t.len }
 func (t *Int64Table) Cap() int { return t.size() }
 
 func (t *Int64Table) Probe(keys []int64, values []int32) int {
-	return t.probe(unsafecast.Int64ToUint64(keys), values)
+	return t.probe(unsafecast.Slice[uint64](keys), values)
 }
 
 func (t *Int64Table) ProbeArray(keys sparse.Int64Array, values []int32) int {
@@ -362,7 +362,7 @@ func (t *Float64Table) Len() int { return t.len }
 func (t *Float64Table) Cap() int { return t.size() }
 
 func (t *Float64Table) Probe(keys []float64, values []int32) int {
-	return t.probe(unsafecast.Float64ToUint64(keys), values)
+	return t.probe(unsafecast.Slice[uint64](keys), values)
 }
 
 func (t *Float64Table) ProbeArray(keys sparse.Float64Array, values []int32) int {
@@ -639,7 +639,7 @@ func (t *table128) init(cap int, maxLoad float64) {
 
 func (t *table128) kv() (keys [][16]byte, values []int32) {
 	i := t.cap * 16
-	return unsafecast.BytesToUint128(t.table[:i]), unsafecast.BytesToInt32(t.table[i:])
+	return unsafecast.Slice[[16]byte](t.table[:i]), unsafecast.Slice[int32](t.table[i:])
 }
 
 func (t *table128) grow(totalValues int) {
@@ -753,8 +753,8 @@ func (t *table128) probeArray(keys sparse.Uint128Array, values []int32) int {
 func multiProbe128Default(table []byte, tableCap, tableLen int, hashes []uintptr, keys sparse.Uint128Array, values []int32) int {
 	modulo := uintptr(tableCap) - 1
 	offset := uintptr(tableCap) * 16
-	tableKeys := unsafecast.BytesToUint128(table[:offset])
-	tableValues := unsafecast.BytesToInt32(table[offset:])
+	tableKeys := unsafecast.Slice[[16]byte](table[:offset])
+	tableValues := unsafecast.Slice[int32](table[offset:])
 
 	for i, hash := range hashes {
 		key := keys.Index(i)

--- a/internal/bitpack/unpack_int32_amd64.go
+++ b/internal/bitpack/unpack_int32_amd64.go
@@ -29,7 +29,7 @@ func unpackInt32(dst []int32, src []byte, bitWidth uint) {
 	case hasAVX2 && bitWidth <= 31:
 		unpackInt32x27to31bitsAVX2(dst, src, bitWidth)
 	case bitWidth == 32:
-		copy(dst, unsafecast.BytesToInt32(src))
+		copy(dst, unsafecast.Slice[int32](src))
 	default:
 		unpackInt32Default(dst, src, bitWidth)
 	}

--- a/internal/bitpack/unpack_int32_purego.go
+++ b/internal/bitpack/unpack_int32_purego.go
@@ -2,12 +2,10 @@
 
 package bitpack
 
-import (
-	"github.com/parquet-go/parquet-go/internal/unsafecast"
-)
+import "github.com/parquet-go/parquet-go/internal/unsafecast"
 
 func unpackInt32(dst []int32, src []byte, bitWidth uint) {
-	bits := unsafecast.BytesToUint32(src)
+	bits := unsafecast.Slice[uint32](src)
 	bitMask := uint32(1<<bitWidth) - 1
 	bitOffset := uint(0)
 

--- a/internal/bitpack/unpack_int64_amd64.go
+++ b/internal/bitpack/unpack_int64_amd64.go
@@ -19,7 +19,7 @@ func unpackInt64(dst []int64, src []byte, bitWidth uint) {
 	case hasAVX2 && bitWidth <= 32:
 		unpackInt64x1to32bitsAVX2(dst, src, bitWidth)
 	case bitWidth == 64:
-		copy(dst, unsafecast.BytesToInt64(src))
+		copy(dst, unsafecast.Slice[int64](src))
 	default:
 		unpackInt64Default(dst, src, bitWidth)
 	}

--- a/internal/bitpack/unpack_int64_purego.go
+++ b/internal/bitpack/unpack_int64_purego.go
@@ -5,7 +5,7 @@ package bitpack
 import "github.com/parquet-go/parquet-go/internal/unsafecast"
 
 func unpackInt64(dst []int64, src []byte, bitWidth uint) {
-	bits := unsafecast.BytesToUint32(src)
+	bits := unsafecast.Slice[uint32](src)
 	bitMask := uint64(1<<bitWidth) - 1
 	bitOffset := uint(0)
 

--- a/internal/unsafecast/unsafecast.go
+++ b/internal/unsafecast/unsafecast.go
@@ -33,13 +33,13 @@ func AddressOfString(data string) *byte {
 // PointerOf is like AddressOf but returns an unsafe.Pointer, losing type
 // information about the underlying data.
 func PointerOf[T any](data []T) unsafe.Pointer {
-	return unsafe.Pointer(AddressOf(data))
+	return unsafe.Pointer(unsafe.SliceData(data))
 }
 
 // PointerOfString is like AddressOfString but returns an unsafe.Pointer, losing
 // type information about the underlying data.
 func PointerOfString(data string) unsafe.Pointer {
-	return unsafe.Pointer(AddressOfString(data))
+	return unsafe.Pointer(unsafe.StringData(data))
 }
 
 // PointerOfValue returns the address of the object packed in the given value.

--- a/internal/unsafecast/unsafecast.go
+++ b/internal/unsafecast/unsafecast.go
@@ -9,30 +9,7 @@
 //	With great power comes great responsibility.
 package unsafecast
 
-import (
-	"reflect"
-	"unsafe"
-)
-
-// PointerOf is like AddressOf but returns an unsafe.Pointer, losing type
-// information about the underlying data.
-func PointerOf[T any](data []T) unsafe.Pointer {
-	return unsafe.Pointer(unsafe.SliceData(data))
-}
-
-// PointerOfString is like AddressOfString but returns an unsafe.Pointer, losing
-// type information about the underlying data.
-func PointerOfString(data string) unsafe.Pointer {
-	return unsafe.Pointer(unsafe.StringData(data))
-}
-
-// PointerOfValue returns the address of the object packed in the given value.
-//
-// This function is like value.UnsafePointer but works for any underlying type,
-// bypassing the safety checks done by the reflect package.
-func PointerOfValue(value reflect.Value) unsafe.Pointer {
-	return (*[2]unsafe.Pointer)(unsafe.Pointer(&value))[1]
-}
+import "unsafe"
 
 // The slice type represents the memory layout of slices in Go. It is similar to
 // reflect.SliceHeader but uses a unsafe.Pointer instead of uintptr to for the
@@ -65,18 +42,13 @@ func Slice[To, From any](data []From) []To {
 	return *(*[]To)(unsafe.Pointer(&s))
 }
 
-// BytesToString converts a byte slice to a string value. The returned string
-// shares the backing array of the byte slice.
+// String converts a byte slice to a string value. The returned string shares
+// the backing array of the byte slice.
 //
 // Programs using this function are responsible for ensuring that the data slice
 // is not modified while the returned string is in use, otherwise the guarantee
 // of immutability of Go string values will be violated, resulting in undefined
 // behavior.
-func BytesToString(data []byte) string {
+func String(data []byte) string {
 	return unsafe.String(unsafe.SliceData(data), len(data))
-}
-
-// StringToBytes applies the inverse conversion of BytesToString.
-func StringToBytes(data string) []byte {
-	return unsafe.Slice(unsafe.StringData(data), len(data))
 }

--- a/internal/unsafecast/unsafecast.go
+++ b/internal/unsafecast/unsafecast.go
@@ -14,22 +14,6 @@ import (
 	"unsafe"
 )
 
-// AddressOf returns the address to the first element in data, even if the slice
-// has length zero.
-func AddressOf[T any](data []T) *T {
-	return unsafe.SliceData(data)
-}
-
-// AddressOfBytes returns the address of the first byte in data.
-func AddressOfBytes(data []byte) *byte {
-	return unsafe.SliceData(data)
-}
-
-// AddressOfString returns the address of the first byte in data.
-func AddressOfString(data string) *byte {
-	return unsafe.StringData(data)
-}
-
 // PointerOf is like AddressOf but returns an unsafe.Pointer, losing type
 // information about the underlying data.
 func PointerOf[T any](data []T) unsafe.Pointer {
@@ -73,16 +57,12 @@ func Slice[To, From any](data []From) []To {
 	// information, so instead we implement the type conversion.
 	var zf From
 	var zt To
-	s := (*slice)(unsafe.Pointer(&data))
-	s.len = int((uintptr(s.len) * unsafe.Sizeof(zf)) / unsafe.Sizeof(zt))
-	s.cap = int((uintptr(s.cap) * unsafe.Sizeof(zf)) / unsafe.Sizeof(zt))
-	return *(*[]To)(unsafe.Pointer(s))
-}
-
-// Bytes constructs a byte slice. The pointer to the first element of the slice
-// is set to data, the length and capacity are set to size.
-func Bytes(data *byte, size int) []byte {
-	return unsafe.Slice(data, size)
+	var s = slice{
+		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&data)),
+		len: int((uintptr(len(data)) * unsafe.Sizeof(zf)) / unsafe.Sizeof(zt)),
+		cap: int((uintptr(cap(data)) * unsafe.Sizeof(zf)) / unsafe.Sizeof(zt)),
+	}
+	return *(*[]To)(unsafe.Pointer(&s))
 }
 
 // BytesToString converts a byte slice to a string value. The returned string
@@ -100,65 +80,3 @@ func BytesToString(data []byte) string {
 func StringToBytes(data string) []byte {
 	return unsafe.Slice(unsafe.StringData(data), len(data))
 }
-
-// -----------------------------------------------------------------------------
-// TODO: the functions below are used for backward compatibility with Go 1.17
-// where generics weren't available. We should remove them and inline calls to
-// unsafecast.Slice when we change our minimum supported Go version to 1.18.
-// -----------------------------------------------------------------------------
-
-func BoolToBytes(data []bool) []byte { return Slice[byte](data) }
-
-func Int8ToBytes(data []int8) []byte { return Slice[byte](data) }
-
-func Int16ToBytes(data []int16) []byte { return Slice[byte](data) }
-
-func Int32ToBytes(data []int32) []byte { return Slice[byte](data) }
-
-func Int64ToBytes(data []int64) []byte { return Slice[byte](data) }
-
-func Float32ToBytes(data []float32) []byte { return Slice[byte](data) }
-
-func Float64ToBytes(data []float64) []byte { return Slice[byte](data) }
-
-func Uint32ToBytes(data []uint32) []byte { return Slice[byte](data) }
-
-func Uint64ToBytes(data []uint64) []byte { return Slice[byte](data) }
-
-func Uint128ToBytes(data [][16]byte) []byte { return Slice[byte](data) }
-
-func Int16ToUint16(data []int16) []uint16 { return Slice[uint16](data) }
-
-func Int32ToUint32(data []int32) []uint32 { return Slice[uint32](data) }
-
-func Int64ToUint64(data []int64) []uint64 { return Slice[uint64](data) }
-
-func Float32ToUint32(data []float32) []uint32 { return Slice[uint32](data) }
-
-func Float64ToUint64(data []float64) []uint64 { return Slice[uint64](data) }
-
-func Uint32ToInt32(data []uint32) []int32 { return Slice[int32](data) }
-
-func Uint32ToInt64(data []uint32) []int64 { return Slice[int64](data) }
-
-func Uint64ToInt64(data []uint64) []int64 { return Slice[int64](data) }
-
-func BytesToBool(data []byte) []bool { return Slice[bool](data) }
-
-func BytesToInt8(data []byte) []int8 { return Slice[int8](data) }
-
-func BytesToInt16(data []byte) []int16 { return Slice[int16](data) }
-
-func BytesToInt32(data []byte) []int32 { return Slice[int32](data) }
-
-func BytesToInt64(data []byte) []int64 { return Slice[int64](data) }
-
-func BytesToUint32(data []byte) []uint32 { return Slice[uint32](data) }
-
-func BytesToUint64(data []byte) []uint64 { return Slice[uint64](data) }
-
-func BytesToUint128(data []byte) [][16]byte { return Slice[[16]byte](data) }
-
-func BytesToFloat32(data []byte) []float32 { return Slice[float32](data) }
-
-func BytesToFloat64(data []byte) []float64 { return Slice[float64](data) }

--- a/internal/unsafecast/unsafecast.go
+++ b/internal/unsafecast/unsafecast.go
@@ -35,7 +35,7 @@ func Slice[To, From any](data []From) []To {
 	var zf From
 	var zt To
 	var s = slice{
-		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&data)),
+		ptr: unsafe.Pointer(unsafe.SliceData(data)),
 		len: int((uintptr(len(data)) * unsafe.Sizeof(zf)) / unsafe.Sizeof(zt)),
 		cap: int((uintptr(cap(data)) * unsafe.Sizeof(zf)) / unsafe.Sizeof(zt)),
 	}

--- a/internal/unsafecast/unsafecast_test.go
+++ b/internal/unsafecast/unsafecast_test.go
@@ -18,7 +18,7 @@ func TestUnsafeCastSlice(t *testing.T) {
 		t.Fatalf("length mismatch: want=2 got=%d", len(b))
 	}
 	if cap(b) != 6 { // (13 * sizeof(uint32)) / sizeof(int64)
-		t.Fatalf("capacity mismatch: want=7 got=%d", cap(b))
+		t.Fatalf("capacity mismatch: want=6 got=%d", cap(b))
 	}
 	if b[0] != 1 {
 		t.Errorf("wrong value at index 0: want=1 got=%d", b[0])

--- a/order.go
+++ b/order.go
@@ -36,14 +36,14 @@ func orderOfBool(data []bool) int {
 }
 
 func streakOfTrue(data []bool) int {
-	if i := bytes.IndexByte(unsafecast.BoolToBytes(data), 0); i >= 0 {
+	if i := bytes.IndexByte(unsafecast.Slice[byte](data), 0); i >= 0 {
 		return i
 	}
 	return len(data)
 }
 
 func streakOfFalse(data []bool) int {
-	if i := bytes.IndexByte(unsafecast.BoolToBytes(data), 1); i >= 0 {
+	if i := bytes.IndexByte(unsafecast.Slice[byte](data), 1); i >= 0 {
 		return i
 	}
 	return len(data)

--- a/page_test.go
+++ b/page_test.go
@@ -53,13 +53,13 @@ func testPageInt32(t *testing.T) {
 		testBufferPage(t, schema, pageTest{
 			write: func(w parquet.ValueWriter) (interface{}, error) {
 				values := []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-				n, err := w.(io.Writer).Write(unsafecast.Int32ToBytes(values))
+				n, err := w.(io.Writer).Write(unsafecast.Slice[byte](values))
 				return values[:n/4], err
 			},
 
 			read: func(r parquet.ValueReader) (interface{}, error) {
 				values := make([]int32, 10)
-				n, err := r.(io.Reader).Read(unsafecast.Int32ToBytes(values))
+				n, err := r.(io.Reader).Read(unsafecast.Slice[byte](values))
 				return values[:n/4], err
 			},
 		})
@@ -89,13 +89,13 @@ func testPageInt64(t *testing.T) {
 		testBufferPage(t, schema, pageTest{
 			write: func(w parquet.ValueWriter) (interface{}, error) {
 				values := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-				n, err := w.(io.Writer).Write(unsafecast.Int64ToBytes(values))
+				n, err := w.(io.Writer).Write(unsafecast.Slice[byte](values))
 				return values[:n/8], err
 			},
 
 			read: func(r parquet.ValueReader) (interface{}, error) {
 				values := make([]int64, 10)
-				n, err := r.(io.Reader).Read(unsafecast.Int64ToBytes(values))
+				n, err := r.(io.Reader).Read(unsafecast.Slice[byte](values))
 				return values[:n/8], err
 			},
 		})
@@ -125,13 +125,13 @@ func testPageInt96(t *testing.T) {
 		testBufferPage(t, schema, pageTest{
 			write: func(w parquet.ValueWriter) (interface{}, error) {
 				values := []deprecated.Int96{{0: 0}, {0: 1}, {0: 2}}
-				n, err := w.(io.Writer).Write(deprecated.Int96ToBytes(values))
+				n, err := w.(io.Writer).Write(unsafecast.Slice[byte](values))
 				return values[:n/12], err
 			},
 
 			read: func(r parquet.ValueReader) (interface{}, error) {
 				values := make([]deprecated.Int96, 3)
-				n, err := r.(io.Reader).Read(deprecated.Int96ToBytes(values))
+				n, err := r.(io.Reader).Read(unsafecast.Slice[byte](values))
 				return values[:n/12], err
 			},
 		})
@@ -161,13 +161,13 @@ func testPageFloat(t *testing.T) {
 		testBufferPage(t, schema, pageTest{
 			write: func(w parquet.ValueWriter) (interface{}, error) {
 				values := []float32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-				n, err := w.(io.Writer).Write(unsafecast.Float32ToBytes(values))
+				n, err := w.(io.Writer).Write(unsafecast.Slice[byte](values))
 				return values[:n/4], err
 			},
 
 			read: func(r parquet.ValueReader) (interface{}, error) {
 				values := make([]float32, 10)
-				n, err := r.(io.Reader).Read(unsafecast.Float32ToBytes(values))
+				n, err := r.(io.Reader).Read(unsafecast.Slice[byte](values))
 				return values[:n/4], err
 			},
 		})
@@ -197,13 +197,13 @@ func testPageDouble(t *testing.T) {
 		testBufferPage(t, schema, pageTest{
 			write: func(w parquet.ValueWriter) (interface{}, error) {
 				values := []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-				n, err := w.(io.Writer).Write(unsafecast.Float64ToBytes(values))
+				n, err := w.(io.Writer).Write(unsafecast.Slice[byte](values))
 				return values[:n/8], err
 			},
 
 			read: func(r parquet.ValueReader) (interface{}, error) {
 				values := make([]float64, 10)
-				n, err := r.(io.Reader).Read(unsafecast.Float64ToBytes(values))
+				n, err := r.(io.Reader).Read(unsafecast.Slice[byte](values))
 				return values[:n/8], err
 			},
 		})

--- a/page_values.go
+++ b/page_values.go
@@ -149,7 +149,7 @@ type int32PageValues struct {
 }
 
 func (r *int32PageValues) Read(b []byte) (n int, err error) {
-	n, err = r.ReadInt32s(unsafecast.BytesToInt32(b))
+	n, err = r.ReadInt32s(unsafecast.Slice[int32](b))
 	return 4 * n, err
 }
 
@@ -180,7 +180,7 @@ type int64PageValues struct {
 }
 
 func (r *int64PageValues) Read(b []byte) (n int, err error) {
-	n, err = r.ReadInt64s(unsafecast.BytesToInt64(b))
+	n, err = r.ReadInt64s(unsafecast.Slice[int64](b))
 	return 8 * n, err
 }
 
@@ -211,7 +211,7 @@ type int96PageValues struct {
 }
 
 func (r *int96PageValues) Read(b []byte) (n int, err error) {
-	n, err = r.ReadInt96s(deprecated.BytesToInt96(b))
+	n, err = r.ReadInt96s(unsafecast.Slice[deprecated.Int96](b))
 	return 12 * n, err
 }
 
@@ -242,7 +242,7 @@ type floatPageValues struct {
 }
 
 func (r *floatPageValues) Read(b []byte) (n int, err error) {
-	n, err = r.ReadFloats(unsafecast.BytesToFloat32(b))
+	n, err = r.ReadFloats(unsafecast.Slice[float32](b))
 	return 4 * n, err
 }
 
@@ -273,7 +273,7 @@ type doublePageValues struct {
 }
 
 func (r *doublePageValues) Read(b []byte) (n int, err error) {
-	n, err = r.ReadDoubles(unsafecast.BytesToFloat64(b))
+	n, err = r.ReadDoubles(unsafecast.Slice[float64](b))
 	return 8 * n, err
 }
 
@@ -395,7 +395,7 @@ type uint32PageValues struct {
 }
 
 func (r *uint32PageValues) Read(b []byte) (n int, err error) {
-	n, err = r.ReadUint32s(unsafecast.BytesToUint32(b))
+	n, err = r.ReadUint32s(unsafecast.Slice[uint32](b))
 	return 4 * n, err
 }
 
@@ -426,7 +426,7 @@ type uint64PageValues struct {
 }
 
 func (r *uint64PageValues) Read(b []byte) (n int, err error) {
-	n, err = r.ReadUint64s(unsafecast.BytesToUint64(b))
+	n, err = r.ReadUint64s(unsafecast.Slice[uint64](b))
 	return 8 * n, err
 }
 

--- a/sparse/array.go
+++ b/sparse/array.go
@@ -3,8 +3,6 @@ package sparse
 import (
 	"time"
 	"unsafe"
-
-	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 type Array struct{ array }
@@ -40,7 +38,11 @@ type array struct {
 
 func makeArray[T any](base []T) array {
 	var z T
-	return array{ptr: unsafecast.PointerOf(base), len: uintptr(len(base)), off: unsafe.Sizeof(z)}
+	return array{
+		ptr: unsafe.Pointer(unsafe.SliceData(base)),
+		len: uintptr(len(base)),
+		off: unsafe.Sizeof(z),
+	}
 }
 
 func unsafeArray(base unsafe.Pointer, length int, offset uintptr) array {

--- a/sparse/array.go
+++ b/sparse/array.go
@@ -3,12 +3,14 @@ package sparse
 import (
 	"time"
 	"unsafe"
+
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 type Array struct{ array }
 
 func UnsafeArray(base unsafe.Pointer, length int, offset uintptr) Array {
-	return Array{makeArray(base, uintptr(length), offset)}
+	return Array{unsafeArray(base, length, offset)}
 }
 
 func (a Array) Len() int                   { return int(a.len) }
@@ -36,8 +38,13 @@ type array struct {
 	off uintptr
 }
 
-func makeArray(base unsafe.Pointer, length, offset uintptr) array {
-	return array{ptr: base, len: length, off: offset}
+func makeArray[T any](base []T) array {
+	var z T
+	return array{ptr: unsafecast.PointerOf(base), len: uintptr(len(base)), off: unsafe.Sizeof(z)}
+}
+
+func unsafeArray(base unsafe.Pointer, length int, offset uintptr) array {
+	return array{ptr: base, len: uintptr(length), off: offset}
 }
 
 func (a array) index(i int) unsafe.Pointer {
@@ -72,11 +79,11 @@ func (a array) offset(off uintptr) array {
 type BoolArray struct{ array }
 
 func MakeBoolArray(values []bool) BoolArray {
-	return BoolArray{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 1)}
+	return BoolArray{makeArray(values)}
 }
 
 func UnsafeBoolArray(base unsafe.Pointer, length int, offset uintptr) BoolArray {
-	return BoolArray{makeArray(base, uintptr(length), offset)}
+	return BoolArray{unsafeArray(base, length, offset)}
 }
 
 func (a BoolArray) Len() int                 { return int(a.len) }
@@ -88,11 +95,11 @@ func (a BoolArray) UnsafeArray() Array       { return Array{a.array} }
 type Int8Array struct{ array }
 
 func MakeInt8Array(values []int8) Int8Array {
-	return Int8Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Int8Array{makeArray(values)}
 }
 
 func UnsafeInt8Array(base unsafe.Pointer, length int, offset uintptr) Int8Array {
-	return Int8Array{makeArray(base, uintptr(length), offset)}
+	return Int8Array{unsafeArray(base, length, offset)}
 }
 
 func (a Int8Array) Len() int                 { return int(a.len) }
@@ -104,11 +111,11 @@ func (a Int8Array) UnsafeArray() Array       { return Array{a.array} }
 type Int16Array struct{ array }
 
 func MakeInt16Array(values []int16) Int16Array {
-	return Int16Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Int16Array{makeArray(values)}
 }
 
 func UnsafeInt16Array(base unsafe.Pointer, length int, offset uintptr) Int16Array {
-	return Int16Array{makeArray(base, uintptr(length), offset)}
+	return Int16Array{unsafeArray(base, length, offset)}
 }
 
 func (a Int16Array) Len() int                  { return int(a.len) }
@@ -122,11 +129,11 @@ func (a Int16Array) UnsafeArray() Array        { return Array{a.array} }
 type Int32Array struct{ array }
 
 func MakeInt32Array(values []int32) Int32Array {
-	return Int32Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 4)}
+	return Int32Array{makeArray(values)}
 }
 
 func UnsafeInt32Array(base unsafe.Pointer, length int, offset uintptr) Int32Array {
-	return Int32Array{makeArray(base, uintptr(length), offset)}
+	return Int32Array{unsafeArray(base, length, offset)}
 }
 
 func (a Int32Array) Len() int                  { return int(a.len) }
@@ -142,11 +149,11 @@ func (a Int32Array) UnsafeArray() Array        { return Array{a.array} }
 type Int64Array struct{ array }
 
 func MakeInt64Array(values []int64) Int64Array {
-	return Int64Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Int64Array{makeArray(values)}
 }
 
 func UnsafeInt64Array(base unsafe.Pointer, length int, offset uintptr) Int64Array {
-	return Int64Array{makeArray(base, uintptr(length), offset)}
+	return Int64Array{unsafeArray(base, length, offset)}
 }
 
 func (a Int64Array) Len() int                  { return int(a.len) }
@@ -164,11 +171,11 @@ func (a Int64Array) UnsafeArray() Array        { return Array{a.array} }
 type Float32Array struct{ array }
 
 func MakeFloat32Array(values []float32) Float32Array {
-	return Float32Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 4)}
+	return Float32Array{makeArray(values)}
 }
 
 func UnsafeFloat32Array(base unsafe.Pointer, length int, offset uintptr) Float32Array {
-	return Float32Array{makeArray(base, uintptr(length), offset)}
+	return Float32Array{unsafeArray(base, length, offset)}
 }
 
 func (a Float32Array) Len() int                    { return int(a.len) }
@@ -181,11 +188,11 @@ func (a Float32Array) UnsafeArray() Array          { return Array{a.array} }
 type Float64Array struct{ array }
 
 func MakeFloat64Array(values []float64) Float64Array {
-	return Float64Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Float64Array{makeArray(values)}
 }
 
 func UnsafeFloat64Array(base unsafe.Pointer, length int, offset uintptr) Float64Array {
-	return Float64Array{makeArray(base, uintptr(length), offset)}
+	return Float64Array{unsafeArray(base, length, offset)}
 }
 
 func (a Float64Array) Len() int                    { return int(a.len) }
@@ -197,11 +204,11 @@ func (a Float64Array) UnsafeArray() Array          { return Array{a.array} }
 type Uint8Array struct{ array }
 
 func MakeUint8Array(values []uint8) Uint8Array {
-	return Uint8Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Uint8Array{makeArray(values)}
 }
 
 func UnsafeUint8Array(base unsafe.Pointer, length int, offset uintptr) Uint8Array {
-	return Uint8Array{makeArray(base, uintptr(length), offset)}
+	return Uint8Array{unsafeArray(base, length, offset)}
 }
 
 func (a Uint8Array) Len() int                  { return int(a.len) }
@@ -212,11 +219,11 @@ func (a Uint8Array) UnsafeArray() Array        { return Array{a.array} }
 type Uint16Array struct{ array }
 
 func MakeUint16Array(values []uint16) Uint16Array {
-	return Uint16Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Uint16Array{makeArray(values)}
 }
 
 func UnsafeUint16Array(base unsafe.Pointer, length int, offset uintptr) Uint16Array {
-	return Uint16Array{makeArray(base, uintptr(length), offset)}
+	return Uint16Array{unsafeArray(base, length, offset)}
 }
 
 func (a Uint16Array) Len() int                   { return int(a.len) }
@@ -228,11 +235,11 @@ func (a Uint16Array) UnsafeArray() Array         { return Array{a.array} }
 type Uint32Array struct{ array }
 
 func MakeUint32Array(values []uint32) Uint32Array {
-	return Uint32Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 4)}
+	return Uint32Array{makeArray(values)}
 }
 
 func UnsafeUint32Array(base unsafe.Pointer, length int, offset uintptr) Uint32Array {
-	return Uint32Array{makeArray(base, uintptr(length), offset)}
+	return Uint32Array{unsafeArray(base, length, offset)}
 }
 
 func (a Uint32Array) Len() int                   { return int(a.len) }
@@ -245,11 +252,11 @@ func (a Uint32Array) UnsafeArray() Array         { return Array{a.array} }
 type Uint64Array struct{ array }
 
 func MakeUint64Array(values []uint64) Uint64Array {
-	return Uint64Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Uint64Array{makeArray(values)}
 }
 
 func UnsafeUint64Array(base unsafe.Pointer, length int, offset uintptr) Uint64Array {
-	return Uint64Array{makeArray(base, uintptr(length), offset)}
+	return Uint64Array{unsafeArray(base, length, offset)}
 }
 
 func (a Uint64Array) Len() int                   { return int(a.len) }
@@ -263,11 +270,11 @@ func (a Uint64Array) UnsafeArray() Array         { return Array{a.array} }
 type Uint128Array struct{ array }
 
 func MakeUint128Array(values [][16]byte) Uint128Array {
-	return Uint128Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 16)}
+	return Uint128Array{makeArray(values)}
 }
 
 func UnsafeUint128Array(base unsafe.Pointer, length int, offset uintptr) Uint128Array {
-	return Uint128Array{makeArray(base, uintptr(length), offset)}
+	return Uint128Array{unsafeArray(base, length, offset)}
 }
 
 func (a Uint128Array) Len() int                    { return int(a.len) }
@@ -283,11 +290,11 @@ type StringArray struct{ array }
 
 func MakeStringArray(values []string) StringArray {
 	const sizeOfString = unsafe.Sizeof("")
-	return StringArray{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), sizeOfString)}
+	return StringArray{makeArray(values)}
 }
 
 func UnsafeStringArray(base unsafe.Pointer, length int, offset uintptr) StringArray {
-	return StringArray{makeArray(base, uintptr(length), offset)}
+	return StringArray{unsafeArray(base, length, offset)}
 }
 
 func (a StringArray) Len() int                   { return int(a.len) }
@@ -298,12 +305,11 @@ func (a StringArray) UnsafeArray() Array         { return Array{a.array} }
 type TimeArray struct{ array }
 
 func MakeTimeArray(values []time.Time) TimeArray {
-	const sizeOfTime = unsafe.Sizeof(time.Time{})
-	return TimeArray{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), sizeOfTime)}
+	return TimeArray{makeArray(values)}
 }
 
 func UnsafeTimeArray(base unsafe.Pointer, length int, offset uintptr) TimeArray {
-	return TimeArray{makeArray(base, uintptr(length), offset)}
+	return TimeArray{unsafeArray(base, length, offset)}
 }
 
 func (a TimeArray) Len() int                 { return int(a.len) }

--- a/sparse/gather.go
+++ b/sparse/gather.go
@@ -1,21 +1,21 @@
 package sparse
 
-import "unsafe"
+import "github.com/parquet-go/parquet-go/internal/unsafecast"
 
 func GatherInt32(dst []int32, src Int32Array) int {
-	return GatherUint32(*(*[]uint32)(unsafe.Pointer(&dst)), src.Uint32Array())
+	return GatherUint32(unsafecast.Slice[uint32](dst), src.Uint32Array())
 }
 
 func GatherInt64(dst []int64, src Int64Array) int {
-	return GatherUint64(*(*[]uint64)(unsafe.Pointer(&dst)), src.Uint64Array())
+	return GatherUint64(unsafecast.Slice[uint64](dst), src.Uint64Array())
 }
 
 func GatherFloat32(dst []float32, src Float32Array) int {
-	return GatherUint32(*(*[]uint32)(unsafe.Pointer(&dst)), src.Uint32Array())
+	return GatherUint32(unsafecast.Slice[uint32](dst), src.Uint32Array())
 }
 
 func GatherFloat64(dst []float64, src Float64Array) int {
-	return GatherUint64(*(*[]uint64)(unsafe.Pointer(&dst)), src.Uint64Array())
+	return GatherUint64(unsafecast.Slice[uint64](dst), src.Uint64Array())
 }
 
 func GatherBits(dst []byte, src Uint8Array) int { return gatherBits(dst, src) }

--- a/type.go
+++ b/type.go
@@ -12,7 +12,6 @@ import (
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
-	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 // Kind is an enumeration type representing the physical types supported by the
@@ -901,7 +900,7 @@ func (t fixedLenByteArrayType) AssignValue(dst reflect.Value, src Value) error {
 			// overhead we instead convert the reflect.Value holding the
 			// destination array into a byte slice which allows us to use
 			// a more efficient call to copy.
-			d := unsafe.Slice((*byte)(unsafecast.PointerOfValue(dst)), len(v))
+			d := unsafe.Slice((*byte)(reflectValueData(dst)), len(v))
 			copy(d, v)
 			return nil
 		}
@@ -913,6 +912,10 @@ func (t fixedLenByteArrayType) AssignValue(dst reflect.Value, src Value) error {
 	val := reflect.ValueOf(copyBytes(v))
 	dst.Set(val)
 	return nil
+}
+
+func reflectValueData(v reflect.Value) unsafe.Pointer {
+	return (*[2]unsafe.Pointer)(unsafe.Pointer(&v))[1]
 }
 
 func (t fixedLenByteArrayType) ConvertValue(val Value, typ Type) (Value, error) {


### PR DESCRIPTION
This PR removes functions from the `unsafecast` package in favor of using new functions available in the `unsafe` package and the generic `unsafecast.Slice`.

There are no changes in behavior, this is purely a code maintenance update to reduce the amount of code using unsafe constructs, where bugs tend to arise more easily.