### PR TITLE
add read mode to NewRowGroupRowReader

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -431,7 +431,7 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 //
 // The buffer and the returned reader share memory. Mutating the buffer
 // concurrently to reading rows may result in non-deterministic behavior.
-func (buf *Buffer) Rows() Rows { return newRowGroupRows(buf, ReadModeSync) }
+func (buf *Buffer) Rows() Rows { return NewRowGroupRowReader(buf, ReadModeSync) }
 
 // bufferWriter is an adapter for Buffer which implements both RowWriter and
 // PageWriter to enable optimizations in CopyRows for types that support writing

--- a/file.go
+++ b/file.go
@@ -421,7 +421,7 @@ func (g *fileRowGroup) Schema() *Schema                 { return g.schema }
 func (g *fileRowGroup) NumRows() int64                  { return g.rowGroup.NumRows }
 func (g *fileRowGroup) ColumnChunks() []ColumnChunk     { return g.columns }
 func (g *fileRowGroup) SortingColumns() []SortingColumn { return g.sorting }
-func (g *fileRowGroup) Rows() Rows                      { return newRowGroupRows(g, g.config.ReadMode) }
+func (g *fileRowGroup) Rows() Rows                      { return NewRowGroupRowReader(g, g.config.ReadMode) }
 
 type fileSortingColumn struct {
 	column     *Column

--- a/multi_row_group.go
+++ b/multi_row_group.go
@@ -109,7 +109,7 @@ func (c *multiRowGroup) SortingColumns() []SortingColumn { return nil }
 
 func (c *multiRowGroup) Schema() *Schema { return c.schema }
 
-func (c *multiRowGroup) Rows() Rows { return newRowGroupRows(c, c.pageReadMode) }
+func (c *multiRowGroup) Rows() Rows { return NewRowGroupRowReader(c, c.pageReadMode) }
 
 type multiColumnChunk struct {
 	rowGroup *multiRowGroup

--- a/row_group.go
+++ b/row_group.go
@@ -163,11 +163,7 @@ func (r *rowGroup) NumRows() int64                  { return r.numRows }
 func (r *rowGroup) ColumnChunks() []ColumnChunk     { return r.columns }
 func (r *rowGroup) SortingColumns() []SortingColumn { return r.sorting }
 func (r *rowGroup) Schema() *Schema                 { return r.schema }
-func (r *rowGroup) Rows() Rows                      { return newRowGroupRows(r, ReadModeSync) }
-
-func NewRowGroupRowReader(rowGroup RowGroup) Rows {
-	return newRowGroupRows(rowGroup, ReadModeSync)
-}
+func (r *rowGroup) Rows() Rows                      { return NewRowGroupRowReader(r, ReadModeSync) }
 
 type rowGroupRows struct {
 	rowGroup     RowGroup
@@ -196,7 +192,7 @@ func (r *rowGroupRows) buffer(i int) []Value {
 	return r.buffers[j:k:k]
 }
 
-func newRowGroupRows(rowGroup RowGroup, pageReadMode ReadMode) *rowGroupRows {
+func NewRowGroupRowReader(rowGroup RowGroup, pageReadMode ReadMode) Rows {
 	return &rowGroupRows{
 		rowGroup:     rowGroup,
 		pageReadMode: pageReadMode,


### PR DESCRIPTION
This PR changes the signature of `NewRowGroupRowReader` to take a read mode as argument, enabling programs to create a row group row reader in async mode when it's useful.

This is a breaking change, but I don't expect this migration to be hard to make, the compiler will pick up any misuse of the code, and usage of this API shouldn't be very common since programs would typically call `.Rows()` on row groups to get a reader over the rows.

Let me know if you have any concerns.