### PR TITLE
docs: Fix MergeRowGroups example

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ if err != nil {
 }
 
 writer := parquet.NewGenericWriter[RowType](output)
-_, err := parquet.CopyRows(writer, merge)
+_, err := parquet.CopyRows(writer, merge.Rows())
 if err != nil {
     ...
 }


### PR DESCRIPTION
Updates outdated example of MergeRowGroups.

Closes #207.