### PR TITLE
Use atomic pointer for column and offset indexes, so they can be lazily populated in a thread-safe way

### DIFF
--- a/column_index.go
+++ b/column_index.go
@@ -107,17 +107,19 @@ func (i fileColumnIndex) nullPage(j int, index *format.ColumnIndex) bool {
 }
 
 func (i fileColumnIndex) MinValue(j int) Value {
-	if i.nullPage(j, i.columnIndex()) {
+	index := i.columnIndex()
+	if i.nullPage(j, index) {
 		return Value{}
 	}
-	return i.makeValue(i.columnIndex().MinValues[j])
+	return i.makeValue(index.MinValues[j])
 }
 
 func (i fileColumnIndex) MaxValue(j int) Value {
-	if i.nullPage(j, i.columnIndex()) {
+	index := i.columnIndex()
+	if i.nullPage(j, index) {
 		return Value{}
 	}
-	return i.makeValue(i.columnIndex().MaxValues[j])
+	return i.makeValue(index.MaxValues[j])
 }
 
 func (i fileColumnIndex) IsAscending() bool {

--- a/column_index.go
+++ b/column_index.go
@@ -87,40 +87,42 @@ func (f *formatColumnIndex) IsDescending() bool {
 type fileColumnIndex struct{ chunk *fileColumnChunk }
 
 func (i fileColumnIndex) NumPages() int {
-	return len(i.chunk.columnIndex.NullPages)
+	return len(i.chunk.columnIndex.Load().NullPages)
 }
 
 func (i fileColumnIndex) NullCount(j int) int64 {
-	if len(i.chunk.columnIndex.NullCounts) > 0 {
-		return i.chunk.columnIndex.NullCounts[j]
+	index := i.chunk.columnIndex.Load()
+	if len(index.NullCounts) > 0 {
+		return index.NullCounts[j]
 	}
 	return 0
 }
 
 func (i fileColumnIndex) NullPage(j int) bool {
-	return len(i.chunk.columnIndex.NullPages) > 0 && i.chunk.columnIndex.NullPages[j]
+	index := i.chunk.columnIndex.Load()
+	return len(index.NullPages) > 0 && index.NullPages[j]
 }
 
 func (i fileColumnIndex) MinValue(j int) Value {
 	if i.NullPage(j) {
 		return Value{}
 	}
-	return i.makeValue(i.chunk.columnIndex.MinValues[j])
+	return i.makeValue(i.chunk.columnIndex.Load().MinValues[j])
 }
 
 func (i fileColumnIndex) MaxValue(j int) Value {
 	if i.NullPage(j) {
 		return Value{}
 	}
-	return i.makeValue(i.chunk.columnIndex.MaxValues[j])
+	return i.makeValue(i.chunk.columnIndex.Load().MaxValues[j])
 }
 
 func (i fileColumnIndex) IsAscending() bool {
-	return i.chunk.columnIndex.BoundaryOrder == format.Ascending
+	return i.chunk.columnIndex.Load().BoundaryOrder == format.Ascending
 }
 
 func (i fileColumnIndex) IsDescending() bool {
-	return i.chunk.columnIndex.BoundaryOrder == format.Descending
+	return i.chunk.columnIndex.Load().BoundaryOrder == format.Descending
 }
 
 func (i *fileColumnIndex) makeValue(b []byte) Value {

--- a/column_index.go
+++ b/column_index.go
@@ -99,16 +99,12 @@ func (i fileColumnIndex) NullCount(j int) int64 {
 }
 
 func (i fileColumnIndex) NullPage(j int) bool {
-	return i.nullPage(j, i.columnIndex())
-}
-
-func (i fileColumnIndex) nullPage(j int, index *format.ColumnIndex) bool {
-	return len(index.NullPages) > 0 && index.NullPages[j]
+	return isNullPage(j, i.columnIndex())
 }
 
 func (i fileColumnIndex) MinValue(j int) Value {
 	index := i.columnIndex()
-	if i.nullPage(j, index) {
+	if isNullPage(j, index) {
 		return Value{}
 	}
 	return i.makeValue(index.MinValues[j])
@@ -116,7 +112,7 @@ func (i fileColumnIndex) MinValue(j int) Value {
 
 func (i fileColumnIndex) MaxValue(j int) Value {
 	index := i.columnIndex()
-	if i.nullPage(j, index) {
+	if isNullPage(j, index) {
 		return Value{}
 	}
 	return i.makeValue(index.MaxValues[j])
@@ -135,6 +131,10 @@ func (i *fileColumnIndex) makeValue(b []byte) Value {
 }
 
 func (i fileColumnIndex) columnIndex() *format.ColumnIndex { return i.chunk.columnIndex.Load() }
+
+func isNullPage(j int, index *format.ColumnIndex) bool {
+	return len(index.NullPages) > 0 && index.NullPages[j]
+}
 
 type emptyColumnIndex struct{}
 

--- a/file.go
+++ b/file.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/parquet-go/parquet-go/encoding/thrift"
 	"github.com/parquet-go/parquet-go/format"
@@ -390,8 +391,8 @@ func (g *fileRowGroup) init(file *File, schema *Schema, columns []*Column, rowGr
 
 		if file.hasIndexes() {
 			j := (int(rowGroup.Ordinal) * len(columns)) + i
-			fileColumnChunks[i].columnIndex = &file.columnIndexes[j]
-			fileColumnChunks[i].offsetIndex = &file.offsetIndexes[j]
+			fileColumnChunks[i].columnIndex.Store(&file.columnIndexes[j])
+			fileColumnChunks[i].offsetIndex.Store(&file.offsetIndexes[j])
 		}
 
 		g.columns[i] = &fileColumnChunks[i]
@@ -441,8 +442,8 @@ type fileColumnChunk struct {
 	column      *Column
 	bloomFilter *bloomFilter
 	rowGroup    *format.RowGroup
-	columnIndex *format.ColumnIndex
-	offsetIndex *format.OffsetIndex
+	columnIndex atomic.Pointer[format.ColumnIndex]
+	offsetIndex atomic.Pointer[format.OffsetIndex]
 	chunk       *format.ColumnChunk
 }
 
@@ -461,23 +462,25 @@ func (c *fileColumnChunk) Pages() Pages {
 }
 
 func (c *fileColumnChunk) ColumnIndex() (ColumnIndex, error) {
-	if err := c.readColumnIndex(); err != nil {
+	index, err := c.readColumnIndex()
+	if err != nil {
 		return nil, err
 	}
-	if c.columnIndex == nil || c.chunk.ColumnIndexOffset == 0 {
+	if index == nil || c.chunk.ColumnIndexOffset == 0 {
 		return nil, ErrMissingColumnIndex
 	}
 	return fileColumnIndex{c}, nil
 }
 
 func (c *fileColumnChunk) OffsetIndex() (OffsetIndex, error) {
-	if err := c.readOffsetIndex(); err != nil {
+	index, err := c.readOffsetIndex()
+	if err != nil {
 		return nil, err
 	}
-	if c.offsetIndex == nil || c.chunk.OffsetIndexOffset == 0 {
+	if index == nil || c.chunk.OffsetIndexOffset == 0 {
 		return nil, ErrMissingOffsetIndex
 	}
-	return (*fileOffsetIndex)(c.offsetIndex), nil
+	return (*fileOffsetIndex)(index), nil
 }
 
 func (c *fileColumnChunk) BloomFilter() BloomFilter {
@@ -491,48 +494,56 @@ func (c *fileColumnChunk) NumValues() int64 {
 	return c.chunk.MetaData.NumValues
 }
 
-func (c *fileColumnChunk) readColumnIndex() error {
-	if c.columnIndex != nil {
-		return nil
+func (c *fileColumnChunk) readColumnIndex() (*format.ColumnIndex, error) {
+	if index := c.columnIndex.Load(); index != nil {
+		return index, nil
 	}
 	chunkMeta := c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
 	offset, length := chunkMeta.ColumnIndexOffset, chunkMeta.ColumnIndexLength
 	if offset == 0 {
-		return nil
+		return nil, nil
 	}
 
 	indexData := make([]byte, int(length))
 	var columnIndex format.ColumnIndex
 	if _, err := readAt(c.file.reader, indexData, offset); err != nil {
-		return fmt.Errorf("read %d bytes column index at offset %d: %w", length, offset, err)
+		return nil, fmt.Errorf("read %d bytes column index at offset %d: %w", length, offset, err)
 	}
 	if err := thrift.Unmarshal(&c.file.protocol, indexData, &columnIndex); err != nil {
-		return fmt.Errorf("decode column index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
+		return nil, fmt.Errorf("decode column index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
 	}
-	c.columnIndex = &columnIndex
-	return nil
+	index := &columnIndex
+	if !c.columnIndex.CompareAndSwap(nil, index) {
+		// another goroutine populated it since we last read the pointer
+		return c.columnIndex.Load(), nil
+	}
+	return index, nil
 }
 
-func (c *fileColumnChunk) readOffsetIndex() error {
-	if c.offsetIndex != nil {
-		return nil
+func (c *fileColumnChunk) readOffsetIndex() (*format.OffsetIndex, error) {
+	if index := c.offsetIndex.Load(); index != nil {
+		return index, nil
 	}
 	chunkMeta := c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
 	offset, length := chunkMeta.OffsetIndexOffset, chunkMeta.OffsetIndexLength
 	if offset == 0 {
-		return nil
+		return nil, nil
 	}
 
 	indexData := make([]byte, int(length))
 	var offsetIndex format.OffsetIndex
 	if _, err := readAt(c.file.reader, indexData, offset); err != nil {
-		return fmt.Errorf("read %d bytes offset index at offset %d: %w", length, offset, err)
+		return nil, fmt.Errorf("read %d bytes offset index at offset %d: %w", length, offset, err)
 	}
 	if err := thrift.Unmarshal(&c.file.protocol, indexData, &offsetIndex); err != nil {
-		return fmt.Errorf("decode offset index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
+		return nil, fmt.Errorf("decode offset index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
 	}
-	c.offsetIndex = &offsetIndex
-	return nil
+	index := &offsetIndex
+	if !c.offsetIndex.CompareAndSwap(nil, index) {
+		// another goroutine populated it since we last read the pointer
+		return c.offsetIndex.Load(), nil
+	}
+	return index, nil
 }
 
 type filePages struct {
@@ -744,7 +755,7 @@ func (f *filePages) SeekToRow(rowIndex int64) (err error) {
 	if f.chunk == nil {
 		return io.ErrClosedPipe
 	}
-	if f.chunk.offsetIndex == nil {
+	if index := f.chunk.offsetIndex.Load(); index == nil {
 		_, err = f.section.Seek(f.dataOffset-f.baseOffset, io.SeekStart)
 		f.skip = rowIndex
 		f.index = 0
@@ -752,7 +763,7 @@ func (f *filePages) SeekToRow(rowIndex int64) (err error) {
 			f.index = 1
 		}
 	} else {
-		pages := f.chunk.offsetIndex.PageLocations
+		pages := index.PageLocations
 		index := sort.Search(len(pages), func(i int) bool {
 			return pages[i].FirstRowIndex > rowIndex
 		}) - 1


### PR DESCRIPTION
This allows a single `*parquet.File` to be safely used by multiple concurrent readers... I think. I suppose there may be other thread-safety issues lurking that I haven't yet found, so this begs the question: is this change appropriate?

It _seems_ like all of the state in a `File` is static/immutable after the file is opened with the exception of these indexes. So I'm hoping this change is in the right direction.

Resolves #167.