### PR TITLE
fix(buffer): Improve Buffer resilience to invalid sort column names

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -354,9 +354,6 @@ func (buf *Buffer) Len() int {
 // Less returns true if row[i] < row[j] in the buffer.
 func (buf *Buffer) Less(i, j int) bool {
 	for _, entry := range buf.sorted {
-		if entry.buffer == nil {
-			continue
-		}
 		col := entry.buffer
 		switch {
 		case col.Less(i, j):

--- a/buffer.go
+++ b/buffer.go
@@ -353,12 +353,11 @@ func (buf *Buffer) Len() int {
 
 // Less returns true if row[i] < row[j] in the buffer.
 func (buf *Buffer) Less(i, j int) bool {
-	for _, entry := range buf.sorted {
-		col := entry.buffer
+	for _, col := range buf.sorted {
 		switch {
-		case col.Less(i, j):
+		case col.buffer.Less(i, j):
 			return true
-		case col.Less(j, i):
+		case col.buffer.Less(j, i):
 			return false
 		}
 	}

--- a/buffer.go
+++ b/buffer.go
@@ -311,7 +311,7 @@ func (buf *Buffer) configure(schema *Schema) {
 					s1, s2 := sc.Path(), targetLeaf.path
 					n := min(len(s1), len(s2))
 					pathMatch := true
-					for i := 0; i < n; i++ {
+					for i := range n {
 						if s1[i] != s2[i] {
 							pathMatch = false
 							break

--- a/buffer.go
+++ b/buffer.go
@@ -231,9 +231,10 @@ func NewBuffer(options ...RowGroupOption) *Buffer {
 	return buf
 }
 
-// configure sets up the buffer's columns and sorting columns based on the provided schema.
-// It ensures that all sorting columns are present in the schema and that the buffer's
-// columns are correctly configured for each leaf column in the schema.
+// configure sets up the buffer's columns based on the provided schema.
+// It also prepares the internal sorting logic by using only the requested sorting columns
+// (from buf.config.Sorting.SortingColumns) that are actually found within the schema,
+// preserving the requested order but ignoring missing columns.
 func (buf *Buffer) configure(schema *Schema) {
 	if schema == nil {
 		return

--- a/buffer.go
+++ b/buffer.go
@@ -197,7 +197,6 @@ type Buffer struct {
 
 type sortedColumn struct {
 	buffer      ColumnBuffer
-	schemaIndex int
 }
 
 // NewBuffer constructs a new buffer, using the given list of buffer options
@@ -280,7 +279,6 @@ func (buf *Buffer) configure(schema *Schema) {
 			}
 			sortedPlaceholders[sortingIndex] = &sortedColumn{
 				buffer:      column,
-				schemaIndex: columnIndex,
 			}
 		}
 	})

--- a/buffer.go
+++ b/buffer.go
@@ -309,10 +309,7 @@ func (buf *Buffer) configure(schema *Schema) {
 				if targetLeaf != nil {
 					// Inline comparison logic for sc.Path() and targetLeaf.path
 					s1, s2 := sc.Path(), targetLeaf.path
-					n := len(s1)
-					if n > len(s2) {
-						n = len(s2)
-					}
+					n := min(len(s1), len(s2))
 					pathMatch := true
 					for i := 0; i < n; i++ {
 						if s1[i] != s2[i] {

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -1039,16 +1039,14 @@ func TestBufferSortInvalidColumnPanic(t *testing.T) {
 		Name string
 	}
 
-	// This call should panic because "NonExistent" is not a valid column
 	_ = parquet.NewGenericBuffer[SortTestRow](
 		parquet.SortingRowGroupConfig(
 			parquet.SortingColumns(
 				parquet.Ascending("ID"),
-				parquet.Ascending("NonExistent"), // Invalid column name
+				parquet.Ascending("NonExistent"),
 			),
 		),
 	)
 
-	// If the code reaches here, the test failed because it didn't panic
 	t.Errorf("Code proceeded after creating buffer with invalid sorting column, expected panic")
 }


### PR DESCRIPTION
Fixes: #134

This PR addresses the nil pointer panic that occurred when attempting to sort a Buffer or GenericBuffer configured with a SortingColumns option containing column names that do not exist in the buffer's schema.
