### PR TITLE
fix definition levels of typed optional list

### DIFF
--- a/column_buffer_test.go
+++ b/column_buffer_test.go
@@ -2,7 +2,7 @@ package parquet
 
 import (
 	"bytes"
-	"slices"
+	"reflect"
 	"testing"
 )
 
@@ -51,7 +51,7 @@ func TestWriteAndReadOptionalList(t *testing.T) {
 
 	records := []record{
 		{Values: []float64{1.0, 2.0, 3.0}},
-		{Values: nil},
+		{Values: []float64{}},
 		{Values: []float64{4.0, 5.0}},
 	}
 
@@ -65,9 +65,7 @@ func TestWriteAndReadOptionalList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !slices.EqualFunc(records, found, func(a, b record) bool {
-		return slices.Equal(a.Values, b.Values)
-	}) {
+	if !reflect.DeepEqual(records, found) {
 		t.Fatalf("expected %v, got %v", records, found)
 	}
 }
@@ -94,7 +92,7 @@ func TestWriteAndReadOptionalPointer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !slices.Equal(records, found) {
+	if !reflect.DeepEqual(records, found) {
 		t.Fatalf("expected %v, got %v", records, found)
 	}
 }

--- a/column_buffer_test.go
+++ b/column_buffer_test.go
@@ -1,6 +1,8 @@
 package parquet
 
 import (
+	"bytes"
+	"slices"
 	"testing"
 )
 
@@ -40,6 +42,61 @@ func BenchmarkBroadcastRangeInt32(b *testing.B) {
 		broadcastRangeInt32(buf, 0)
 	}
 	b.SetBytes(4 * int64(len(buf)))
+}
+
+func TestWriteAndReadOptionalList(t *testing.T) {
+	type record struct {
+		Values []float64 `parquet:"values,list,optional"`
+	}
+
+	records := []record{
+		{Values: []float64{1.0, 2.0, 3.0}},
+		{Values: nil},
+		{Values: []float64{4.0, 5.0}},
+	}
+
+	buffer := new(bytes.Buffer)
+	if err := Write(buffer, records); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := Read[record](bytes.NewReader(buffer.Bytes()), int64(buffer.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.EqualFunc(records, found, func(a, b record) bool {
+		return slices.Equal(a.Values, b.Values)
+	}) {
+		t.Fatalf("expected %v, got %v", records, found)
+	}
+}
+
+func TestWriteAndReadOptionalPointer(t *testing.T) {
+	type record struct {
+		Value float64 `parquet:"values,optional"`
+	}
+
+	records := []record{
+		{Value: 1.0},
+		{Value: 0.0},
+		{Value: 2.0},
+		{Value: 0.0},
+	}
+
+	buffer := new(bytes.Buffer)
+	if err := Write(buffer, records); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := Read[record](bytes.NewReader(buffer.Bytes()), int64(buffer.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(records, found) {
+		t.Fatalf("expected %v, got %v", records, found)
+	}
 }
 
 // https://github.com/segmentio/parquet-go/issues/501

--- a/reader_test.go
+++ b/reader_test.go
@@ -114,7 +114,7 @@ func TestIssue400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = w.Close(); err != nil {
+	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,8 +124,8 @@ func TestIssue400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(expect[0], values[0]) {
-		t.Errorf("want %q got %q", values[0], expect[0])
+	if !reflect.DeepEqual(expect, values) {
+		t.Errorf("want %v got %v", expect, values)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug that would trigger on an edge case where using a generic writer with type parameters and writing struct fields of slice type with both the `optional` and `list` tags set, for example:

```go
type record struct {
  Values []float64 `parquet:",list,optional"`
}
```

Under those conditions, the definition levels were miscalculated, which resulted in all null values on those fields when reading the files back.