### PR TITLE
Don't allow a schema with zero columns

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -102,11 +102,17 @@ func NewGenericWriter[T any](output io.Writer, options ...WriterOption) *Generic
 
 	if schema == nil && t != nil {
 		schema = schemaOf(dereference(t))
+		if len(schema.Columns()) == 0 {
+			panic("generic writer must be instantiated with type that has at least one exported field.")
+		}
 		config.Schema = schema
 	}
 
 	if config.Schema == nil {
 		panic("generic writer must be instantiated with schema or concrete type.")
+	}
+	if len(config.Schema.Columns()) == 0 {
+		panic("generic writer must be instantiated with schema that has at least one column.")
 	}
 
 	return &GenericWriter[T]{

--- a/writer_test.go
+++ b/writer_test.go
@@ -107,7 +107,7 @@ func TestIssue249(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	w := parquet.NewGenericWriter[*noExportedFields](&buf)
-	n, err := w.Write([]*noExportedFields{
+	_, err := w.Write([]*noExportedFields{
 		{a: "a", b: "c", c: "c", x: []int32{0, 1, 2}},
 		{a: "a", b: "c", c: "c", x: []int32{0, 1, 2}},
 		{a: "a", b: "c", c: "c", x: []int32{0, 1, 2}},
@@ -115,7 +115,7 @@ func TestIssue249(t *testing.T) {
 	if err == nil {
 		t.Fatal("expecting Write to return an error, but it did not")
 	}
-	if !strings.Contains(err.Error(), "noExportedFields has zero columns") {
+	if !strings.Contains(err.Error(), "noExportedFields: it has no columns (maybe it has no exported fields)") {
 		t.Fatalf("expecting Write to return an error describing that the input type has no columns; instead got: %v", err)
 	}
 }


### PR DESCRIPTION
Without any columns, a columnar format cannot contain any rows, and thus no data. So it seems like it must be a programmer error (such as passing a struct with no exported fields).

Without these checks, we can later get into a index-out-of-range panics because some parts of the code assume at least one column is present.

Here's an example panic, that occurred when a writer was closed. This happened in an earlier form of the test added in the first commit of #242 (the test was later removed due to a decision to change/simplify how that functionality gets exposed).

```
--- FAIL: TestWriteRowsColumns (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 8 [running]:
testing.tRunner.func1.2({0x102d43c60, 0x140000243f0})
	/Users/jhumphries/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
	/Users/jhumphries/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1737 +0x334
panic({0x102d43c60?, 0x140000243f0?})
	/Users/jhumphries/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/runtime/panic.go:787 +0x124
github.com/parquet-go/parquet-go.(*writer).writeRowGroup(0x140001cc000?, 0x0?, {0x0?, 0x1400010bcc8?, 0x14000104480?})
	/Users/jhumphries/src/parquet-go/writer.go:934 +0xdac
github.com/parquet-go/parquet-go.(*writer).flush(...)
	/Users/jhumphries/src/parquet-go/writer.go:831
github.com/parquet-go/parquet-go.(*writer).close(0x140001cc000)
	/Users/jhumphries/src/parquet-go/writer.go:818 +0x3c
github.com/parquet-go/parquet-go.(*Writer).Close(...)
	/Users/jhumphries/src/parquet-go/writer.go:360
github.com/parquet-go/parquet-go.(*GenericWriter[...]).Close(...)
	/Users/jhumphries/src/parquet-go/writer.go:171
github.com/parquet-go/parquet-go_test.asRowSlice[...]({0x102dbdce0, 0x14000003dc0}, {0x1400018e008, 0x3e8, 0x1026e6290})
	/Users/jhumphries/src/parquet-go/writer_test.go:194 +0x2a0
github.com/parquet-go/parquet-go_test.testWriteRowsColumns[...](0x14000003dc0)
	/Users/jhumphries/src/parquet-go/writer_test.go:132 +0x78
github.com/parquet-go/parquet-go_test.TestWriteRowsColumns.func1(0x14000003dc0?)
	/Users/jhumphries/src/parquet-go/writer_test.go:111 +0x28
testing.tRunner(0x14000003dc0, 0x102d95198)
	/Users/jhumphries/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 7
	/Users/jhumphries/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/testing/testing.go:1851 +0x374
```