### PR TITLE
ability to register extra encodings

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -94,16 +94,15 @@ func isDictionaryFormat(encoding format.Encoding) bool {
 	return encoding == format.PlainDictionary || encoding == format.RLEDictionary
 }
 
-func RegisterEncoding(enc encoding.Encoding) bool {
+func RegisterEncoding(enc encoding.Encoding) {
 	ns := encoding.NotSupported{}
 	if enc == ns {
-		return false
+		panic("cannot register parquet encoding as not-supported")
 	}
 	if LookupEncoding(enc.Encoding()) != ns {
-		return false
+		panic("cannot register parquet encoding that overrides the standard specification")
 	}
 	extraEncodings.Store(enc.Encoding(), enc)
-	return true
 }
 
 // LookupEncoding returns the parquet encoding associated with the given code.


### PR DESCRIPTION
Currently it is possible to implement the `encoding.Encoding` interface to write parquet files but they cannot be read back since the list of considered encodings when reading is static and uses `encoding.LookupEncoding`. This PR makes it possible to read back parquet files that were written with a custom encoding.