### PR TITLE
fix: Correct conversion order in convertToType function

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -86,7 +86,7 @@ func convertToSelf(column []Value) error { return nil }
 func convertToType(targetType, sourceType Type) conversionFunc {
 	return func(column []Value) error {
 		for i, v := range column {
-			v, err := sourceType.ConvertValue(v, targetType)
+			v, err := targetType.ConvertValue(v, sourceType)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The interface as defined at:

 https://github.com/parquet-go/parquet-go/blob/main/type.go#L210-L213 

The parameter `typ` is the conversion's **source** type, and the receiver defines the **target** type. 
This was accidentally reversed in this usage. 