### PR TITLE
Fix panic in newIndexedPage

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -29,7 +29,7 @@ const (
 	//
 	// This constant is used to determine a useful chunk size depending on the
 	// size of values being inserted in dictionaries. More values of small size
-	// can fit in CPU caches, so the inserts can operation on larger chunks.
+	// can fit in CPU caches, so the inserts can operate on larger chunks.
 	insertsTargetCacheFootprint = 8192
 )
 
@@ -1242,7 +1242,7 @@ func newIndexedPage(typ *indexedType, columnIndex int16, numValues int32, data e
 			copy(tmp, values)
 			values = tmp
 		} else {
-			clear := values[len(values) : len(values)+size]
+			clear := values[len(values):size]
 			for i := range clear {
 				clear[i] = 0
 			}

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/encoding"
 )
 
 var dictionaryTypes = [...]parquet.Type{
@@ -271,4 +272,12 @@ func TestIssue312(t *testing.T) {
 			_ = columnType.NewDictionary(0, 1, values)
 		})
 	}
+}
+
+func TestNewIndexedPage(t *testing.T) {
+	// Reproduces a slice arithmetic bug in newIndexedPage that
+	// could cause a panic when cap(vals) >= size and len(vals)+size > cap(vals).
+	dict := parquet.ByteArrayType.NewDictionary(1, 1, encoding.ByteArrayValues([]byte("foobar"), []uint32{0}))
+	// cap(vals) = 100; size = 100; len(vals) = 50  ==> boom!
+	dict.Type().NewPage(1, 100, encoding.Int32Values(make([]int32, 50, 100)))
 }


### PR DESCRIPTION
There was a slice arithmetic bug in `newIndexedPage` that can cause a "slice bounds out of range" panic. This adds a very simple test to reproduce the issue and then includes the one-liner fix.