### PR TITLE
file: add option to skip reading magic bytes

### DIFF
--- a/file.go
+++ b/file.go
@@ -49,11 +49,13 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	}
 	f := &File{reader: r, size: size, config: c}
 
-	if _, err := readAt(r, b[:4], 0); err != nil {
-		return nil, fmt.Errorf("reading magic header of parquet file: %w", err)
-	}
-	if string(b[:4]) != "PAR1" {
-		return nil, fmt.Errorf("invalid magic header of parquet file: %q", b[:4])
+	if !c.SkipMagicBytes {
+		if _, err := readAt(r, b[:4], 0); err != nil {
+			return nil, fmt.Errorf("reading magic header of parquet file: %w", err)
+		}
+		if string(b[:4]) != "PAR1" {
+			return nil, fmt.Errorf("invalid magic header of parquet file: %q", b[:4])
+		}
 	}
 
 	if cast, ok := f.reader.(interface{ SetMagicFooterSection(offset, length int64) }); ok {


### PR DESCRIPTION
This PR adds an option to skip reading magic bytes at the beginning of parquet files. The `PAR1` prefix is a useful indicator that the application is working with parquet files, but it is often unnecessary to read when we can trust the underlying data.

In scenarios like #188, this also likely removes one round trip to the storage layer, since we only need to read the footer to decode a parquet file schema and metadata.