### PR TITLE
Support list in parquet-value tag

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -81,7 +81,7 @@ func bufferFuncOf[T any](t reflect.Type, schema *Schema) bufferFunc[T] {
 }
 
 func makeBufferFunc[T any](t reflect.Type, schema *Schema) bufferFunc[T] {
-	writeRows := writeRowsFuncOf(t, schema, nil)
+	writeRows := writeRowsFuncOf(t, schema, nil, nil)
 	return func(buf *GenericBuffer[T], rows []T) (n int, err error) {
 		err = writeRows(buf.base.columns, makeArrayOf(rows), columnLevels{})
 		if err == nil {

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -1333,3 +1333,33 @@ func TestReadMapAsAny(t *testing.T) {
 		t.Errorf("value mismatch: want=%+v got=%+v", anyd, anys)
 	}
 }
+
+func TestMapValueList(t *testing.T) {
+	type Top struct {
+		Map map[string][]string `parquet:"," parquet-value:",list"`
+	}
+
+	tops := []Top{
+		{
+			Map: map[string][]string{
+				"key1": {"value1", "value2"},
+			},
+		},
+	}
+
+	buf := new(bytes.Buffer)
+	w := parquet.NewGenericWriter[Top](buf)
+	_, err := w.Write(tops)
+	if err != nil {
+		t.Fatal("write error: ", err)
+	}
+	w.Close()
+
+	file := bytes.NewReader(buf.Bytes())
+	rows, err := parquet.Read[Top](file, file.Size())
+	if err != nil {
+		t.Fatal("read error: ", err)
+	}
+
+	assertRowsEqual(t, rows, tops)
+}

--- a/schema.go
+++ b/schema.go
@@ -555,8 +555,8 @@ func decimalFixedLenByteArraySize(precision int) int {
 	return int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
 }
 
-func forEachStructTagOption(sf reflect.StructField, do func(t reflect.Type, option, args string)) {
-	if tag := sf.Tag.Get("parquet"); tag != "" {
+func forEachStructTagOption(sf reflect.StructField, tag string, do func(t reflect.Type, option, args string)) {
+	if tag := sf.Tag.Get(tag); tag != "" {
 		_, tag = split(tag) // skip the field name
 		for tag != "" {
 			option := ""

--- a/writer.go
+++ b/writer.go
@@ -155,7 +155,7 @@ func writeFuncOf[T any](t reflect.Type, schema *Schema) writeFunc[T] {
 }
 
 func makeWriteFunc[T any](t reflect.Type, schema *Schema) writeFunc[T] {
-	writeRows := writeRowsFuncOf(t, schema, nil)
+	writeRows := writeRowsFuncOf(t, schema, nil, nil)
 	return func(w *GenericWriter[T], rows []T) (n int, err error) {
 		if w.columns == nil {
 			w.columns = make([]ColumnBuffer, len(w.base.writer.columns))


### PR DESCRIPTION
fixes #267

In this PR, when creating the schema of a parquet file,
if one of the elements is a `map`, I check the `parquet-value` tag, and if it contains a `list`, update the path to include `"list", "element"`

this PR is not ready yet.
the write part works,
but the reading needs to be updated to support the new path as well.
for now, the test `TestMapValueList` is failing.

I open the PR to get some feedback from the maintainers,
so see that I'm on the right track, and that it is worth to put more effort to update the read as well