### PR TITLE
Perf: Skip dictionary decode if we've already done it

### DIFF
--- a/file.go
+++ b/file.go
@@ -810,6 +810,12 @@ func (f *FilePages) ReadPage() (Page, error) {
 		case format.DataPage:
 			page, err = f.readDataPageV1(header, data)
 		case format.DictionaryPage:
+			// If we have already read and decoded the dictionary page, we can skip it. This occurs when
+			// ReadDictionary is called before ReadPage.
+			if f.dictionary != nil {
+				continue
+			}
+
 			// Sometimes parquet files do not have the dictionary page offset
 			// recorded in the column metadata. We account for this by lazily
 			// reading dictionary pages when we encounter them.


### PR DESCRIPTION
This simple PR skips the dictionary decode if it's already been performed. This happens when ReadDictionary is called before ReadPage.

A potentially better, but harder, improvement would be to recognize in ReadDictionary that it can advance `f.rbuf` and do it correctly so the header is not double decoded.