### PR TITLE
write bloom filters near page index

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -945,15 +945,6 @@ func (w *writer) writeRowGroup(rowGroupSchema *Schema, rowGroupSortingColumns []
 	}
 	fileOffset := w.writer.offset
 
-	for _, c := range w.columns {
-		if len(c.filter) > 0 {
-			c.columnChunk.MetaData.BloomFilterOffset = w.writer.offset
-			if err := c.writeBloomFilter(&w.writer); err != nil {
-				return 0, err
-			}
-		}
-	}
-
 	for i, c := range w.columns {
 		w.columnIndex[i] = format.ColumnIndex(c.columnIndex.ColumnIndex())
 
@@ -977,6 +968,15 @@ func (w *writer) writeRowGroup(rowGroupSchema *Schema, rowGroupSortingColumns []
 		}
 		if _, err := io.Copy(&w.writer, c.pageBuffer); err != nil {
 			return 0, fmt.Errorf("writing buffered pages of row group column %d: %w", i, err)
+		}
+	}
+
+	for _, c := range w.columns {
+		if len(c.filter) > 0 {
+			c.columnChunk.MetaData.BloomFilterOffset = w.writer.offset
+			if err := c.writeBloomFilter(&w.writer); err != nil {
+				return 0, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Partial solution for #135 

By writing the bloom filter after the column chunks, they end up being near the page index in the common case where there is one row group per file.

It's possible that this is a good enough solution; for very large files that are split into multiple row groups, the bloom filters could grow so large that it's probably impractical to hold them all in memory. The optimization that consist in reading the footer, page index, and bloom filters at the same time might only apply to small to medium size files.

Let me know if you have more context to share @thorfour !