### PR TITLE
Fix memory leak in CopyPages

### DIFF
--- a/page.go
+++ b/page.go
@@ -351,6 +351,7 @@ func CopyPages(dst PageWriter, src PageReader) (numValues int64, err error) {
 		}
 		n, err := dst.WritePage(p)
 		numValues += n
+		Release(p)
 		if err != nil {
 			return numValues, err
 		}


### PR DESCRIPTION
The `CopyPages` function does not release pages after it is done with copying values to the writer. Although this will release the underlying bytes for reuse, my understanding is that the writer should clone values it intends to retain due to this exact reason.

The issue can be reproduced by running the added test without the added `parquet.Release` call: `PARQUETGODEBUG=tracebuf=1 go test . -v -count 10 -run TestCopyFilePages`