### PR TITLE
use slices package

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -239,7 +240,7 @@ func BenchmarkSortGenericBuffer(b *testing.B) {
 		ID [16]byte
 	}
 
-	buf := parquet.NewGenericBuffer[Row](
+	buffer := parquet.NewGenericBuffer[Row](
 		parquet.SortingRowGroupConfig(
 			parquet.SortingColumns(
 				parquet.Ascending("ID"),
@@ -255,15 +256,15 @@ func BenchmarkSortGenericBuffer(b *testing.B) {
 		binary.LittleEndian.PutUint64(rows[i].ID[8:], ^uint64(i))
 	}
 
-	buf.Write(rows)
+	buffer.Write(rows)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 10; j++ {
-			buf.Swap(prng.Intn(len(rows)), prng.Intn(len(rows)))
+			buffer.Swap(prng.Intn(len(rows)), prng.Intn(len(rows)))
 		}
 
-		sort.Sort(buf)
+		sort.Sort(buffer)
 	}
 }
 
@@ -494,11 +495,12 @@ type sortFunc func(parquet.Type, []parquet.Value)
 func unordered(typ parquet.Type, values []parquet.Value) {}
 
 func ascending(typ parquet.Type, values []parquet.Value) {
-	sort.Slice(values, func(i, j int) bool { return typ.Compare(values[i], values[j]) < 0 })
+	slices.SortFunc(values, func(a, b parquet.Value) int { return typ.Compare(a, b) })
 }
 
 func descending(typ parquet.Type, values []parquet.Value) {
-	sort.Slice(values, func(i, j int) bool { return typ.Compare(values[i], values[j]) > 0 })
+	ascending(typ, values)
+	slices.Reverse(values)
 }
 
 func testBuffer(t *testing.T, node parquet.Node, buffer *parquet.Buffer, encoding encoding.Encoding, values []interface{}, sortFunc sortFunc) {
@@ -567,6 +569,7 @@ func testBuffer(t *testing.T, node parquet.Node, buffer *parquet.Buffer, encodin
 	// number of values as a proxy for the row indexes.
 	halfValues := numValues / 2
 
+scnearios:
 	for _, test := range [...]struct {
 		scenario string
 		values   []parquet.Value
@@ -583,20 +586,22 @@ func testBuffer(t *testing.T, node parquet.Node, buffer *parquet.Buffer, encodin
 			n, err := test.reader.ReadValues(v[:])
 			if n > 0 {
 				if n != 1 {
-					t.Fatalf("reading value from %q reader returned the wrong count: want=1 got=%d", test.scenario, n)
+					t.Errorf("reading value from %q reader returned the wrong count: want=1 got=%d", test.scenario, n)
+					continue scnearios
 				}
 				if i < len(test.values) {
 					if !parquet.Equal(v[0], test.values[i]) {
-						t.Fatalf("%q value at index %d mismatches: want=%v got=%v", test.scenario, i, test.values[i], v[0])
+						t.Errorf("%q value at index %d mismatches: want=%v got=%v", test.scenario, i, test.values[i], v[0])
+						continue scnearios
 					}
 				}
 				i++
 			}
 			if err != nil {
-				if err == io.EOF {
-					break
+				if err != io.EOF {
+					t.Errorf("reading value from %q reader: %v", test.scenario, err)
 				}
-				t.Fatalf("reading value from %q reader: %v", test.scenario, err)
+				break
 			}
 		}
 
@@ -911,21 +916,21 @@ func TestNullsSortFirst(t *testing.T) {
 		{A: nil},
 		{A: &str2},
 	}
-	buf := parquet.NewBuffer(
+	buffer := parquet.NewBuffer(
 		s,
 		parquet.SortingRowGroupConfig(parquet.SortingColumns(parquet.NullsFirst(parquet.Ascending(s.Columns()[0][0])))),
 	)
 	for _, rec := range records {
 		row := s.Deconstruct(nil, rec)
-		_, err := buf.WriteRows([]parquet.Row{row})
+		_, err := buffer.WriteRows([]parquet.Row{row})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	sort.Sort(buf)
+	sort.Sort(buffer)
 
-	rows := buf.Rows()
+	rows := buffer.Rows()
 	defer rows.Close()
 	rowBuf := make([]parquet.Row, len(records))
 	if _, err := rows.ReadRows(rowBuf); err != nil {

--- a/dedupe_test.go
+++ b/dedupe_test.go
@@ -1,7 +1,8 @@
 package parquet_test
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"testing"
 
 	"github.com/parquet-go/parquet-go"
@@ -27,8 +28,8 @@ func TestDedupeRowReader(t *testing.T) {
 		dedupeRows = append(dedupeRows, row)
 	}
 
-	sort.Slice(dedupeRows, func(i, j int) bool {
-		return dedupeRows[i].Value < dedupeRows[j].Value
+	slices.SortFunc(dedupeRows, func(a, b Row) int {
+		return cmp.Compare(a.Value, b.Value)
 	})
 
 	buffer1 := parquet.NewRowBuffer[Row]()
@@ -75,8 +76,8 @@ func TestDedupeRowWriter(t *testing.T) {
 		dedupeRows = append(dedupeRows, row)
 	}
 
-	sort.Slice(dedupeRows, func(i, j int) bool {
-		return dedupeRows[i].Value < dedupeRows[j].Value
+	slices.SortFunc(dedupeRows, func(a, b Row) int {
+		return cmp.Compare(a.Value, b.Value)
 	})
 
 	buffer1 := parquet.NewRowBuffer[Row]()

--- a/encoding/thrift/encode.go
+++ b/encoding/thrift/encode.go
@@ -2,10 +2,11 @@ package thrift
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"math"
 	"reflect"
-	"sort"
+	"slices"
 	"sync/atomic"
 )
 
@@ -360,8 +361,8 @@ func encodeFuncStructOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 		}
 	})
 
-	sort.SliceStable(enc.fields, func(i, j int) bool {
-		return enc.fields[i].id < enc.fields[j].id
+	slices.SortStableFunc(enc.fields, func(a, b structEncoderField) int {
+		return cmp.Compare(a.id, b.id)
 	})
 
 	for i := len(enc.fields) - 1; i > 0; i-- {

--- a/node.go
+++ b/node.go
@@ -2,7 +2,8 @@ package parquet
 
 import (
 	"reflect"
-	"sort"
+	"slices"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -288,8 +289,8 @@ func (g Group) Fields() []Field {
 			name: name,
 		})
 	}
-	sort.Slice(groupFields, func(i, j int) bool {
-		return groupFields[i].name < groupFields[j].name
+	slices.SortFunc(groupFields, func(a, b groupField) int {
+		return strings.Compare(a.name, b.name)
 	})
 	fields := make([]Field, len(groupFields))
 	for i := range groupFields {

--- a/order_test.go
+++ b/order_test.go
@@ -3,6 +3,7 @@ package parquet
 import (
 	"bytes"
 	"cmp"
+	"slices"
 	"sort"
 	"testing"
 
@@ -97,7 +98,7 @@ func TestOrderOfBool(t *testing.T) {
 		if !check(values) {
 			return false
 		}
-		sort.Sort(sort.Reverse(boolOrder(values)))
+		slices.Reverse(values)
 		if !check(values) {
 			return false
 		}
@@ -116,11 +117,11 @@ func TestOrderOfInt32(t *testing.T) {
 		if !check(values) {
 			return false
 		}
-		sort.Sort(int32Order(values))
+		slices.Sort(values)
 		if !check(values) {
 			return false
 		}
-		sort.Sort(sort.Reverse(int32Order(values)))
+		slices.Reverse(values)
 		if !check(values) {
 			return false
 		}
@@ -154,11 +155,11 @@ func TestOrderOfInt64(t *testing.T) {
 		if !check(values) {
 			return false
 		}
-		sort.Sort(int64Order(values))
+		slices.Sort(values)
 		if !check(values) {
 			return false
 		}
-		sort.Sort(sort.Reverse(int64Order(values)))
+		slices.Reverse(values)
 		if !check(values) {
 			return false
 		}
@@ -188,11 +189,11 @@ func TestOrderOfUint32(t *testing.T) {
 		if !check(values) {
 			return false
 		}
-		sort.Sort(uint32Order(values))
+		slices.Sort(values)
 		if !check(values) {
 			return false
 		}
-		sort.Sort(sort.Reverse(uint32Order(values)))
+		slices.Reverse(values)
 		if !check(values) {
 			return false
 		}
@@ -222,11 +223,11 @@ func TestOrderOfUint64(t *testing.T) {
 		if !check(values) {
 			return false
 		}
-		sort.Sort(uint64Order(values))
+		slices.Sort(values)
 		if !check(values) {
 			return false
 		}
-		sort.Sort(sort.Reverse(uint64Order(values)))
+		slices.Reverse(values)
 		if !check(values) {
 			return false
 		}
@@ -256,11 +257,11 @@ func TestOrderOfFloat32(t *testing.T) {
 		if !check(values) {
 			return false
 		}
-		sort.Sort(float32Order(values))
+		slices.Sort(values)
 		if !check(values) {
 			return false
 		}
-		sort.Sort(sort.Reverse(float32Order(values)))
+		slices.Reverse(values)
 		if !check(values) {
 			return false
 		}
@@ -290,11 +291,11 @@ func TestOrderOfFloat64(t *testing.T) {
 		if !check(values) {
 			return false
 		}
-		sort.Sort(float64Order(values))
+		slices.Sort(values)
 		if !check(values) {
 			return false
 		}
-		sort.Sort(sort.Reverse(float64Order(values)))
+		slices.Reverse(values)
 		if !check(values) {
 			return false
 		}
@@ -321,19 +322,19 @@ func TestOrderOfBytes(t *testing.T) {
 		return checkOrdering(t, bytesOrder(values), orderOfBytes(values))
 	}
 	err := quick.Check(func(values [][16]byte) bool {
-		slices := make([][]byte, len(values))
+		byteSlices := make([][]byte, len(values))
 		for i := range values {
-			slices[i] = values[i][:]
+			byteSlices[i] = values[i][:]
 		}
-		if !check(slices) {
+		if !check(byteSlices) {
 			return false
 		}
-		sort.Sort(bytesOrder(slices))
-		if !check(slices) {
+		slices.SortFunc(byteSlices, bytes.Compare)
+		if !check(byteSlices) {
 			return false
 		}
-		sort.Sort(sort.Reverse(bytesOrder(slices)))
-		if !check(slices) {
+		slices.Reverse(byteSlices)
+		if !check(byteSlices) {
 			return false
 		}
 		return true

--- a/row_buffer_test.go
+++ b/row_buffer_test.go
@@ -271,7 +271,7 @@ func BenchmarkSortRowBuffer(b *testing.B) {
 		ID [16]byte
 	}
 
-	buf := parquet.NewRowBuffer[Row](
+	buffer := parquet.NewRowBuffer[Row](
 		parquet.SortingRowGroupConfig(
 			parquet.SortingColumns(
 				parquet.Ascending("ID"),
@@ -287,15 +287,15 @@ func BenchmarkSortRowBuffer(b *testing.B) {
 		binary.LittleEndian.PutUint64(rows[i].ID[8:], ^uint64(i))
 	}
 
-	buf.Write(rows)
+	buffer.Write(rows)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 10; j++ {
-			buf.Swap(prng.Intn(len(rows)), prng.Intn(len(rows)))
+			buffer.Swap(prng.Intn(len(rows)), prng.Intn(len(rows)))
 		}
 
-		sort.Sort(buf)
+		sort.Sort(buffer)
 	}
 }
 

--- a/writer.go
+++ b/writer.go
@@ -3,6 +3,7 @@ package parquet
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -12,7 +13,6 @@ import (
 	"os"
 	"reflect"
 	"slices"
-	"sort"
 
 	"github.com/parquet-go/parquet-go/compress"
 	"github.com/parquet-go/parquet-go/encoding"
@@ -1669,19 +1669,15 @@ addPages:
 }
 
 func sortPageEncodings(encodings []format.Encoding) {
-	sort.Slice(encodings, func(i, j int) bool {
-		return encodings[i] < encodings[j]
-	})
+	slices.Sort(encodings)
 }
 
 func sortPageEncodingStats(stats []format.PageEncodingStats) {
-	sort.Slice(stats, func(i, j int) bool {
-		s1 := &stats[i]
-		s2 := &stats[j]
-		if s1.PageType != s2.PageType {
-			return s1.PageType < s2.PageType
+	slices.SortFunc(stats, func(s1, s2 format.PageEncodingStats) int {
+		if k := cmp.Compare(s1.PageType, s2.PageType); k != 0 {
+			return k
 		}
-		return s1.Encoding < s2.Encoding
+		return cmp.Compare(s1.Encoding, s2.Encoding)
 	})
 }
 


### PR DESCRIPTION
This pull request updates the code base to use the `slices` package instead of `sort` wherever we work on slices. This is a simple maintenance work that improves type safety and modernizes the code a bit.