### PR TITLE
Consistent test naming for legacy issues (issue numbers from segmentio repo)

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -175,7 +175,7 @@ func benchmarkGenericBuffer[Row generator[Row]](b *testing.B) {
 	})
 }
 
-func TestIssue327(t *testing.T) {
+func TestIssueSegmentio327(t *testing.T) {
 	t.Run("untagged nested lists should panic", func(t *testing.T) {
 		type testType struct {
 			ListOfLists [][]int
@@ -191,7 +191,7 @@ func TestIssue327(t *testing.T) {
 	})
 }
 
-func TestIssue346(t *testing.T) {
+func TestIssueSegmentio346(t *testing.T) {
 	type TestType struct {
 		Key int
 	}
@@ -204,7 +204,7 @@ func TestIssue346(t *testing.T) {
 	_, _ = buffer.Write(data)
 }
 
-func TestIssue347(t *testing.T) {
+func TestIssueSegmentio347(t *testing.T) {
 	type TestType struct {
 		Key int
 	}

--- a/column_buffer_test.go
+++ b/column_buffer_test.go
@@ -98,7 +98,7 @@ func TestWriteAndReadOptionalPointer(t *testing.T) {
 }
 
 // https://github.com/segmentio/parquet-go/issues/501
-func TestIssue501(t *testing.T) {
+func TestIssueSegmentio501(t *testing.T) {
 	col := newBooleanColumnBuffer(BooleanType, 0, 2055208)
 
 	// write all trues and then flush the buffer

--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -77,7 +77,7 @@ func (d *byteArrayDictionary) lookupString(indexes []int32, rows sparse.Array) {
 	//
 	// This command was used to trigger the problem:
 	//
-	//	GOMAXPROCS=8 go test -run TestIssue368 -count 10
+	//	GOMAXPROCS=8 go test -run TestIssueSegmentio368 -count 10
 	//
 	// https://github.com/segmentio/parquet-go/issues/368
 	//

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -201,7 +201,7 @@ func BenchmarkDictionary(b *testing.B) {
 	}
 }
 
-func TestIssue312(t *testing.T) {
+func TestIssueSegmentio312(t *testing.T) {
 	node := parquet.String()
 	node = parquet.Encoded(node, &parquet.RLEDictionary)
 	g := parquet.Group{}

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -199,7 +199,7 @@ func ExampleSearch() {
 	// {"Luke" "Skywalker"}
 }
 
-func TestIssue360(t *testing.T) {
+func TestIssueSegmentio360(t *testing.T) {
 	type TestType struct {
 		Key []int
 	}
@@ -239,7 +239,7 @@ func TestIssue360(t *testing.T) {
 	assertRowsEqual(t, expect, rows)
 }
 
-func TestIssue362ParquetReadFromGenericReaders(t *testing.T) {
+func TestIssueSegmentio362ParquetReadFromGenericReaders(t *testing.T) {
 	path := "testdata/dms_test_table_LOAD00000001.parquet"
 	fp, err := os.Open(path)
 	if err != nil {
@@ -262,7 +262,7 @@ func TestIssue362ParquetReadFromGenericReaders(t *testing.T) {
 	}
 }
 
-func TestIssue362ParquetReadFile(t *testing.T) {
+func TestIssueSegmentio362ParquetReadFile(t *testing.T) {
 	rows1, err := parquet.ReadFile[any]("testdata/dms_test_table_LOAD00000001.parquet")
 	if err != nil {
 		t.Fatal(err)
@@ -276,7 +276,7 @@ func TestIssue362ParquetReadFile(t *testing.T) {
 	assertRowsEqual(t, rows1, rows2)
 }
 
-func TestIssue368(t *testing.T) {
+func TestIssueSegmentio368(t *testing.T) {
 	f, err := os.Open("testdata/issue368.parquet")
 	if err != nil {
 		t.Fatal(err)
@@ -305,7 +305,7 @@ func TestIssue368(t *testing.T) {
 	}
 }
 
-func TestIssue377(t *testing.T) {
+func TestIssueSegmentio377(t *testing.T) {
 	type People struct {
 		Name string
 		Age  int
@@ -341,7 +341,7 @@ func TestIssue377(t *testing.T) {
 	assertRowsEqual(t, rows, ods)
 }
 
-func TestIssue423(t *testing.T) {
+func TestIssueSegmentio423(t *testing.T) {
 	type Inner struct {
 		Value string `parquet:","`
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -91,7 +91,7 @@ func testGenericReaderRows[Row any](rows []Row) error {
 	return nil
 }
 
-func TestIssue400(t *testing.T) {
+func TestIssueSegmentio400(t *testing.T) {
 	type B struct {
 		Name string
 	}

--- a/sorting_test.go
+++ b/sorting_test.go
@@ -246,7 +246,7 @@ func assertRowsEqualByRow[T any](t *testing.T, rowsGot, rowsWant []T) {
 	}
 }
 
-func TestIssue_82(t *testing.T) {
+func TestIssue82(t *testing.T) {
 	type Record struct {
 		A string `parquet:"a"`
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -100,7 +100,7 @@ func benchmarkGenericWriter[Row generator[Row]](b *testing.B) {
 	})
 }
 
-func TestIssue272(t *testing.T) {
+func TestIssueSegmentio272(t *testing.T) {
 	type T2 struct {
 		X string `parquet:",dict,optional"`
 	}
@@ -160,7 +160,7 @@ func TestIssue272(t *testing.T) {
 	}
 }
 
-func TestIssue279(t *testing.T) {
+func TestIssueSegmentio279(t *testing.T) {
 	type T2 struct {
 		Id   int    `parquet:",plain,optional"`
 		Name string `parquet:",plain,optional"`
@@ -223,7 +223,7 @@ func TestIssue279(t *testing.T) {
 	}
 }
 
-func TestIssue302(t *testing.T) {
+func TestIssueSegmentio302(t *testing.T) {
 	tests := []struct {
 		name string
 		fn   func(t *testing.T)
@@ -310,7 +310,7 @@ func TestIssue302(t *testing.T) {
 	}
 }
 
-func TestIssue347Writer(t *testing.T) {
+func TestIssueSegmentio347Writer(t *testing.T) {
 	type TestType struct {
 		Key int
 	}
@@ -332,7 +332,7 @@ func TestIssue347Writer(t *testing.T) {
 	_ = parquet.NewGenericWriter[any](b)
 }
 
-func TestIssue375(t *testing.T) {
+func TestIssueSegmentio375(t *testing.T) {
 	type Row struct{ FirstName, LastName string }
 
 	output := new(bytes.Buffer)


### PR DESCRIPTION
I noticed that many of the test names that refer to issues all refer to issues that don't exist in this repo -- like `TestIssue272` in `writer_test.go` (current highest issue/PR number in this repo is ~250). Some reference issues as high as 500. I realized that these are issue numbers from the legacy (pre-fork) repo: https://github.com/segmentio/parquet-go/issues.

In the interest of clarity for future readers, I figured it might be nice to name them more clearly. I've renamed them all to include `Segmentio` in the name. So `TestIssueSegmentio272` refers to issue 272 in that other repo.

For test cases that referenced issues in _this_ repo (there were four of them), I didn't rename or touch them -- except 82, to remove an underscore that was inconsistent with other test case names.

What do you think? Does this seem like an improvement?