### PR TITLE
fix: missing int32 and int64 LogicalTypes

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -519,9 +519,9 @@ func TestSchemaRoundTrip(t *testing.T) {
 			roundTripped: `message root {
 	optional group ints {
 		required int32 int16 (INT(16,true));
-		required int32 int32;
+		required int32 int32 (INT(32,true));
 		required int32 int32l (INT(32,true));
-		required int64 int64;
+		required int64 int64 (INT(64,true));
 		required int64 int64l (INT(64,true));
 		required int32 int8 (INT(8,true));
 		required int96 int96;

--- a/type.go
+++ b/type.go
@@ -348,14 +348,19 @@ func (t booleanType) ConvertValue(val Value, typ Type) (Value, error) {
 
 type int32Type struct{}
 
-func (t int32Type) String() string                           { return "INT32" }
-func (t int32Type) Kind() Kind                               { return Int32 }
-func (t int32Type) Length() int                              { return 32 }
-func (t int32Type) EstimateSize(n int) int                   { return 4 * n }
-func (t int32Type) EstimateNumValues(n int) int              { return n / 4 }
-func (t int32Type) Compare(a, b Value) int                   { return compareInt32(a.int32(), b.int32()) }
-func (t int32Type) ColumnOrder() *format.ColumnOrder         { return &typeDefinedColumnOrder }
-func (t int32Type) LogicalType() *format.LogicalType         { return nil }
+func (t int32Type) String() string                   { return "INT32" }
+func (t int32Type) Kind() Kind                       { return Int32 }
+func (t int32Type) Length() int                      { return 32 }
+func (t int32Type) EstimateSize(n int) int           { return 4 * n }
+func (t int32Type) EstimateNumValues(n int) int      { return n / 4 }
+func (t int32Type) Compare(a, b Value) int           { return compareInt32(a.int32(), b.int32()) }
+func (t int32Type) ColumnOrder() *format.ColumnOrder { return &typeDefinedColumnOrder }
+func (t int32Type) LogicalType() *format.LogicalType {
+	return &format.LogicalType{Integer: &format.IntType{
+		BitWidth: 32,
+		IsSigned: true,
+	}}
+}
 func (t int32Type) ConvertedType() *deprecated.ConvertedType { return nil }
 func (t int32Type) PhysicalType() *format.Type               { return &physicalTypes[Int32] }
 
@@ -431,14 +436,19 @@ func (t int32Type) ConvertValue(val Value, typ Type) (Value, error) {
 
 type int64Type struct{}
 
-func (t int64Type) String() string                           { return "INT64" }
-func (t int64Type) Kind() Kind                               { return Int64 }
-func (t int64Type) Length() int                              { return 64 }
-func (t int64Type) EstimateSize(n int) int                   { return 8 * n }
-func (t int64Type) EstimateNumValues(n int) int              { return n / 8 }
-func (t int64Type) Compare(a, b Value) int                   { return compareInt64(a.int64(), b.int64()) }
-func (t int64Type) ColumnOrder() *format.ColumnOrder         { return &typeDefinedColumnOrder }
-func (t int64Type) LogicalType() *format.LogicalType         { return nil }
+func (t int64Type) String() string                   { return "INT64" }
+func (t int64Type) Kind() Kind                       { return Int64 }
+func (t int64Type) Length() int                      { return 64 }
+func (t int64Type) EstimateSize(n int) int           { return 8 * n }
+func (t int64Type) EstimateNumValues(n int) int      { return n / 8 }
+func (t int64Type) Compare(a, b Value) int           { return compareInt64(a.int64(), b.int64()) }
+func (t int64Type) ColumnOrder() *format.ColumnOrder { return &typeDefinedColumnOrder }
+func (t int64Type) LogicalType() *format.LogicalType {
+	return &format.LogicalType{Integer: &format.IntType{
+		BitWidth: 64,
+		IsSigned: true,
+	}}
+}
 func (t int64Type) ConvertedType() *deprecated.ConvertedType { return nil }
 func (t int64Type) PhysicalType() *format.Type               { return &physicalTypes[Int64] }
 

--- a/type_test.go
+++ b/type_test.go
@@ -1,0 +1,23 @@
+package parquet_test
+
+import (
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+func TestLogicalTypesEqual(t *testing.T) {
+	tests := []struct {
+		a, b parquet.Node
+	}{
+		{parquet.Leaf(parquet.Int32Type), parquet.Int(32)},
+		{parquet.Leaf(parquet.Int64Type), parquet.Int(64)},
+	}
+
+	for _, test := range tests {
+		eq := parquet.EqualNodes(test.a, test.b)
+		if !eq {
+			t.Errorf("expected %v to be equal to %v", test.a, test.b)
+		}
+	}
+}


### PR DESCRIPTION
AFAICT this package has two implementations of the Parquet types int32 and int64. (This is true for other types; I'm just focusing on these two.)
- [`type intType format.IntType`](https://github.com/parquet-go/parquet-go/blob/401fed3de95633e24b110127f346a674f9c62a64/type.go#L1119); example: [`parquet.Int(32)`](https://github.com/parquet-go/parquet-go/blob/401fed3de95633e24b110127f346a674f9c62a64/type.go#L1074-L1080)
- [`type int32Type struct{}`](https://github.com/parquet-go/parquet-go/blob/2ff63c3c8bfd0af19d307c0600c04a4007a2d696/type.go#L349); example: `parquet.Leaf(parquet.Int32Type)`

The `LogicalType()` methods from these implementations differ - one returns nil, the other returns `INT(32, true)`. This causes `parquet.EqualNodes()` to signal the types are not equal. However, [LogicalTypes.md](https://github.com/apache/parquet-format/blob/3ce0760933b875bc8a11f5be0b883cd107b95b43/LogicalTypes.md#signed-integers) indicates that these should be equivalent:
> INT(32, true) and INT(64, true) are implied by the int32 and int64 primitive types if no other annotation is present and should be considered optional.

`parquet.EqualNodes()` uses `reflect.DeepEqual()` to compare logical types. IMHO there are better ways to do that comparison, but this proposal is much simpler - int32 and int64 return non-nil logical type in all circumstances. I've included a regression test.