### PR TITLE
feat: export NodesAreEqual

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -414,7 +414,7 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 		return 0, ErrRowGroupSchemaMissing
 	case buf.schema == nil:
 		buf.configure(rowGroupSchema)
-	case !nodesAreEqual(buf.schema, rowGroupSchema):
+	case !NodesAreEqual(buf.schema, rowGroupSchema):
 		return 0, ErrRowGroupSchemaMismatch
 	}
 	if !sortingColumnsHavePrefix(rowGroup.SortingColumns(), buf.SortingColumns()) {

--- a/buffer.go
+++ b/buffer.go
@@ -414,7 +414,7 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 		return 0, ErrRowGroupSchemaMissing
 	case buf.schema == nil:
 		buf.configure(rowGroupSchema)
-	case !NodesAreEqual(buf.schema, rowGroupSchema):
+	case !EqualNodes(buf.schema, rowGroupSchema):
 		return 0, ErrRowGroupSchemaMismatch
 	}
 	if !sortingColumnsHavePrefix(rowGroup.SortingColumns(), buf.SortingColumns()) {

--- a/convert.go
+++ b/convert.go
@@ -249,7 +249,7 @@ func Convert(to, from Node) (conv Conversion, err error) {
 		schema = NewSchema("", to)
 	}
 
-	if nodesAreEqual(to, from) {
+	if NodesAreEqual(to, from) {
 		return identity{schema}, nil
 	}
 

--- a/convert.go
+++ b/convert.go
@@ -249,7 +249,7 @@ func Convert(to, from Node) (conv Conversion, err error) {
 		schema = NewSchema("", to)
 	}
 
-	if NodesAreEqual(to, from) {
+	if EqualNodes(to, from) {
 		return identity{schema}, nil
 	}
 

--- a/merge.go
+++ b/merge.go
@@ -33,7 +33,7 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 		schema = rowGroups[0].Schema()
 
 		for _, rowGroup := range rowGroups[1:] {
-			if !nodesAreEqual(schema, rowGroup.Schema()) {
+			if !NodesAreEqual(schema, rowGroup.Schema()) {
 				return nil, ErrRowGroupSchemaMismatch
 			}
 		}
@@ -43,7 +43,7 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 	copy(mergedRowGroups, rowGroups)
 
 	for i, rowGroup := range mergedRowGroups {
-		if rowGroupSchema := rowGroup.Schema(); !nodesAreEqual(schema, rowGroupSchema) {
+		if rowGroupSchema := rowGroup.Schema(); !NodesAreEqual(schema, rowGroupSchema) {
 			conv, err := Convert(schema, rowGroupSchema)
 			if err != nil {
 				return nil, fmt.Errorf("cannot merge row groups: %w", err)

--- a/merge.go
+++ b/merge.go
@@ -33,7 +33,7 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 		schema = rowGroups[0].Schema()
 
 		for _, rowGroup := range rowGroups[1:] {
-			if !NodesAreEqual(schema, rowGroup.Schema()) {
+			if !EqualNodes(schema, rowGroup.Schema()) {
 				return nil, ErrRowGroupSchemaMismatch
 			}
 		}
@@ -43,7 +43,7 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 	copy(mergedRowGroups, rowGroups)
 
 	for i, rowGroup := range mergedRowGroups {
-		if rowGroupSchema := rowGroup.Schema(); !NodesAreEqual(schema, rowGroupSchema) {
+		if rowGroupSchema := rowGroup.Schema(); !EqualNodes(schema, rowGroupSchema) {
 			conv, err := Convert(schema, rowGroupSchema)
 			if err != nil {
 				return nil, fmt.Errorf("cannot merge row groups: %w", err)

--- a/multi_row_group.go
+++ b/multi_row_group.go
@@ -81,7 +81,7 @@ func compatibleSchemaOf(rowGroups []RowGroup) (*Schema, error) {
 	// Slow path: The schema pointers are not the same, but they still have to
 	// be compatible.
 	for _, rowGroup := range rowGroups[1:] {
-		if !NodesAreEqual(schema, rowGroup.Schema()) {
+		if !EqualNodes(schema, rowGroup.Schema()) {
 			return nil, ErrRowGroupSchemaMismatch
 		}
 	}

--- a/multi_row_group.go
+++ b/multi_row_group.go
@@ -81,7 +81,7 @@ func compatibleSchemaOf(rowGroups []RowGroup) (*Schema, error) {
 	// Slow path: The schema pointers are not the same, but they still have to
 	// be compatible.
 	for _, rowGroup := range rowGroups[1:] {
-		if !nodesAreEqual(schema, rowGroup.Schema()) {
+		if !NodesAreEqual(schema, rowGroup.Schema()) {
 			return nil, ErrRowGroupSchemaMismatch
 		}
 	}

--- a/node.go
+++ b/node.go
@@ -487,7 +487,8 @@ func fieldByName(node Node, name string) Field {
 	return nil
 }
 
-func nodesAreEqual(node1, node2 Node) bool {
+// NodesAreEqual compares two parquet nodes and returns true if they are equal.
+func NodesAreEqual(node1, node2 Node) bool {
 	if node1.Leaf() {
 		return node2.Leaf() && leafNodesAreEqual(node1, node2)
 	} else {
@@ -529,7 +530,7 @@ func groupNodesAreEqual(node1, node2 Node) bool {
 			return false
 		}
 
-		if !nodesAreEqual(f1, f2) {
+		if !NodesAreEqual(f1, f2) {
 			return false
 		}
 	}

--- a/node.go
+++ b/node.go
@@ -487,8 +487,15 @@ func fieldByName(node Node, name string) Field {
 	return nil
 }
 
-// NodesAreEqual compares two parquet nodes and returns true if they are equal.
-func NodesAreEqual(node1, node2 Node) bool {
+// EqualNodes returns true if node1 and node2 are equal.
+//
+// Nodes that are not of the same repetition type (optional, required, repeated) or
+// of the same hierarchical type (leaf, group) are considered not equal.
+// Leaf nodes are considered equal if they are of the same data type.
+// Group nodes are considered equal if their fields have the same names and are recursively equal.
+//
+// Note that the encoding and compression of the nodes are not considered by this function.
+func EqualNodes(node1, node2 Node) bool {
 	if node1.Leaf() {
 		return node2.Leaf() && leafNodesAreEqual(node1, node2)
 	} else {
@@ -530,7 +537,7 @@ func groupNodesAreEqual(node1, node2 Node) bool {
 			return false
 		}
 
-		if !NodesAreEqual(f1, f2) {
+		if !EqualNodes(f1, f2) {
 			return false
 		}
 	}

--- a/reader.go
+++ b/reader.go
@@ -57,7 +57,7 @@ func NewGenericReader[T any](input io.ReaderAt, options ...ReaderOption) *Generi
 		},
 	}
 
-	if !NodesAreEqual(c.Schema, f.schema) {
+	if !EqualNodes(c.Schema, f.schema) {
 		r.base.file.rowGroup = convertRowGroupTo(r.base.file.rowGroup, c.Schema)
 	}
 
@@ -90,7 +90,7 @@ func NewGenericRowGroupReader[T any](rowGroup RowGroup, options ...ReaderOption)
 		},
 	}
 
-	if !NodesAreEqual(c.Schema, rowGroup.Schema()) {
+	if !EqualNodes(c.Schema, rowGroup.Schema()) {
 		r.base.file.rowGroup = convertRowGroupTo(r.base.file.rowGroup, c.Schema)
 	}
 
@@ -337,7 +337,7 @@ func NewRowGroupReader(rowGroup RowGroup, options ...ReaderOption) *Reader {
 }
 
 func convertRowGroupTo(rowGroup RowGroup, schema *Schema) RowGroup {
-	if rowGroupSchema := rowGroup.Schema(); !NodesAreEqual(schema, rowGroupSchema) {
+	if rowGroupSchema := rowGroup.Schema(); !EqualNodes(schema, rowGroupSchema) {
 		conv, err := Convert(schema, rowGroupSchema)
 		if err != nil {
 			// TODO: this looks like something we should not be panicking on,
@@ -416,7 +416,7 @@ func (r *Reader) Read(row interface{}) error {
 func (r *Reader) updateReadSchema(rowType reflect.Type) error {
 	schema := schemaOf(rowType)
 
-	if NodesAreEqual(schema, r.file.schema) {
+	if EqualNodes(schema, r.file.schema) {
 		r.read.init(schema, r.file.rowGroup)
 	} else {
 		conv, err := Convert(schema, r.file.schema)

--- a/reader.go
+++ b/reader.go
@@ -57,7 +57,7 @@ func NewGenericReader[T any](input io.ReaderAt, options ...ReaderOption) *Generi
 		},
 	}
 
-	if !nodesAreEqual(c.Schema, f.schema) {
+	if !NodesAreEqual(c.Schema, f.schema) {
 		r.base.file.rowGroup = convertRowGroupTo(r.base.file.rowGroup, c.Schema)
 	}
 
@@ -90,7 +90,7 @@ func NewGenericRowGroupReader[T any](rowGroup RowGroup, options ...ReaderOption)
 		},
 	}
 
-	if !nodesAreEqual(c.Schema, rowGroup.Schema()) {
+	if !NodesAreEqual(c.Schema, rowGroup.Schema()) {
 		r.base.file.rowGroup = convertRowGroupTo(r.base.file.rowGroup, c.Schema)
 	}
 
@@ -337,7 +337,7 @@ func NewRowGroupReader(rowGroup RowGroup, options ...ReaderOption) *Reader {
 }
 
 func convertRowGroupTo(rowGroup RowGroup, schema *Schema) RowGroup {
-	if rowGroupSchema := rowGroup.Schema(); !nodesAreEqual(schema, rowGroupSchema) {
+	if rowGroupSchema := rowGroup.Schema(); !NodesAreEqual(schema, rowGroupSchema) {
 		conv, err := Convert(schema, rowGroupSchema)
 		if err != nil {
 			// TODO: this looks like something we should not be panicking on,
@@ -416,7 +416,7 @@ func (r *Reader) Read(row interface{}) error {
 func (r *Reader) updateReadSchema(rowType reflect.Type) error {
 	schema := schemaOf(rowType)
 
-	if nodesAreEqual(schema, r.file.schema) {
+	if NodesAreEqual(schema, r.file.schema) {
 		r.read.init(schema, r.file.rowGroup)
 	} else {
 		conv, err := Convert(schema, r.file.schema)

--- a/row.go
+++ b/row.go
@@ -298,7 +298,7 @@ func copyRows(dst RowWriter, src RowReader, buf []Row) (written int64, err error
 	sourceSchema := sourceSchemaOf(src)
 
 	if targetSchema != nil && sourceSchema != nil {
-		if !NodesAreEqual(targetSchema, sourceSchema) {
+		if !EqualNodes(targetSchema, sourceSchema) {
 			conv, err := Convert(targetSchema, sourceSchema)
 			if err != nil {
 				return 0, err

--- a/row.go
+++ b/row.go
@@ -298,7 +298,7 @@ func copyRows(dst RowWriter, src RowReader, buf []Row) (written int64, err error
 	sourceSchema := sourceSchemaOf(src)
 
 	if targetSchema != nil && sourceSchema != nil {
-		if !nodesAreEqual(targetSchema, sourceSchema) {
+		if !NodesAreEqual(targetSchema, sourceSchema) {
 			conv, err := Convert(targetSchema, sourceSchema)
 			if err != nil {
 				return 0, err

--- a/writer.go
+++ b/writer.go
@@ -415,7 +415,7 @@ func (w *Writer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 		return 0, ErrRowGroupSchemaMissing
 	case w.schema == nil:
 		w.configure(rowGroupSchema)
-	case !NodesAreEqual(w.schema, rowGroupSchema):
+	case !EqualNodes(w.schema, rowGroupSchema):
 		return 0, ErrRowGroupSchemaMismatch
 	}
 	if err := w.writer.flush(); err != nil {

--- a/writer.go
+++ b/writer.go
@@ -415,7 +415,7 @@ func (w *Writer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 		return 0, ErrRowGroupSchemaMissing
 	case w.schema == nil:
 		w.configure(rowGroupSchema)
-	case !nodesAreEqual(w.schema, rowGroupSchema):
+	case !NodesAreEqual(w.schema, rowGroupSchema):
 		return 0, ErrRowGroupSchemaMismatch
 	}
 	if err := w.writer.flush(); err != nil {


### PR DESCRIPTION
Comparing `Node`s for equality is not trivial. A function already exists, so let's export it.