### PR TITLE
expose more file internals

### DIFF
--- a/column.go
+++ b/column.go
@@ -103,16 +103,16 @@ func (c *Column) PagesFrom(reader io.ReaderAt) Pages {
 		return emptyPages{}
 	}
 	r := &columnPages{
-		pages: make([]filePages, len(c.file.rowGroups)),
+		pages: make([]FilePages, len(c.file.rowGroups)),
 	}
 	for i := range r.pages {
-		r.pages[i].init(c.file.rowGroups[i].(*fileRowGroup).columns[c.index].(*FileColumnChunk), reader)
+		r.pages[i].init(c.file.rowGroups[i].(*FileRowGroup).columns[c.index].(*FileColumnChunk), reader)
 	}
 	return r
 }
 
 type columnPages struct {
-	pages []filePages
+	pages []FilePages
 	index int
 }
 

--- a/column_chunk.go
+++ b/column_chunk.go
@@ -6,6 +6,7 @@ import (
 )
 
 var (
+	ErrMissingBloomFilter = errors.New("missing bloom filter")
 	ErrMissingColumnIndex = errors.New("missing column index")
 	ErrMissingOffsetIndex = errors.New("missing offset index")
 )

--- a/file.go
+++ b/file.go
@@ -130,24 +130,14 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		return nil, fmt.Errorf("opening columns of parquet file: %w", err)
 	}
 
-	var schema *Schema
 	if c.Schema != nil {
-		schema = c.Schema
+		f.schema = c.Schema
 	} else {
-		schema = NewSchema(f.root.Name(), f.root)
+		f.schema = NewSchema(f.root.Name(), f.root)
 	}
-	columns := make([]*Column, 0, numLeafColumnsOf(f.root))
-	f.schema = schema
-	f.root.forEachLeaf(func(c *Column) { columns = append(columns, c) })
-
-	rowGroups := make([]fileRowGroup, len(f.metadata.RowGroups))
-	for i := range rowGroups {
-		rowGroups[i].init(f, schema, columns, &f.metadata.RowGroups[i])
-	}
-	f.rowGroups = make([]RowGroup, len(rowGroups))
-	for i := range rowGroups {
-		f.rowGroups[i] = &rowGroups[i]
-	}
+	columns := makeLeafColumns(f.root)
+	rowGroups := makeFileRowGroups(f, columns)
+	f.rowGroups = makeRowGroups(rowGroups)
 
 	if !c.SkipBloomFilters {
 		section := io.NewSectionReader(r, 0, size)
@@ -182,7 +172,7 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 						cast.SetBloomFilterSection(bloomFilterOffset, bloomFilterLength)
 					}
 
-					c.bloomFilter = newBloomFilter(r, offset, &header)
+					c.bloomFilter.Store(newBloomFilter(r, offset, &header))
 				}
 			}
 		}
@@ -322,6 +312,8 @@ func (f *File) ReadPageIndex() ([]format.ColumnIndex, []format.OffsetIndex, erro
 func (f *File) NumRows() int64 { return f.metadata.NumRows }
 
 // RowGroups returns the list of row groups in the file.
+//
+// Elements of the returned slice are guaranteed to be of type *FileRowGroup.
 func (f *File) RowGroups() []RowGroup { return f.rowGroups }
 
 // Root returns the root column of f.
@@ -399,21 +391,23 @@ func lookupKeyValueMetadata(keyValueMetadata []format.KeyValue, key string) (val
 	return "", false
 }
 
-type fileRowGroup struct {
-	schema   *Schema
+// FileRowGroup is an implementation of the RowGroup interface on parquet files
+// returned by OpenFile.
+type FileRowGroup struct {
+	file     *File
 	rowGroup *format.RowGroup
 	columns  []ColumnChunk
 	sorting  []SortingColumn
-	config   *FileConfig
 }
 
-func (g *fileRowGroup) init(file *File, schema *Schema, columns []*Column, rowGroup *format.RowGroup) {
-	g.schema = schema
+func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowGroup) {
+	g.file = file
 	g.rowGroup = rowGroup
-	g.config = file.config
 	g.columns = make([]ColumnChunk, len(rowGroup.Columns))
 	g.sorting = make([]SortingColumn, len(rowGroup.SortingColumns))
 	fileColumnChunks := make([]FileColumnChunk, len(rowGroup.Columns))
+	fileColumnIndexes := make([]FileColumnIndex, len(rowGroup.Columns))
+	fileOffsetIndexes := make([]FileOffsetIndex, len(rowGroup.Columns))
 
 	for i := range g.columns {
 		fileColumnChunks[i] = FileColumnChunk{
@@ -425,8 +419,12 @@ func (g *fileRowGroup) init(file *File, schema *Schema, columns []*Column, rowGr
 
 		if file.hasIndexes() {
 			j := (int(rowGroup.Ordinal) * len(columns)) + i
-			fileColumnChunks[i].columnIndex.Store(&file.columnIndexes[j])
-			fileColumnChunks[i].offsetIndex.Store(&file.offsetIndexes[j])
+
+			fileColumnIndexes[i] = FileColumnIndex{index: &file.columnIndexes[j], kind: columns[i].Type().Kind()}
+			fileOffsetIndexes[i] = FileOffsetIndex{index: &file.offsetIndexes[j]}
+
+			fileColumnChunks[i].columnIndex.Store(&fileColumnIndexes[i])
+			fileColumnChunks[i].offsetIndex.Store(&fileOffsetIndexes[i])
 		}
 
 		g.columns[i] = &fileColumnChunks[i]
@@ -441,13 +439,24 @@ func (g *fileRowGroup) init(file *File, schema *Schema, columns []*Column, rowGr
 	}
 }
 
-func (g *fileRowGroup) Schema() *Schema                 { return g.schema }
-func (g *fileRowGroup) NumRows() int64                  { return g.rowGroup.NumRows }
-func (g *fileRowGroup) ColumnChunks() []ColumnChunk     { return g.columns }
-func (g *fileRowGroup) SortingColumns() []SortingColumn { return g.sorting }
-func (g *fileRowGroup) Rows() Rows {
+// Schema returns the schema of the row group.
+func (g *FileRowGroup) Schema() *Schema { return g.file.schema }
+
+// NumRows returns the number of rows in the row group.
+func (g *FileRowGroup) NumRows() int64 { return g.rowGroup.NumRows }
+
+// ColumnChunks returns the list of column chunks in the row group.
+//
+// Elements of the returned slice are guaranteed to be of type *FileColumnChunk.
+func (g *FileRowGroup) ColumnChunks() []ColumnChunk { return g.columns }
+
+// SortingColumns returns the list of sorting columns in the row group.
+func (g *FileRowGroup) SortingColumns() []SortingColumn { return g.sorting }
+
+// Rows returns a row reader for the row group.
+func (g *FileRowGroup) Rows() Rows {
 	rowGroup := RowGroup(g)
-	if g.config.ReadMode == ReadModeAsync {
+	if g.file.config.ReadMode == ReadModeAsync {
 		rowGroup = AsyncRowGroup(rowGroup)
 	}
 	return NewRowGroupRowReader(rowGroup)
@@ -477,43 +486,61 @@ func (s *fileSortingColumn) String() string {
 	return b.String()
 }
 
+// FileColumnChunk is an implementation of the ColumnChunk interface on parquet
+// files returned by OpenFile.
 type FileColumnChunk struct {
 	file        *File
 	column      *Column
-	bloomFilter *bloomFilter
 	rowGroup    *format.RowGroup
-	columnIndex atomic.Pointer[format.ColumnIndex]
-	offsetIndex atomic.Pointer[format.OffsetIndex]
 	chunk       *format.ColumnChunk
+	columnIndex atomic.Pointer[FileColumnIndex]
+	offsetIndex atomic.Pointer[FileOffsetIndex]
+	bloomFilter atomic.Pointer[FileBloomFilter]
 }
 
+// Type returns the type of the column chunk.
 func (c *FileColumnChunk) Type() Type {
 	return c.column.Type()
 }
 
+// Column returns the column index of this chunk in its parent row group.
 func (c *FileColumnChunk) Column() int {
 	return int(c.column.Index())
 }
 
+// Pages returns a page reader for the column chunk.
 func (c *FileColumnChunk) Pages() Pages {
-	return c.PagesFrom(c.file.reader)
-}
-
-func (c *FileColumnChunk) PagesFrom(reader io.ReaderAt) Pages {
-	p := new(filePages)
-	p.init(c, reader)
-	pages := Pages(p)
+	pages := Pages(c.PagesFrom(c.file.reader))
 	if c.file.config.ReadMode == ReadModeAsync {
 		pages = AsyncPages(pages)
 	}
 	return pages
 }
 
-func (c *FileColumnChunk) ColumnIndex() (ColumnIndex, error) {
-	return c.ColumnIndexFrom(c.file.reader)
+// PagesFrom returns a page reader for the column chunk, using the reader passed
+// as argument instead of the one that the file was originally opened from.
+//
+// Note that unlike when calling Pages, the returned reader is not wrapped in an
+// AsyncPages reader if the file was opened in async mode.
+func (c *FileColumnChunk) PagesFrom(reader io.ReaderAt) *FilePages {
+	pages := new(FilePages)
+	pages.init(c, reader)
+	return pages
 }
 
-func (c *FileColumnChunk) ColumnIndexFrom(reader io.ReaderAt) (ColumnIndex, error) {
+// ColumnIndex returns the column index of the column chunk, or an error if it
+// didn't exist or couldn't be read.
+func (c *FileColumnChunk) ColumnIndex() (ColumnIndex, error) {
+	index, err := c.ColumnIndexFrom(c.file.reader)
+	if err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+// ColumnIndexFrom is like ColumnIndex but uses the reader passed as argument to
+// read the column index.
+func (c *FileColumnChunk) ColumnIndexFrom(reader io.ReaderAt) (*FileColumnIndex, error) {
 	index, err := c.readColumnIndexFrom(reader)
 	if err != nil {
 		return nil, err
@@ -521,14 +548,22 @@ func (c *FileColumnChunk) ColumnIndexFrom(reader io.ReaderAt) (ColumnIndex, erro
 	if index == nil || c.chunk.ColumnIndexOffset == 0 {
 		return nil, ErrMissingColumnIndex
 	}
-	return fileColumnIndex{c}, nil
+	return index, nil
 }
 
+// OffsetIndex returns the offset index of the column chunk, or an error if it
+// didn't exist or couldn't be read.
 func (c *FileColumnChunk) OffsetIndex() (OffsetIndex, error) {
-	return c.OffsetIndexFrom(c.file.reader)
+	index, err := c.OffsetIndexFrom(c.file.reader)
+	if err != nil {
+		return nil, err
+	}
+	return index, nil
 }
 
-func (c *FileColumnChunk) OffsetIndexFrom(reader io.ReaderAt) (OffsetIndex, error) {
+// OffsetIndexFrom is like OffsetIndex but uses the reader passed as argument to
+// read the offset index.
+func (c *FileColumnChunk) OffsetIndexFrom(reader io.ReaderAt) (*FileOffsetIndex, error) {
 	index, err := c.readOffsetIndex(reader)
 	if err != nil {
 		return nil, err
@@ -536,30 +571,51 @@ func (c *FileColumnChunk) OffsetIndexFrom(reader io.ReaderAt) (OffsetIndex, erro
 	if index == nil || c.chunk.OffsetIndexOffset == 0 {
 		return nil, ErrMissingOffsetIndex
 	}
-	return (*fileOffsetIndex)(index), nil
+	return index, nil
 }
 
+// BloomFilter returns the bloom filter of the column chunk, or nil if it didn't
+// have one.
 func (c *FileColumnChunk) BloomFilter() BloomFilter {
-	if c.bloomFilter == nil {
+	filter, err := c.BloomFilterFrom(c.file.reader)
+	switch err {
+	case nil:
+		return filter
+	case ErrMissingBloomFilter:
 		return nil
+	default:
+		return &errorBloomFilter{err: err}
 	}
-	return c.bloomFilter
 }
 
+// BloomFilterFrom is like BloomFilter but uses the reader passed as argument to
+// read the bloom filter.
+func (c *FileColumnChunk) BloomFilterFrom(reader io.ReaderAt) (*FileBloomFilter, error) {
+	filter, err := c.readBloomFilter(reader)
+	if err != nil {
+		return nil, err
+	}
+	if filter == nil || c.chunk.MetaData.BloomFilterOffset == 0 {
+		return nil, ErrMissingBloomFilter
+	}
+	return filter, nil
+}
+
+// NumValues returns the number of values in the column chunk.
 func (c *FileColumnChunk) NumValues() int64 {
 	return c.chunk.MetaData.NumValues
 }
 
-func (c *FileColumnChunk) readColumnIndex() (*format.ColumnIndex, error) {
+func (c *FileColumnChunk) readColumnIndex() (*FileColumnIndex, error) {
 	return c.readColumnIndexFrom(c.file.reader)
 }
 
-func (c *FileColumnChunk) readColumnIndexFrom(reader io.ReaderAt) (*format.ColumnIndex, error) {
+func (c *FileColumnChunk) readColumnIndexFrom(reader io.ReaderAt) (*FileColumnIndex, error) {
 	if index := c.columnIndex.Load(); index != nil {
 		return index, nil
 	}
-	chunkMeta := c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
-	offset, length := chunkMeta.ColumnIndexOffset, chunkMeta.ColumnIndexLength
+	columnChunk := &c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
+	offset, length := columnChunk.ColumnIndexOffset, columnChunk.ColumnIndexLength
 	if offset == 0 {
 		return nil, nil
 	}
@@ -572,7 +628,7 @@ func (c *FileColumnChunk) readColumnIndexFrom(reader io.ReaderAt) (*format.Colum
 	if err := thrift.Unmarshal(&c.file.protocol, indexData, &columnIndex); err != nil {
 		return nil, fmt.Errorf("decode column index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
 	}
-	index := &columnIndex
+	index := &FileColumnIndex{index: &columnIndex, kind: c.column.Type().Kind()}
 	// We do a CAS (and Load on CAS failure) instead of a simple Store for
 	// the nice property that concurrent calling goroutines will only ever
 	// observe a single pointer value for the result.
@@ -583,12 +639,12 @@ func (c *FileColumnChunk) readColumnIndexFrom(reader io.ReaderAt) (*format.Colum
 	return index, nil
 }
 
-func (c *FileColumnChunk) readOffsetIndex(reader io.ReaderAt) (*format.OffsetIndex, error) {
+func (c *FileColumnChunk) readOffsetIndex(reader io.ReaderAt) (*FileOffsetIndex, error) {
 	if index := c.offsetIndex.Load(); index != nil {
 		return index, nil
 	}
-	chunkMeta := c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
-	offset, length := chunkMeta.OffsetIndexOffset, chunkMeta.OffsetIndexLength
+	columnChunk := &c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()]
+	offset, length := columnChunk.OffsetIndexOffset, columnChunk.OffsetIndexLength
 	if offset == 0 {
 		return nil, nil
 	}
@@ -601,7 +657,7 @@ func (c *FileColumnChunk) readOffsetIndex(reader io.ReaderAt) (*format.OffsetInd
 	if err := thrift.Unmarshal(&c.file.protocol, indexData, &offsetIndex); err != nil {
 		return nil, fmt.Errorf("decode offset index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
 	}
-	index := &offsetIndex
+	index := &FileOffsetIndex{index: &offsetIndex}
 	if !c.offsetIndex.CompareAndSwap(nil, index) {
 		// another goroutine populated it since we last read the pointer
 		return c.offsetIndex.Load(), nil
@@ -609,7 +665,39 @@ func (c *FileColumnChunk) readOffsetIndex(reader io.ReaderAt) (*format.OffsetInd
 	return index, nil
 }
 
-type filePages struct {
+func (c *FileColumnChunk) readBloomFilter(reader io.ReaderAt) (*FileBloomFilter, error) {
+	if filter := c.bloomFilter.Load(); filter != nil {
+		return filter, nil
+	}
+	columnChunkMetaData := &c.file.metadata.RowGroups[c.rowGroup.Ordinal].Columns[c.Column()].MetaData
+	offset := columnChunkMetaData.BloomFilterOffset
+	length := c.file.size - offset
+	if offset == 0 {
+		return nil, nil
+	}
+
+	section := io.NewSectionReader(reader, offset, length)
+	rbuf, rbufpool := getBufioReader(section, 1024)
+	defer putBufioReader(rbuf, rbufpool)
+
+	header := format.BloomFilterHeader{}
+	compact := thrift.CompactProtocol{}
+	decoder := thrift.NewDecoder(compact.NewReader(rbuf))
+
+	if err := decoder.Decode(&header); err != nil {
+		return nil, fmt.Errorf("decoding bloom filter header: %w", err)
+	}
+
+	offset, _ = section.Seek(0, io.SeekCurrent)
+	filter := newBloomFilter(reader, offset, &header)
+
+	if !c.bloomFilter.CompareAndSwap(nil, filter) {
+		return c.bloomFilter.Load(), nil
+	}
+	return filter, nil
+}
+
+type FilePages struct {
 	chunk    *FileColumnChunk
 	rbuf     *bufio.Reader
 	rbufpool *sync.Pool
@@ -628,7 +716,7 @@ type filePages struct {
 	bufferSize int
 }
 
-func (f *filePages) init(c *FileColumnChunk, reader io.ReaderAt) {
+func (f *FilePages) init(c *FileColumnChunk, reader io.ReaderAt) {
 	f.chunk = c
 	f.baseOffset = c.chunk.MetaData.DataPageOffset
 	f.dataOffset = f.baseOffset
@@ -644,7 +732,23 @@ func (f *filePages) init(c *FileColumnChunk, reader io.ReaderAt) {
 	f.decoder.Reset(f.protocol.NewReader(f.rbuf))
 }
 
-func (f *filePages) ReadPage() (Page, error) {
+// ReadDictionary returns the dictionary of the column chunk, or nil if the
+// column chunk did not have one.
+//
+// The program is not required to call this method before calling ReadPage,
+// the dictionary is read automatically when needed. It is exposed to allow
+// programs to access the dictionary without reading the first page.
+func (f *FilePages) ReadDictionary() (Dictionary, error) {
+	if f.dictionary == nil && f.dictOffset > 0 {
+		if err := f.readDictionary(); err != nil {
+			return nil, err
+		}
+	}
+	return f.dictionary, nil
+}
+
+// ReadPages reads the next from from f.
+func (f *FilePages) ReadPage() (Page, error) {
 	if f.chunk == nil {
 		return nil, io.EOF
 	}
@@ -718,7 +822,7 @@ func (f *filePages) ReadPage() (Page, error) {
 	}
 }
 
-func (f *filePages) readDictionary() error {
+func (f *FilePages) readDictionary() error {
 	chunk := io.NewSectionReader(f.section.Outer())
 	rbuf, pool := getBufioReader(chunk, f.bufferSize)
 	defer putBufioReader(rbuf, pool)
@@ -741,7 +845,7 @@ func (f *filePages) readDictionary() error {
 	return f.readDictionaryPage(header, page)
 }
 
-func (f *filePages) readDictionaryPage(header *format.PageHeader, page *buffer) error {
+func (f *FilePages) readDictionaryPage(header *format.PageHeader, page *buffer) error {
 	if header.DictionaryPageHeader == nil {
 		return ErrMissingPageHeader
 	}
@@ -753,7 +857,7 @@ func (f *filePages) readDictionaryPage(header *format.PageHeader, page *buffer) 
 	return nil
 }
 
-func (f *filePages) readDataPageV1(header *format.PageHeader, page *buffer) (Page, error) {
+func (f *FilePages) readDataPageV1(header *format.PageHeader, page *buffer) (Page, error) {
 	if header.DataPageHeader == nil {
 		return nil, ErrMissingPageHeader
 	}
@@ -765,7 +869,7 @@ func (f *filePages) readDataPageV1(header *format.PageHeader, page *buffer) (Pag
 	return f.chunk.column.decodeDataPageV1(DataPageHeaderV1{header.DataPageHeader}, page, f.dictionary, header.UncompressedPageSize)
 }
 
-func (f *filePages) readDataPageV2(header *format.PageHeader, page *buffer) (Page, error) {
+func (f *FilePages) readDataPageV2(header *format.PageHeader, page *buffer) (Page, error) {
 	if header.DataPageHeaderV2 == nil {
 		return nil, ErrMissingPageHeader
 	}
@@ -780,7 +884,7 @@ func (f *filePages) readDataPageV2(header *format.PageHeader, page *buffer) (Pag
 	return f.chunk.column.decodeDataPageV2(DataPageHeaderV2{header.DataPageHeaderV2}, page, f.dictionary, header.UncompressedPageSize)
 }
 
-func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*buffer, error) {
+func (f *FilePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*buffer, error) {
 	page := buffers.get(int(header.CompressedPageSize))
 	defer page.unref()
 
@@ -814,7 +918,8 @@ func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*
 	return page, nil
 }
 
-func (f *filePages) SeekToRow(rowIndex int64) (err error) {
+// SeekToRow seeks to the given row index in the column chunk.
+func (f *FilePages) SeekToRow(rowIndex int64) (err error) {
 	if f.chunk == nil {
 		return io.ErrClosedPipe
 	}
@@ -826,7 +931,7 @@ func (f *filePages) SeekToRow(rowIndex int64) (err error) {
 			f.index = 1
 		}
 	} else {
-		pages := index.PageLocations
+		pages := index.index.PageLocations
 		index := sort.Search(len(pages), func(i int) bool {
 			return pages[i].FirstRowIndex > rowIndex
 		}) - 1
@@ -841,7 +946,8 @@ func (f *filePages) SeekToRow(rowIndex int64) (err error) {
 	return err
 }
 
-func (f *filePages) Close() error {
+// Close closes the page reader.
+func (f *FilePages) Close() error {
 	putBufioReader(f.rbuf, f.rbufpool)
 	f.chunk = nil
 	f.section = io.SectionReader{}
@@ -856,7 +962,7 @@ func (f *filePages) Close() error {
 	return nil
 }
 
-func (f *filePages) columnPath() columnPath {
+func (f *FilePages) columnPath() columnPath {
 	return columnPath(f.chunk.column.Path())
 }
 

--- a/file.go
+++ b/file.go
@@ -439,6 +439,9 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 	}
 }
 
+// File returns the file that this row group belongs to.
+func (g *FileRowGroup) File() *File { return g.file }
+
 // Schema returns the schema of the row group.
 func (g *FileRowGroup) Schema() *Schema { return g.file.schema }
 
@@ -498,15 +501,17 @@ type FileColumnChunk struct {
 	bloomFilter atomic.Pointer[FileBloomFilter]
 }
 
+// File returns the file that this column chunk belongs to.
+func (c *FileColumnChunk) File() *File { return c.file }
+
+// Node returns the node that this column chunk belongs to in the parquet schema.
+func (c *FileColumnChunk) Node() Node { return c.column }
+
 // Type returns the type of the column chunk.
-func (c *FileColumnChunk) Type() Type {
-	return c.column.Type()
-}
+func (c *FileColumnChunk) Type() Type { return c.column.Type() }
 
 // Column returns the column index of this chunk in its parent row group.
-func (c *FileColumnChunk) Column() int {
-	return int(c.column.Index())
-}
+func (c *FileColumnChunk) Column() int { return int(c.column.Index()) }
 
 // Pages returns a page reader for the column chunk.
 func (c *FileColumnChunk) Pages() Pages {

--- a/file_test.go
+++ b/file_test.go
@@ -214,8 +214,8 @@ func TestFileKeyValueMetadata(t *testing.T) {
 	}
 }
 
-func TestFileColumnChunks(t *testing.T) {
-	f, err := os.Open("testdata/file.parquet")
+func TestFileTypes(t *testing.T) {
+	f, err := os.Open("testdata/alltypes_plain.parquet")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,6 +233,9 @@ func TestFileColumnChunks(t *testing.T) {
 	}
 
 	for _, rowGroup := range p.RowGroups() {
+		if _, ok := rowGroup.(*parquet.FileRowGroup); !ok {
+			t.Fatalf("row group of parquet.File must be of type *parquet.FileRowGroup but got %T", rowGroup)
+		}
 		for _, columnChunk := range rowGroup.ColumnChunks() {
 			if _, ok := columnChunk.(*parquet.FileColumnChunk); !ok {
 				t.Fatalf("column chunk of parquet.File must be of type *parquet.FileColumnChunk but got %T", columnChunk)

--- a/offset_index.go
+++ b/offset_index.go
@@ -23,22 +23,24 @@ type OffsetIndex interface {
 	FirstRowIndex(int) int64
 }
 
-type fileOffsetIndex format.OffsetIndex
-
-func (i *fileOffsetIndex) NumPages() int {
-	return len(i.PageLocations)
+type FileOffsetIndex struct {
+	index *format.OffsetIndex
 }
 
-func (i *fileOffsetIndex) Offset(j int) int64 {
-	return i.PageLocations[j].Offset
+func (i *FileOffsetIndex) NumPages() int {
+	return len(i.index.PageLocations)
 }
 
-func (i *fileOffsetIndex) CompressedPageSize(j int) int64 {
-	return int64(i.PageLocations[j].CompressedPageSize)
+func (i *FileOffsetIndex) Offset(j int) int64 {
+	return i.index.PageLocations[j].Offset
 }
 
-func (i *fileOffsetIndex) FirstRowIndex(j int) int64 {
-	return i.PageLocations[j].FirstRowIndex
+func (i *FileOffsetIndex) CompressedPageSize(j int) int64 {
+	return int64(i.index.PageLocations[j].CompressedPageSize)
+}
+
+func (i *FileOffsetIndex) FirstRowIndex(j int) int64 {
+	return i.index.PageLocations[j].FirstRowIndex
 }
 
 type emptyOffsetIndex struct{}

--- a/writer.go
+++ b/writer.go
@@ -545,19 +545,10 @@ func (w *writerFileView) Root() *Column {
 
 func (w *writerFileView) RowGroups() []RowGroup {
 	if w.writer.fileMetaData != nil {
-		root := w.Root()
-		columns := make([]*Column, 0, numLeafColumnsOf(root))
-		root.forEachLeaf(func(c *Column) { columns = append(columns, c) })
-
-		fileRowGroups := make([]fileRowGroup, len(w.writer.fileMetaData.RowGroups))
-		for i := range fileRowGroups {
-			fileRowGroups[i].init(nil, w.schema, columns, &w.writer.fileMetaData.RowGroups[i])
-		}
-		rowGroups := make([]RowGroup, len(fileRowGroups))
-		for i := range fileRowGroups {
-			rowGroups[i] = &fileRowGroups[i]
-		}
-		return rowGroups
+		columns := makeLeafColumns(w.Root())
+		file := &File{metadata: *w.writer.fileMetaData, schema: w.schema}
+		fileRowGroups := makeFileRowGroups(file, columns)
+		return makeRowGroups(fileRowGroups)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR builds on #212 to expose more of the internal types. Having access to these types is useful because they expose methods that aren't part of the interfaces.