### PR TITLE
Add tag option to support isAdjustedToUTC

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -776,10 +776,8 @@ func parseUTCNormalization(arg string) (isUTCNormalized bool, err error) {
 	case "local":
 		return false, nil
 	default:
-
+		return false, fmt.Errorf("unknown utc normalization: %s", arg)
 	}
-
-	return false, fmt.Errorf("unknown utc normalization: %s", arg)
 }
 
 type goNode struct {

--- a/schema_test.go
+++ b/schema_test.go
@@ -235,8 +235,8 @@ func TestSchemaOf(t *testing.T) {
 		{
 			value: new(struct {
 				Inner struct {
-					TimestampAdjusted    int64 `parquet:"timestamp_adjusted_utc,timestamp(millisecond:true)"`
-					TimestampNotAdjusted int64 `parquet:"timestamp_not_adjusted_utc,timestamp(millisecond:false)"`
+					TimestampAdjusted    int64 `parquet:"timestamp_adjusted_utc,timestamp(millisecond:utc)"`
+					TimestampNotAdjusted int64 `parquet:"timestamp_not_adjusted_utc,timestamp(millisecond:local)"`
 				} `parquet:"inner,optional"`
 			}),
 			print: `message {
@@ -321,9 +321,9 @@ func TestInvalidSchemaOf(t *testing.T) {
 		},
 		{
 			value: new(struct {
-				Time int64 `parquet:",time(microsecond:notabool)"`
+				Time int64 `parquet:",time(microsecond:foo)"`
 			}),
-			panic: `time(microsecond:notabool) is an invalid parquet tag: Time int64 [time(microsecond:notabool)]`,
+			panic: `time(microsecond:foo) is an invalid parquet tag: Time int64 [time(microsecond:foo)]`,
 		},
 
 		// Timestamp tags must be int64 or time.Time
@@ -360,15 +360,15 @@ func TestInvalidSchemaOf(t *testing.T) {
 		},
 		{
 			value: new(struct {
-				Timestamp time.Time `parquet:",timestamp(millisecond:notabool)"`
+				Timestamp time.Time `parquet:",timestamp(millisecond:foo)"`
 			}),
-			panic: `timestamp(millisecond:notabool) is an invalid parquet tag: Timestamp time.Time [timestamp(millisecond:notabool)]`,
+			panic: `timestamp(millisecond:foo) is an invalid parquet tag: Timestamp time.Time [timestamp(millisecond:foo)]`,
 		},
 		{
 			value: new(struct {
-				Timestamp time.Time `parquet:",timestamp(millisecond:true:false)"`
+				Timestamp time.Time `parquet:",timestamp(millisecond:utc:local)"`
 			}),
-			panic: `timestamp(millisecond:true:false) is an invalid parquet tag: Timestamp time.Time [timestamp(millisecond:true:false)]`,
+			panic: `timestamp(millisecond:utc:local) is an invalid parquet tag: Timestamp time.Time [timestamp(millisecond:utc:local)]`,
 		},
 	}
 


### PR DESCRIPTION
This PR extends https://github.com/parquet-go/parquet-go/pull/216 to add a second optional parameter to the `time` and `timestamp` tags to support explicitly setting the `isAdjustedToUTC` annotation.

Fixes https://github.com/parquet-go/parquet-go/issues/228