### PR TITLE
fix: group nodes equal when fields not sorted

### DIFF
--- a/node.go
+++ b/node.go
@@ -1,6 +1,7 @@
 package parquet
 
 import (
+	"cmp"
 	"reflect"
 	"slices"
 	"strings"
@@ -533,6 +534,12 @@ func groupNodesAreEqual(node1, node2 Node) bool {
 		return false
 	}
 
+	slices.SortFunc(fields1, func(a, b Field) int {
+		return cmp.Compare(a.Name(), b.Name())
+	})
+	slices.SortFunc(fields2, func(a, b Field) int {
+		return cmp.Compare(a.Name(), b.Name())
+	})
 	for i := range fields1 {
 		f1 := fields1[i]
 		f2 := fields2[i]

--- a/node_test.go
+++ b/node_test.go
@@ -104,3 +104,25 @@ func TestEncodingOf(t *testing.T) {
 		})
 	}
 }
+
+func TestEqualGroupNodes(t *testing.T) {
+	type RowType struct {
+		Name string `parquet:"name"`
+		Id   string `parquet:"id"`
+	}
+	schemaViaOf := SchemaOf(RowType{})
+
+	group := Group{
+		"name": String(),
+		"id":   String(),
+	}
+	schemaViaNew := NewSchema("", group)
+
+	if schemaViaOf.String() == schemaViaNew.String() {
+		t.Fatal("this test needs two nodes with equal fields in different orders")
+	}
+
+	if !EqualNodes(schemaViaOf, schemaViaNew) {
+		t.Fatal("nodes are not equal")
+	}
+}


### PR DESCRIPTION
Some implementations of `Node.Fields()` sort the returned slice, and some don't. This means that the nodes are not equal according to `EqualNodes()`.

This simply changes `EqualNodes()` to sort fields by name before comparing.