### PR TITLE
Lazy load schema state

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -2047,7 +2047,7 @@ func writeRowsFuncOf(t reflect.Type, schema *Schema, path columnPath) writeRowsF
 }
 
 func writeRowsFuncOfRequired(t reflect.Type, schema *Schema, path columnPath) writeRowsFunc {
-	column := schema.mapping.lookup(path)
+	column := schema.lazyLoadState().mapping.lookup(path)
 	columnIndex := column.columnIndex
 	return func(columns []ColumnBuffer, rows sparse.Array, levels columnLevels) error {
 		columns[columnIndex].writeValues(rows, levels)
@@ -2164,7 +2164,7 @@ func writeRowsFuncOfOptional(t reflect.Type, schema *Schema, path columnPath, wr
 }
 
 func writeRowsFuncOfArray(t reflect.Type, schema *Schema, path columnPath) writeRowsFunc {
-	column := schema.mapping.lookup(path)
+	column := schema.lazyLoadState().mapping.lookup(path)
 	arrayLen := t.Len()
 	columnLen := column.node.Type().Length()
 	if arrayLen != columnLen {

--- a/schema.go
+++ b/schema.go
@@ -19,9 +19,18 @@ import (
 //
 // Schema implements the Node interface to represent the root node of a parquet
 // schema.
+//
+// Schema values are safe to use concurrently from multiple goroutines but must
+// be passed by referenced after being created because their internal state
+// contains synchronization primitives that are not safe to copy.
 type Schema struct {
-	name        string
-	root        Node
+	name  string
+	root  Node
+	once  sync.Once
+	state *schemaState
+}
+
+type schemaState struct {
 	deconstruct deconstructFunc
 	reconstruct reconstructFunc
 	mapping     columnMapping
@@ -123,15 +132,7 @@ func schemaOf(model reflect.Type) *Schema {
 // The function panics if Node contains more leaf columns than supported by the
 // package (see parquet.MaxColumnIndex).
 func NewSchema(name string, root Node) *Schema {
-	mapping, columns := columnMappingOf(root)
-	return &Schema{
-		name:        name,
-		root:        root,
-		deconstruct: makeDeconstructFunc(root),
-		reconstruct: makeReconstructFunc(root),
-		mapping:     mapping,
-		columns:     columns,
-	}
+	return &Schema{name: name, root: root}
 }
 
 func dereference(t reflect.Type) reflect.Type {
@@ -143,7 +144,7 @@ func dereference(t reflect.Type) reflect.Type {
 
 func makeDeconstructFunc(node Node) (deconstruct deconstructFunc) {
 	if schema, _ := node.(*Schema); schema != nil {
-		return schema.deconstruct
+		return schema.lazyLoadState().deconstruct
 	}
 	if !node.Leaf() {
 		_, deconstruct = deconstructFuncOf(0, node)
@@ -153,12 +154,25 @@ func makeDeconstructFunc(node Node) (deconstruct deconstructFunc) {
 
 func makeReconstructFunc(node Node) (reconstruct reconstructFunc) {
 	if schema, _ := node.(*Schema); schema != nil {
-		return schema.reconstruct
+		return schema.lazyLoadState().reconstruct
 	}
 	if !node.Leaf() {
 		_, reconstruct = reconstructFuncOf(0, node)
 	}
 	return reconstruct
+}
+
+func (s *Schema) lazyLoadState() *schemaState {
+	s.once.Do(func() {
+		mapping, columns := columnMappingOf(s.root)
+		s.state = &schemaState{
+			deconstruct: makeDeconstructFunc(s.root),
+			reconstruct: makeReconstructFunc(s.root),
+			mapping:     mapping,
+			columns:     columns,
+		}
+	})
+	return s.state
 }
 
 // ConfigureRowGroup satisfies the RowGroupOption interface, allowing Schema
@@ -218,26 +232,24 @@ func (s *Schema) GoType() reflect.Type { return s.root.GoType() }
 // The method panics is the structure of the go value does not match the
 // parquet schema.
 func (s *Schema) Deconstruct(row Row, value interface{}) Row {
-	columns := make([][]Value, len(s.columns))
-	values := make([]Value, len(s.columns))
+	state := s.lazyLoadState()
+	columns := make([][]Value, len(state.columns))
+	values := make([]Value, len(state.columns))
 
 	for i := range columns {
 		columns[i] = values[i : i : i+1]
 	}
 
-	s.deconstructValueToColumns(columns, reflect.ValueOf(value))
-	return appendRow(row, columns)
-}
-
-func (s *Schema) deconstructValueToColumns(columns [][]Value, value reflect.Value) {
-	for value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
-		if value.IsNil() {
-			value = reflect.Value{}
+	v := reflect.ValueOf(value)
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			v = reflect.Value{}
 			break
 		}
-		value = value.Elem()
+		v = v.Elem()
 	}
-	s.deconstruct(columns, levels{}, value)
+	state.deconstruct(columns, levels{}, v)
+	return appendRow(row, columns)
 }
 
 // Reconstruct reconstructs a Go value from a row.
@@ -267,7 +279,8 @@ func (s *Schema) Reconstruct(value interface{}, row Row) error {
 
 	b := valuesSliceBufferPool.Get().(*valuesSliceBuffer)
 
-	columns := b.reserve(len(s.columns))
+	state := s.lazyLoadState()
+	columns := b.reserve(len(state.columns))
 	row.Range(func(columnIndex int, columnValues []Value) bool {
 		if columnIndex < len(columns) {
 			columns[columnIndex] = columnValues
@@ -275,7 +288,7 @@ func (s *Schema) Reconstruct(value interface{}, row Row) error {
 		return true
 	})
 	// we avoid the defer penalty by releasing b manually
-	err := s.reconstruct(v, levels{}, columns)
+	err := state.reconstruct(v, levels{}, columns)
 	b.release()
 	return err
 }
@@ -320,7 +333,7 @@ var valuesSliceBufferPool = &sync.Pool{
 // If the path was not found in the mapping, or if it did not represent a
 // leaf column of the parquet schema, the boolean will be false.
 func (s *Schema) Lookup(path ...string) (LeafColumn, bool) {
-	leaf := s.mapping.lookup(path)
+	leaf := s.lazyLoadState().mapping.lookup(path)
 	return LeafColumn{
 		Node:               leaf.node,
 		Path:               leaf.path,
@@ -334,9 +347,7 @@ func (s *Schema) Lookup(path ...string) (LeafColumn, bool) {
 //
 // The method always returns the same slice value across calls to ColumnPaths,
 // applications should treat it as immutable.
-func (s *Schema) Columns() [][]string {
-	return s.columns
-}
+func (s *Schema) Columns() [][]string { return s.lazyLoadState().columns }
 
 // Comparator constructs a comparator function which orders rows according to
 // the list of sorting columns passed as arguments.


### PR DESCRIPTION
In many cases, when constructing a schema, only subparts of it will be accessed. For example, if the schema is used as a wrapper for a pre-constructed `parquet.Node`. The inner state of the `parquet.Schema` type contains parts that are only needed under special circumstances.

This PR modifies the `parquet.Schema` implementation to lazily load parts of the schema depending on the application's usage of it. This avoids creating the column mapping or deconstructor/reconstructor functions.