### PR TITLE
Add struct tags for altering the logical type of binary columns

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -246,6 +246,20 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+		{
+			value: new(struct {
+				Byte          []byte `parquet:"b"`
+				String        string `parquet:"s"`
+				ByteAsString  []byte `parquet:"bs,string"`
+				StringAsBytes string `parquet:"sb,bytes"`
+			}),
+			print: `message {
+	required binary b;
+	required binary s (STRING);
+	required binary bs (STRING);
+	required binary sb;
+}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This change provides fine-grained control over the logical type used for `BYTE_ARRAY` physical types.