### PR TITLE
Allowing to set the dictionary on the FilePages

### DIFF
--- a/file.go
+++ b/file.go
@@ -775,6 +775,11 @@ func (f *FilePages) ReadDictionary() (Dictionary, error) {
 	return f.dictionary, nil
 }
 
+// InitDictionary
+func (f *FilePages) InitDictionary(dict Dictionary) {
+	f.dictionary = dict
+}
+
 // ReadPages reads the next from from f.
 func (f *FilePages) ReadPage() (Page, error) {
 	if f.chunk == nil {

--- a/file_test.go
+++ b/file_test.go
@@ -465,21 +465,9 @@ func TestReadDictionaryPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	foundRows := 0
-	for _, rg := range pf.RowGroups() {
-		cc := rg.ColumnChunks()[0]
-		pages := cc.Pages()
 
-		filePages := pages.(*parquet.FilePages)
-		dict, err := filePages.ReadDictionary()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if dict == nil {
-			t.Fatal("expected dictionary page to be available")
-		}
-
+	check := func(pages parquet.Pages) {
 		for {
 			page, err := pages.ReadPage()
 			if err != nil && err != io.EOF {
@@ -509,7 +497,50 @@ func TestReadDictionaryPage(t *testing.T) {
 				foundRows++
 			}
 		}
+	}
 
+	encodedDictionaries := make([][]byte, len(pf.RowGroups()))
+	for i, rg := range pf.RowGroups() {
+		cc := rg.ColumnChunks()[0]
+		pages := cc.Pages()
+
+		filePages := pages.(*parquet.FilePages)
+		dict, err := filePages.ReadDictionary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dict == nil {
+			t.Fatal("expected dictionary page to be available")
+		}
+		check(filePages)
+		encodedDictionary, err := dict.Type().Encode(nil, dict.Page().Data(), &parquet.DeltaByteArray)
+		if err != nil {
+			t.Fatal("expected dictionary to be encoded")
+		}
+		encodedDictionaries[i] = encodedDictionary
+		pages.Close()
+	}
+
+	if foundRows != totalRows {
+		t.Fatalf("expected %d rows, got %d", totalRows, foundRows)
+	}
+	foundRows = 0
+
+	// Reusing dictionary read previously
+	for i, rg := range pf.RowGroups() {
+		cc := rg.ColumnChunks()[0]
+		pages := cc.Pages()
+
+		filePages := pages.(*parquet.FilePages)
+		values := cc.Type().NewValues(make([]byte, 0, 10), make([]uint32, 0, 10))
+		values, err = cc.Type().Decode(values, encodedDictionaries[i], &parquet.DeltaByteArray)
+		if err != nil {
+			t.Fatal("error decoding dictionary")
+		}
+		_, offsets := values.Data()
+		newDictionary := cc.Type().NewDictionary(cc.Column(), len(offsets), values)
+		filePages.InitDictionary(newDictionary)
+		check(filePages)
 		pages.Close()
 	}
 


### PR DESCRIPTION
This PR allows setting a dictionary on the FilePages struct.

This feature is useful in at least two scenarios:

* Parallel reading: When reading pages in parallel, we can read and decode the dictionary once, avoiding repeated work for each reader.
* Frequently read columns: For columns that are read often, caching the dictionary can prevent redundant decoding, improving performance.

A concrete use case is in the [parquet-common](https://github.com/prometheus-community/parquet-common) library, where we use Parquet files as the storage backend for fulfilling queries. In this context, different queries may access the same column, and caching the dictionary can substantially reduce the number of reads on the Parquet file.