### PR TITLE
ci: update versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,6 @@ jobs:
   test:
     strategy:
       matrix:
-        go:
-          - "oldstable"
         tags:
           - ""
           - purego
@@ -43,10 +41,10 @@ jobs:
           mvn --file parquet-java-apache-parquet-1.13.1/parquet-cli/pom.xml install -DskipTests
           mvn --file parquet-java-apache-parquet-1.13.1/parquet-cli/pom.xml dependency:copy-dependencies
 
-      - name: Setup Go ${{ matrix.go }}
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: "go.mod"
 
       - name: Download Dependencies
         run: go mod download
@@ -67,9 +65,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Go ${{ matrix.go }}
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
+          # TODO: update to using the version in go.mod when that version supports the go tool directive (1.24.x)
+          # go-version-file: "go.mod"
           go-version: 1.24.x
 
       - name: Validate formatting
@@ -85,7 +85,7 @@ jobs:
 
   #     - uses: actions/setup-go@v3
   #       with:
-  #         go-version: 1.24.x
+  #          go-version-file: "go.mod"
 
   #     - name: golangci-lint
   #       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
       PARQUETGODEBUG: tracebuf=1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.2.1
+        uses: s4u/setup-maven-action@v1.18.0
         with:
           java-version: 17
           maven-version: 3.9.2
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Go ${{ matrix.go }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,13 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.22.x"
+          - "oldstable"
         tags:
           - ""
           - purego
         label:
-          # TODO: add back ARM64 runners
-          # https://github.com/parquet-go/parquet-go/issues/6
           - ubuntu-latest
+          - ubuntu-24.04-arm
 
     runs-on: ${{ matrix.label }}
 
@@ -45,7 +44,7 @@ jobs:
           mvn --file parquet-java-apache-parquet-1.13.1/parquet-cli/pom.xml dependency:copy-dependencies
 
       - name: Setup Go ${{ matrix.go }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -86,7 +85,7 @@ jobs:
 
   #     - uses: actions/setup-go@v3
   #       with:
-  #         go-version: 1.22.x
+  #         go-version: 1.24.x
 
   #     - name: golangci-lint
   #       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/thirdparty.yaml
+++ b/.github/workflows/thirdparty.yaml
@@ -10,9 +10,6 @@ on:
 jobs:
   third-party-tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ['1.22.x']
 
     steps:
       - name: Checkout parquet-go
@@ -22,9 +19,9 @@ jobs:
         run: git clone https://github.com/grafana/tempo.git
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: "tempo/go.mod"
 
       - name: Replace parquet-go with local version
         run: |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dependency on and install with the following command:
 go get github.com/parquet-go/parquet-go
 ```
 
-Go 1.21 or later is required to use the package.
+Go 1.22 or later is required to use the package.
 
 ### Compatibility Guarantees
 


### PR DESCRIPTION

I was looking at submitting a feature, and CI was failing on my local fork because of out of date versions from setup-go.

While updating the CI pipelines, I figured I would bump some versions while I'm at it.

Lastly, fixed the TODO about enabling support for arm64