### PR TITLE
Add a way to create a "shredded" variant type

### DIFF
--- a/type.go
+++ b/type.go
@@ -2396,10 +2396,10 @@ func variantTypedValueNode(node Node, fieldPath ...string) (typed Node, err erro
 		if err != nil {
 			return nil, err
 		}
-		group[child.Name()] = Group{
+		group[child.Name()] = Required(Group{
 			"value":       Optional(Leaf(ByteArrayType)),
 			"typed_value": Optional(childNode),
-		}
+		})
 	}
 	if node.ID() != 0 {
 		return FieldID(group, node.ID()), nil
@@ -2411,7 +2411,7 @@ func getLogicalType(lt *format.LogicalType) any {
 	// We use reflection so we can always catch a logical type annotation. If a
 	// new one is added, we don't have to remember to update the switch above (unless
 	// a new one is added that is also supported as a variant value).
-	refVal := reflect.ValueOf(lt)
+	refVal := reflect.Indirect(reflect.ValueOf(lt))
 	for i := range refVal.NumField() {
 		field := refVal.Field(i)
 		if field.CanInterface() && !field.IsZero() {

--- a/type.go
+++ b/type.go
@@ -3,9 +3,11 @@ package parquet
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/bits"
 	"reflect"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -2274,23 +2276,150 @@ func (t *nullType) ConvertValue(val Value, _ Type) (Value, error) {
 	return val, nil
 }
 
-// Variant constructs a node of unshredded VARIANT logical type. It is a group with
+// Variant constructs a node of unshredded [VARIANT logical type]. It is a group with
 // two required fields, "metadata" and "value", both byte arrays.
 //
-// Experimental: The specification for variants is still being developed and the type
+// *Experimental*: The specification for variants is still being developed and the type
 // is not fully adopted. Support for this type is subject to change.
 //
 // Initial support does not attempt to process the variant data. So reading and writing
 // data of this type behaves as if it were just a group with two byte array fields, as
 // if the logical type annotation were absent. This may change in the future.
 //
-// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#variant
+// [VARIANT logical type]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#variant
 func Variant() Node {
 	return variantNode{Group{"metadata": Required(Leaf(ByteArrayType)), "value": Required(Leaf(ByteArrayType))}}
 }
 
-// TODO: add ShreddedVariant(Node) function, to create a shredded variant
-//  where the argument defines the type/structure of the shredded value(s).
+// ShreddedVariant constructs a node of shredded [VARIANT logical type]. It is a group
+// a required byte array "metadata" field, an optional byte array "value" field (for
+// any unshredded values), and an optional "typed_value" field whose type is that
+// of the shredded value. If the given node is a group or list (or contains a list),
+// the resulting "typed_value" field will have some additional structure to allow
+// each group or element in a list to have a mix of shredded and unshredded data.
+//
+// The given node must may only contain types that map to valid [variant value types].
+// Therefore, it may not contain ENUM, FLOAT16, INTERVAL, JSON, BSON, VARIANT,
+// GEOMETRY, GEOGRAPHY, MAP, or UNKNOWN logical types. It may only use signed INT
+// logical types. It may only use DECIMAL logical types whose precision is less than
+// or equal to 38. It may not contain any repeated fields unless they are the middle
+// level of a 3-level LIST logical type. Any "required" settings on fields will be
+// ignored: shredded fields must always be optional to represent values that may not
+// conform to the shredded type. It also may not contain empty groups: any groups
+// must have at least one field.
+//
+// More information on shredded variants can be found in the [Parquet documentation].
+//
+// *Experimental*: The specification for variants is still being developed and the type
+// is not fully adopted. Support for this type is subject to change.
+//
+// Initial support does not attempt to process the variant data. So reading and writing
+// data of this type behaves as if it were just a group with two byte array fields, as
+// if the logical type annotation were absent. This may change in the future.
+//
+// [VARIANT logical type]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#variant
+// [variant value types]: https://github.com/apache/parquet-format/blob/master/VariantShredding.md#shredded-value-types
+// [Parquet documentation]: https://github.com/apache/parquet-format/blob/master/VariantShredding.md
+func ShreddedVariant(shreddedType Node) (Node, error) {
+	typedNode, err := variantTypedValueNode(shreddedType)
+	if err != nil {
+		return nil, err
+	}
+	return variantNode{Group{
+		"metadata":    Required(Leaf(ByteArrayType)),
+		"value":       Optional(Leaf(ByteArrayType)),
+		"typed_value": Optional(typedNode),
+	}}, nil
+}
+
+func variantTypedValueNode(node Node, fieldPath ...string) (typed Node, err error) {
+	defer func() {
+		if err != nil && len(fieldPath) > 0 {
+			err = fmt.Errorf("field %s: %w", strings.Join(fieldPath, "."), err)
+		}
+	}()
+	if node.Repeated() {
+		return nil, errors.New("repeated types are not allowed unless they are part of a 3-level LIST logical type")
+	}
+	if lt := node.Type().LogicalType(); lt != nil {
+		switch lt := getLogicalType(lt).(type) {
+		case *format.ListType:
+			// We must first extract the inner list.element field of the 3-level LIST type.
+			children := node.Fields()
+			if len(children) != 1 {
+				return nil, fmt.Errorf("invalid LIST logical type: expecting a single 'list' field but instead found %d", len(children))
+			}
+			grandchildren := children[0].Fields()
+			if len(grandchildren) != 1 {
+				return nil, fmt.Errorf("invalid LIST logical type: expecting a single 'element' field but instead found %d", len(grandchildren))
+			}
+			elementNode, err := variantTypedValueNode(grandchildren[0], fieldPath...)
+			if err != nil {
+				return nil, err
+			}
+			list := List(Required(Group{
+				"value":       Optional(Leaf(ByteArrayType)),
+				"typed_value": Optional(elementNode),
+			}))
+			if node.ID() != 0 {
+				return FieldID(list, node.ID()), nil
+			}
+			return list, nil
+		case *format.IntType:
+			if !lt.IsSigned {
+				return nil, errors.New("signed INT logical types are not allowed")
+			}
+		case *format.DecimalType:
+			if lt.Precision > 38 {
+				return nil, fmt.Errorf("DECIMAL logical types with precision >38 are not allowed (got %d)", lt.Precision)
+			}
+		case *format.DateType:
+		case *format.TimeType:
+		case *format.TimestampType:
+		case *format.StringType:
+		case *format.UUIDType:
+		default:
+			// No other logical types are allowed.
+			return nil, fmt.Errorf("%s logical types are not allowed", lt)
+		}
+	}
+	if node.Leaf() {
+		return node, nil
+	}
+	children := node.Fields()
+	if len(children) == 0 {
+		return nil, errors.New("empty groups are not allowed")
+	}
+	group := make(Group, len(children))
+	for _, child := range children {
+		childNode, err := variantTypedValueNode(child, append(fieldPath, child.Name())...)
+		if err != nil {
+			return nil, err
+		}
+		group[child.Name()] = Group{
+			"value":       Optional(Leaf(ByteArrayType)),
+			"typed_value": Optional(childNode),
+		}
+	}
+	if node.ID() != 0 {
+		return FieldID(group, node.ID()), nil
+	}
+	return group, nil
+}
+
+func getLogicalType(lt *format.LogicalType) any {
+	// We use reflection so we can always catch a logical type annotation. If a
+	// new one is added, we don't have to remember to update the switch above (unless
+	// a new one is added that is also supported as a variant value).
+	refVal := reflect.ValueOf(lt)
+	for i := range refVal.NumField() {
+		field := refVal.Field(i)
+		if field.CanInterface() && !field.IsZero() {
+			return field.Interface()
+		}
+	}
+	return nil
+}
 
 type variantNode struct{ Group }
 

--- a/type_test.go
+++ b/type_test.go
@@ -1,0 +1,54 @@
+package parquet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/format"
+)
+
+func TestShreddedVariant(t *testing.T) {
+	errTestCases := []Node{
+		Variant(),
+		Map(String(), Leaf(ByteArrayType)),
+		Decimal(0, 39, FixedLenByteArrayType(16)),
+		Uint(8),
+		Uint(16),
+		Uint(32),
+		Uint(64),
+		Repeated(Leaf(int32Type{})),
+		Repeated(String()),
+		Enum(),
+		// Also test some logical types that we don't yet support or provide API to construct
+		Leaf(logicalType{Type: ByteArrayType, lt: format.LogicalType{Unknown: &format.NullType{}}}),
+		Leaf(logicalType{Type: ByteArrayType, lt: format.LogicalType{Float16: &format.Float16Type{}}}),
+		Leaf(logicalType{Type: ByteArrayType, lt: format.LogicalType{Geometry: &format.GeometryType{}}}),
+		Leaf(logicalType{Type: ByteArrayType, lt: format.LogicalType{Geography: &format.GeographyType{}}}),
+	}
+	for _, testCase := range errTestCases {
+		// Direct
+		_, err := ShreddedVariant(testCase)
+		if err == nil {
+			t.Errorf("ShreddedVariant(%v) should have returned an error", testCase)
+		} else if !strings.Contains(err.Error(), "not allowed") {
+			t.Errorf("error message should contain 'not allowed': %q", err.Error())
+		}
+		// Indirect (group that contains the offending type)
+		group := Group{"a": String(), "b": testCase}
+		_, err = ShreddedVariant(group)
+		if err == nil {
+			t.Errorf("ShreddedVariant(%v) should have returned an error", group)
+		} else if !strings.Contains(err.Error(), "not allowed") {
+			t.Errorf("error message should contain 'not allowed': %q", err.Error())
+		}
+	}
+}
+
+type logicalType struct {
+	Type
+	lt format.LogicalType
+}
+
+func (l logicalType) LogicalType() *format.LogicalType {
+	return &l.lt
+}


### PR DESCRIPTION
This is continuing support for #244. This addresses a TODO that was left in #245 -- a way to create a schema node for a ["shredded" variant](https://github.com/apache/parquet-format/blob/master/VariantShredding.md). Still no material support for actually using variants, just a way to create a file that has them in its schema.
