### PR TITLE
fix issue 199

### DIFF
--- a/bloom/xxhash/sum64uint_amd64.s
+++ b/bloom/xxhash/sum64uint_amd64.s
@@ -65,8 +65,8 @@ passing as a guarantee that they have not introduced regressions.
 #define prime1 R12
 #define prime2 R13
 #define prime3 R14
-#define prime4 R15
-#define prime5 R15 // same as prime4 because they are not used together
+#define prime4 R11
+#define prime5 R11 // same as prime4 because they are not used together
 
 #define prime1ZMM Z12
 #define prime2ZMM Z13

--- a/encoding/rle/rle_amd64_test.go
+++ b/encoding/rle/rle_amd64_test.go
@@ -3,20 +3,34 @@
 
 package rle
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/sys/cpu"
+)
+
+func requireAVX2(tb testing.TB) {
+	if !cpu.X86.HasAVX2 {
+		tb.Skip("AVX2 not supported")
+	}
+}
 
 func TestEncodeInt32IndexEqual8ContiguousAVX2(t *testing.T) {
+	requireAVX2(t)
 	testEncodeInt32IndexEqual8Contiguous(t, encodeInt32IndexEqual8ContiguousAVX2)
 }
 
 func TestEncodeInt32IndexEqual8ContiguousSSE(t *testing.T) {
+	requireAVX2(t)
 	testEncodeInt32IndexEqual8Contiguous(t, encodeInt32IndexEqual8ContiguousSSE)
 }
 
 func BenchmarkEncodeInt32IndexEqual8ContiguousAVX2(b *testing.B) {
+	requireAVX2(b)
 	benchmarkEncodeInt32IndexEqual8Contiguous(b, encodeInt32IndexEqual8ContiguousAVX2)
 }
 
 func BenchmarkEncodeInt32IndexEqual8ContiguousSSE(b *testing.B) {
+	requireAVX2(b)
 	benchmarkEncodeInt32IndexEqual8Contiguous(b, encodeInt32IndexEqual8ContiguousSSE)
 }

--- a/internal/bytealg/count_amd64.s
+++ b/internal/bytealg/count_amd64.s
@@ -20,7 +20,7 @@ TEXT ·Count(SB), NOSPLIT, $0-40
     XORQ R12, R12
     XORQ R13, R13
     XORQ R14, R14
-    XORQ R15, R15
+    XORQ DI, DI
 
     CMPB ·hasAVX512Count(SB), $0
     JE initAVX2
@@ -49,14 +49,14 @@ loopAVX512:
     ADDQ R8, R12
     ADDQ R9, R13
     ADDQ R10, R14
-    ADDQ R11, R15
+    ADDQ R11, DI
     ADDQ $256, AX
     CMPQ AX, DX
     JNE loopAVX512
     ADDQ R12, R13
-    ADDQ R14, R15
+    ADDQ R14, DI
     ADDQ R13, SI
-    ADDQ R15, SI
+    ADDQ DI, SI
     JMP doneAVX
 
 initAVX2:
@@ -74,12 +74,12 @@ loopAVX2:
     POPCNTL R12, R12
     POPCNTL R13, R13
     ADDQ R12, R14
-    ADDQ R13, R15
+    ADDQ R13, DI
     ADDQ $64, AX
     CMPQ AX, DX
     JNE loopAVX2
     ADDQ R14, SI
-    ADDQ R15, SI
+    ADDQ DI, SI
 
 doneAVX:
     VZEROUPPER


### PR DESCRIPTION
Fixes #199 

The previous attempt in #211 caused file corruption due to an invalid reuse of register R8 in `bytealg.Count`, I reverted the change and I'm submitting this as a proper fix.
