### PR TITLE
feat: parameterize Time/Timestamp IsAdjustedToUTC

### DIFF
--- a/type.go
+++ b/type.go
@@ -1803,10 +1803,19 @@ func (u *nanosecond) TimeUnit() format.TimeUnit {
 }
 
 // Time constructs a leaf node of TIME logical type.
+// IsAdjustedToUTC is true by default.
 //
 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time
 func Time(unit TimeUnit) Node {
-	return Leaf(&timeType{IsAdjustedToUTC: true, Unit: unit.TimeUnit()})
+	return TimeAdjusted(unit, true)
+}
+
+// TimeAdjusted constructs a leaf node of TIME logical type
+// with the IsAdjustedToUTC property explicitly set.
+//
+// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time
+func TimeAdjusted(unit TimeUnit, isAdjustedToUTC bool) Node {
+	return Leaf(&timeType{IsAdjustedToUTC: isAdjustedToUTC, Unit: unit.TimeUnit()})
 }
 
 type timeType format.TimeType
@@ -1919,10 +1928,19 @@ func (t *timeType) ConvertValue(val Value, typ Type) (Value, error) {
 }
 
 // Timestamp constructs of leaf node of TIMESTAMP logical type.
+// IsAdjustedToUTC is true by default.
 //
 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp
 func Timestamp(unit TimeUnit) Node {
-	return Leaf(&timestampType{IsAdjustedToUTC: true, Unit: unit.TimeUnit()})
+	return TimestampAdjusted(unit, true)
+}
+
+// TimestampAdjusted constructs a leaf node of TIMESTAMP logical type
+// with the IsAdjustedToUTC property explicitly set.
+//
+// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#time
+func TimestampAdjusted(unit TimeUnit, isAdjustedToUTC bool) Node {
+	return Leaf(&timestampType{IsAdjustedToUTC: isAdjustedToUTC, Unit: unit.TimeUnit()})
 }
 
 type timestampType format.TimestampType


### PR DESCRIPTION
Add constructors `TimestampAdjusted(unit TimeUnit, isAdjustedToUTC bool)` and `TimeAdjusted(unit TimeUnit, isAdjustedToUTC bool)` for compatibility with Apache Iceberg.

[Apache Iceberg specifically requires](https://iceberg.apache.org/spec/#parquet) that `time` fields have `adjustToUtc=false`, but this library is hard-coded to `true`. Similarly, Iceberg `timestamp` and `timestamptz` fields differ only by whether `adjustToUtc` is false (`timestamp`) or true (`timestamptz`).