### PR TITLE
Rudimentary support for Variants when building a schema

### DIFF
--- a/column.go
+++ b/column.go
@@ -356,6 +356,8 @@ func (cl *columnLoader) open(file *File, metadata *format.FileMetaData, columnIn
 		c.typ = &mapType{}
 	} else if lt != nil && lt.List != nil {
 		c.typ = &listType{}
+	} else if lt != nil && lt.Variant != nil {
+		c.typ = &variantType{}
 	}
 	c.columns = make([]*Column, numChildren)
 

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -99,19 +99,21 @@ type Statistics struct {
 }
 
 // Empty structs to use as logical type annotations.
-type StringType struct{} // allowed for BINARY, must be encoded with UTF-8
-type UUIDType struct{}   // allowed for FIXED[16], must encode raw UUID bytes
-type MapType struct{}    // see see LogicalTypes.md
-type ListType struct{}   // see LogicalTypes.md
-type EnumType struct{}   // allowed for BINARY, must be encoded with UTF-8
-type DateType struct{}   // allowed for INT32
+type StringType struct{}  // allowed for BINARY, must be encoded with UTF-8
+type UUIDType struct{}    // allowed for FIXED[16], must encode raw UUID bytes
+type MapType struct{}     // see LogicalTypes.md
+type ListType struct{}    // see LogicalTypes.md
+type EnumType struct{}    // allowed for BINARY, must be encoded with UTF-8
+type DateType struct{}    // allowed for INT32
+type Float16Type struct{} // allowed for FIXED[2], must encoded raw FLOAT16 bytes
 
-func (*StringType) String() string { return "STRING" }
-func (*UUIDType) String() string   { return "UUID" }
-func (*MapType) String() string    { return "MAP" }
-func (*ListType) String() string   { return "LIST" }
-func (*EnumType) String() string   { return "ENUM" }
-func (*DateType) String() string   { return "DATE" }
+func (*StringType) String() string  { return "STRING" }
+func (*UUIDType) String() string    { return "UUID" }
+func (*MapType) String() string     { return "MAP" }
+func (*ListType) String() string    { return "LIST" }
+func (*EnumType) String() string    { return "ENUM" }
+func (*DateType) String() string    { return "DATE" }
+func (*Float16Type) String() string { return "FLOAT16" }
 
 // Logical type to annotate a column that is always null.
 //
@@ -240,11 +242,12 @@ type LogicalType struct { // union
 	Timestamp *TimestampType `thrift:"8"`
 
 	// 9: reserved for Interval
-	Integer *IntType  `thrift:"10"` // use ConvertedType Int* or Uint*
-	Unknown *NullType `thrift:"11"` // no compatible ConvertedType
-	Json    *JsonType `thrift:"12"` // use ConvertedType JSON
-	Bson    *BsonType `thrift:"13"` // use ConvertedType BSON
-	UUID    *UUIDType `thrift:"14"` // no compatible ConvertedType
+	Integer *IntType     `thrift:"10"` // use ConvertedType Int* or Uint*
+	Unknown *NullType    `thrift:"11"` // no compatible ConvertedType
+	Json    *JsonType    `thrift:"12"` // use ConvertedType JSON
+	Bson    *BsonType    `thrift:"13"` // use ConvertedType BSON
+	UUID    *UUIDType    `thrift:"14"` // no compatible ConvertedType
+	Float16 *Float16Type `thrift:"15"` // no compatible ConvertedType
 }
 
 func (t *LogicalType) String() string {

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -743,6 +743,13 @@ type ColumnMetaData struct {
 
 	// Byte offset from beginning of file to Bloom filter data.
 	BloomFilterOffset int64 `thrift:"14,optional"`
+
+	// Size of Bloom filter data including the serialized header, in bytes.
+	// Added in 2.10 so readers may not read this field from old files and
+	// it can be obtained after the BloomFilterHeader has been deserialized.
+	// Writers should write this field so readers can read the bloom filter
+	// in a single I/O.
+	BloomFilterLength *int32 `thrift:"15,optional"`
 }
 
 type EncryptionWithFooterKey struct{}

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -915,7 +915,14 @@ type ColumnMetaData struct {
 	// representations. The histograms contained in these statistics can
 	// also be useful in some cases for more fine-grained nullability/list length
 	// filter pushdown.
-	SizeStatistics *SizeStatistics `thrift:"16,optional"`
+	// TODO: Uncomment this field when Thrift decoding is fixed. Strangely, when it is
+	// uncommented, test cases in file_test.go fail with an inexplicable error decoding
+	// an unrelated field:
+	//    reading parquet file metadata: decoding thrift payload: 4:FIELD<LIST> → 0/1:LIST<STRUCT>: missing required field: 2:FIELD<I64>
+	// (Seems to be complaining about field TotalBytesSize of RowGroup). This only occurs
+	// with testdata/dict-page-offset-zero.parquet, in both TestOpenFileWithoutPageIndex
+	// and TestOpenFile.
+	//SizeStatistics *SizeStatistics `thrift:"16,optional"`
 
 	// Optional statistics specific for Geometry and Geography logical types
 	GeospatialStatistics *GeospatialStatistics `thrift:"17,optional"`

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -260,6 +260,11 @@ type BsonType struct{}
 
 func (t *BsonType) String() string { return "BSON" }
 
+// Embedded Variant logical type annotation
+type VariantType struct{}
+
+func (*VariantType) String() string { return "VARIANT" }
+
 // LogicalType annotations to replace ConvertedType.
 //
 // To maintain compatibility, implementations using LogicalType for a
@@ -288,6 +293,7 @@ type LogicalType struct { // union
 	Bson    *BsonType    `thrift:"13"` // use ConvertedType BSON
 	UUID    *UUIDType    `thrift:"14"` // no compatible ConvertedType
 	Float16 *Float16Type `thrift:"15"` // no compatible ConvertedType
+	Variant *VariantType `thrift:"16"` // no compatible ConvertedType
 }
 
 func (t *LogicalType) String() string {
@@ -912,6 +918,7 @@ type ColumnOrder struct { // union
 	//   ENUM - unsigned byte-wise comparison
 	//   LIST - undefined
 	//   MAP - undefined
+	//   VARIANT - undefined
 	//
 	// In the absence of logical types, the sort order is determined by the physical type:
 	//   BOOLEAN - false, true

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -427,6 +427,14 @@ func (t *LogicalType) String() string {
 		return t.Bson.String()
 	case t.UUID != nil:
 		return t.UUID.String()
+	case t.Float16 != nil:
+		return t.Float16.String()
+	case t.Variant != nil:
+		return t.Variant.String()
+	case t.Geometry != nil:
+		return t.Geometry.String()
+	case t.Geography != nil:
+		return t.Geography.String()
 	default:
 		return ""
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -628,6 +628,23 @@ func TestSchemaRoundTrip(t *testing.T) {
 	}
 }`,
 		},
+		{
+			name: "variants",
+			schema: parquet.NewSchema("root", parquet.Group{
+				"variants": parquet.Optional(parquet.Group{
+					"unshredded": parquet.Optional(parquet.Variant()),
+					// TODO: Also include shredded variants when they are implemented
+				}),
+			}),
+			roundTripped: `message root {
+	optional group variants {
+		optional group unshredded (VARIANT) {
+			required binary metadata;
+			required binary value;
+		}
+	}
+}`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/type.go
+++ b/type.go
@@ -2274,6 +2274,94 @@ func (t *nullType) ConvertValue(val Value, _ Type) (Value, error) {
 	return val, nil
 }
 
+// Variant constructs a node of unshredded VARIANT logical type. It is a group with
+// two required fields, "metadata" and "value", both byte arrays.
+//
+// Experimental: The specification for variants is still being developed and the type
+// is not fully adopted. Support for this type is subject to change.
+//
+// Initial support does not attempt to process the variant data. So reading and writing
+// data of this type behaves as if it were just a group with two byte array fields, as
+// if the logical type annotation were absent. This may change in the future.
+//
+// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#variant
+func Variant() Node {
+	return variantNode{Group{"metadata": Required(Leaf(ByteArrayType)), "value": Required(Leaf(ByteArrayType))}}
+}
+
+// TODO: add ShreddedVariant(Node) function, to create a shredded variant
+//  where the argument defines the type/structure of the shredded value(s).
+
+type variantNode struct{ Group }
+
+func (variantNode) Type() Type { return &variantType{} }
+
+type variantType format.VariantType
+
+func (t *variantType) String() string { return (*format.VariantType)(t).String() }
+
+func (t *variantType) Kind() Kind { panic("cannot call Kind on parquet VARIANT type") }
+
+func (t *variantType) Length() int { return 0 }
+
+func (t *variantType) EstimateSize(int) int { return 0 }
+
+func (t *variantType) EstimateNumValues(int) int { return 0 }
+
+func (t *variantType) Compare(Value, Value) int {
+	panic("cannot compare values on parquet VARIANT type")
+}
+
+func (t *variantType) ColumnOrder() *format.ColumnOrder { return nil }
+
+func (t *variantType) PhysicalType() *format.Type { return nil }
+
+func (t *variantType) LogicalType() *format.LogicalType {
+	return &format.LogicalType{Variant: (*format.VariantType)(t)}
+}
+
+func (t *variantType) ConvertedType() *deprecated.ConvertedType { return nil }
+
+func (t *variantType) NewColumnIndexer(int) ColumnIndexer {
+	panic("create create column indexer from parquet VARIANT type")
+}
+
+func (t *variantType) NewDictionary(int, int, encoding.Values) Dictionary {
+	panic("cannot create dictionary from parquet VARIANT type")
+}
+
+func (t *variantType) NewColumnBuffer(int, int) ColumnBuffer {
+	panic("cannot create column buffer from parquet VARIANT type")
+}
+
+func (t *variantType) NewPage(int, int, encoding.Values) Page {
+	panic("cannot create page from parquet VARIANT type")
+}
+
+func (t *variantType) NewValues(values []byte, _ []uint32) encoding.Values {
+	panic("cannot create values from parquet VARIANT type")
+}
+
+func (t *variantType) Encode(_ []byte, _ encoding.Values, _ encoding.Encoding) ([]byte, error) {
+	panic("cannot encode parquet VARIANT type")
+}
+
+func (t *variantType) Decode(_ encoding.Values, _ []byte, _ encoding.Encoding) (encoding.Values, error) {
+	panic("cannot decode parquet VARIANT type")
+}
+
+func (t *variantType) EstimateDecodeSize(_ int, _ []byte, _ encoding.Encoding) int {
+	panic("cannot estimate decode size of parquet VARIANT type")
+}
+
+func (t *variantType) AssignValue(reflect.Value, Value) error {
+	panic("cannot assign value to a parquet VARIANT type")
+}
+
+func (t *variantType) ConvertValue(Value, Type) (Value, error) {
+	panic("cannot convert value to a parquet VARIANT type")
+}
+
 type groupType struct{}
 
 func (groupType) String() string { return "group" }


### PR DESCRIPTION
This doesn't actually add useful support -- like the ability to encode/decode variant data to/from Go `any` values.

This is the most superficial of changes by merely adding the ability to _create_ a schema node that has a "variant" logical type (and only an unshredded variant). While superficial, It would still be useful since it would allow for experimenting locally with implementing the processing of variant data in a 3rd party library -- I'd have to handle it as a simple struct of two []byte fields, but at least I could produce a file with the right annotations in it, to test it out with other tooling that may support variants (like Apache Spark).

When looking at the changes in the upstream parquet-format repo, I noticed there were several other adjacent changes that have been made that were missing from this repo. So there are a handful of commits that cherry-pick a handful of other additions to the parquet-format Thrift definitions. None of them are actually used yet except the variant logical type. (And one of the new fields had to be commented out because it tickles an issue in thrift decoding 🤷.)

This would address #244.