### PR TITLE
Expose `FileColumnChunk` with methods to provide a `ReaderAt`

### DIFF
--- a/column.go
+++ b/column.go
@@ -92,6 +92,10 @@ func (c *Column) Column(name string) *Column {
 
 // Pages returns a reader exposing all pages in this column, across row groups.
 func (c *Column) Pages() Pages {
+	return c.PagesFrom(c.file.reader)
+}
+
+func (c *Column) PagesFrom(reader io.ReaderAt) Pages {
 	if c.index < 0 {
 		return emptyPages{}
 	}
@@ -99,7 +103,7 @@ func (c *Column) Pages() Pages {
 		pages: make([]filePages, len(c.file.rowGroups)),
 	}
 	for i := range r.pages {
-		r.pages[i].init(c.file.rowGroups[i].(*fileRowGroup).columns[c.index].(*fileColumnChunk))
+		r.pages[i].init(c.file.rowGroups[i].(*fileRowGroup).columns[c.index].(*FileColumnChunk), reader)
 	}
 	return r
 }

--- a/column_index_be.go
+++ b/column_index_be.go
@@ -6,11 +6,12 @@ package parquet
 
 import (
 	"encoding/binary"
+	"math"
+
 	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding/plain"
 	"github.com/parquet-go/parquet-go/format"
 	"github.com/parquet-go/parquet-go/internal/unsafecast"
-	"math"
 )
 
 type ColumnIndex interface {
@@ -90,7 +91,7 @@ func (f *formatColumnIndex) IsDescending() bool {
 	return f.index.BoundaryOrder == format.Descending
 }
 
-type fileColumnIndex struct{ chunk *fileColumnChunk }
+type fileColumnIndex struct{ chunk *FileColumnChunk }
 
 func (i fileColumnIndex) NumPages() int {
 	return len(i.columnIndex().NullPages)

--- a/column_index_le.go
+++ b/column_index_le.go
@@ -88,7 +88,7 @@ func (f *formatColumnIndex) IsDescending() bool {
 	return f.index.BoundaryOrder == format.Descending
 }
 
-type fileColumnIndex struct{ chunk *fileColumnChunk }
+type fileColumnIndex struct{ chunk *FileColumnChunk }
 
 func (i fileColumnIndex) NumPages() int {
 	return len(i.columnIndex().NullPages)


### PR DESCRIPTION
In some cases it would be useful to read Column Chunks using a `ReaderAt` separate from the one coupled to the column chunk's row group's `File`. 

This PR does the following:
1. Adds methods to `fileColumnChunk` to support providing a `ReaderAt`
1. Exposes the `fileColumnChunk` -> `FileColumnChunk` type, so that we can preserve the existing `ColumnChunk` interface, while allowing callers to type assert to `FileColumnChunk` if they need to use the new methods that accept a `ReaderAt`