### PR TITLE
feat: [Generic]Writer.FileMetaData()

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -1148,6 +1148,17 @@ func TestSetKeyValueMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if len(w.FileMetaData().KeyValueMetadata) != 1 {
+		t.Errorf("expected 1 key/value metadata, got %d", len(w.FileMetaData().KeyValueMetadata))
+	} else {
+		if w.FileMetaData().KeyValueMetadata[0].Key != testKey {
+			t.Errorf("expected metadata key '%s', got '%s'", testKey, w.FileMetaData().KeyValueMetadata[0].Key)
+		}
+		if w.FileMetaData().KeyValueMetadata[0].Value != testValue {
+			t.Errorf("expected metadata value '%s', got '%s'", testValue, w.FileMetaData().KeyValueMetadata[0].Value)
+		}
+	}
+
 	f, err := parquet.OpenFile(bytes.NewReader(b.Bytes()), int64(b.Len()))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Add a convenience method to reveal the "footer" `FileMetaData` structure after writing a file is complete.

---

Some applications require details about a parquet file immediately after it is written. For example, to index metadata for query/compute systems.

The necessary pattern to infer metadata after write:
```golang
w := parquet.NewWriter(...)
w.WriteRowGroups(...)
w.Close()

f := parquet.OpenFile(...)
metadata := f.Metadata()
...
```

If the target storage system has high cost (eg network latency), then it becomes necessary to write the parquet file to an in-memory buffer, parse its metadata, and then pass it to the storage system.