### PR TITLE
add Size() method to GenericWriter

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -221,6 +221,15 @@ func (w *GenericWriter[T]) Schema() *Schema {
 	return w.base.Schema()
 }
 
+// Size return the uncompressed size of objects in the writer buffer
+func (w *GenericWriter[T]) Size() int64 {
+	sum := int64(0)
+	for _, column := range w.columns {
+		sum += column.Size()
+	}
+	return sum
+}
+
 func (w *GenericWriter[T]) writeRows(rows []T) (int, error) {
 	if cap(w.base.rowbuf) < len(rows) {
 		w.base.rowbuf = make([]Row, len(rows))

--- a/writer_test.go
+++ b/writer_test.go
@@ -1285,3 +1285,25 @@ func TestColumnSkipPageBounds(t *testing.T) {
 		t.Fatalf("wrong max value of row groups in parquet file: want='' got=%s", string(statistics.MaxValue))
 	}
 }
+
+func TestWriterSize(t *testing.T) {
+	type testStruct struct {
+		A int `parquet:"a,plain"`
+	}
+
+	tests := make([]testStruct, 100)
+	for i := 0; i < 100; i++ {
+		tests[i] = testStruct{A: i + 1}
+	}
+	schema := parquet.SchemaOf(&testStruct{})
+	b := bytes.NewBuffer(nil)
+	config := parquet.DefaultWriterConfig()
+	w := parquet.NewGenericWriter[testStruct](b, schema, config)
+	_, _ = w.Write(tests[0:50])
+	_, _ = w.Write(tests[50:100])
+	sz := w.Size()
+	if sz <= 0 {
+		t.Fatalf("the size of the data is less or equal zero: want= >0 got=%d",sz)
+	}
+
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1302,6 +1302,7 @@ func TestWriterSize(t *testing.T) {
 	_, _ = w.Write(tests[0:50])
 	_, _ = w.Write(tests[50:100])
 	sz := w.Size()
+	_ = w.Close()
 	if sz <= 0 {
 		t.Fatalf("the size of the data is less or equal zero: want= >0 got=%d",sz)
 	}


### PR DESCRIPTION
This pr add the `Size()` method for the `GenericWriter[T]` struct, which can be useful when the user of the writer need to verify how many bytes are in the writer at the moment, and thus be able to control the final size.