### PR TITLE
add MergeNodes function to merge parquet nodes

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -265,7 +265,7 @@ func Convert(to, from Node) (conv Conversion, err error) {
 		if sourceColumn.node != nil {
 			targetType := targetColumn.node.Type()
 			sourceType := sourceColumn.node.Type()
-			if !typesAreEqual(targetType, sourceType) {
+			if !EqualTypes(targetType, sourceType) {
 				conversions = append(conversions,
 					convertToType(targetType, sourceType),
 				)

--- a/convert.go
+++ b/convert.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math"
 	"math/big"
-	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -260,32 +259,7 @@ func Convert(to, from Node) (conv Conversion, err error) {
 	}
 
 	if EqualNodes(to, from) {
-		//return identity{schema}, nil
-		// Even when schemas are equal, we need to check if column indices match.
-		// MergeNodes can reorder fields (sortFields), so we need column remapping.
-		_, targetColumns := columnMappingOf(to)
-		_, sourceColumns := columnMappingOf(from)
-
-		// Check if column indices are identical (same order)
-		needsRemapping := false
-		if len(targetColumns) == len(sourceColumns) {
-			for i, targetPath := range targetColumns {
-				if i < len(sourceColumns) {
-					sourcePath := sourceColumns[i]
-					if !slices.Equal(targetPath, sourcePath) {
-						needsRemapping = true
-						break
-					}
-				}
-			}
-		} else {
-			needsRemapping = true
-		}
-
-		if !needsRemapping {
-			return identity{schema}, nil
-		}
-		// Fall through to create a proper conversion with column remapping
+		return identity{schema}, nil
 	}
 
 	targetMapping, targetColumns := columnMappingOf(to)

--- a/merge.go
+++ b/merge.go
@@ -37,7 +37,7 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 		schema = rowGroups[0].Schema()
 
 		for _, rowGroup := range rowGroups[1:] {
-			if !SameNodes(schema, rowGroup.Schema()) {
+			if !EqualNodes(schema, rowGroup.Schema()) {
 				return nil, ErrRowGroupSchemaMismatch
 			}
 		}

--- a/merge.go
+++ b/merge.go
@@ -37,10 +37,16 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 		schema = rowGroups[0].Schema()
 
 		for _, rowGroup := range rowGroups[1:] {
-			if !EqualNodes(schema, rowGroup.Schema()) {
+			if !SameNodes(schema, rowGroup.Schema()) {
 				return nil, ErrRowGroupSchemaMismatch
 			}
 		}
+
+		schemas := make([]Node, len(rowGroups))
+		for i, rowGroup := range rowGroups {
+			schemas[i] = rowGroup.Schema()
+		}
+		schema = NewSchema(schema.Name(), MergeNodes(schemas...))
 	}
 
 	mergedRowGroups := make([]RowGroup, len(rowGroups))

--- a/merge.go
+++ b/merge.go
@@ -497,13 +497,13 @@ func (m *mergeBuffer) read() (n int64) {
 	return
 }
 
-// Merge takes a list of nodes and greedily retains properties of the schemas:
+// MergeNodes takes a list of nodes and greedily retains properties of the schemas:
 // - keeps last compression that is not nil
 // - keeps last non-plain encoding that is not nil
 // - keeps last non-zero field id
 // - union of all columns for group nodes
 // - retains the most permissive repetition (required < optional < repeated)
-func Merge(nodes ...Node) Node {
+func MergeNodes(nodes ...Node) Node {
 	switch len(nodes) {
 	case 0:
 		return nil

--- a/merge.go
+++ b/merge.go
@@ -34,19 +34,11 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 		return newEmptyRowGroup(schema), nil
 	}
 	if schema == nil {
-		schema = rowGroups[0].Schema()
-
-		for _, rowGroup := range rowGroups[1:] {
-			if !EqualNodes(schema, rowGroup.Schema()) {
-				return nil, ErrRowGroupSchemaMismatch
-			}
-		}
-
 		schemas := make([]Node, len(rowGroups))
 		for i, rowGroup := range rowGroups {
 			schemas[i] = rowGroup.Schema()
 		}
-		schema = NewSchema(schema.Name(), MergeNodes(schemas...))
+		schema = NewSchema(rowGroups[0].Schema().Name(), MergeNodes(schemas...))
 	}
 
 	mergedRowGroups := make([]RowGroup, len(rowGroups))

--- a/merge_test.go
+++ b/merge_test.go
@@ -464,7 +464,7 @@ func TestMergeRowGroups(t *testing.T) {
 						"user":     {"id", "name"},
 						"metadata": {"created", "updated"},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"user.id":          int64(1),
 						"user.name":        "Alice",
 						"metadata.created": "2023-01-01",
@@ -477,7 +477,7 @@ func TestMergeRowGroups(t *testing.T) {
 						"user":     {"name", "id"},
 						"metadata": {"updated", "created"},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"user.id":          int64(2),
 						"user.name":        "Bob",
 						"metadata.created": "2023-02-01",
@@ -774,12 +774,9 @@ func determineMergedSortingColumns(input []parquet.RowGroup, options []parquet.R
 
 // commonSortingPrefix returns the common prefix of two sorting column slices
 func commonSortingPrefix(a, b []parquet.SortingColumn) []parquet.SortingColumn {
-	minLen := len(a)
-	if len(b) < minLen {
-		minLen = len(b)
-	}
+	minLen := min(len(b), len(a))
 
-	for i := 0; i < minLen; i++ {
+	for i := range minLen {
 		if !equalSortingColumn(a[i], b[i]) {
 			return a[:i]
 		}
@@ -1537,7 +1534,7 @@ func TestMergeFixedSizeByteArrayMinimalReproduction(t *testing.T) {
 
 	// Debug: Let's manually read a few rows to see what's wrong
 	rowBuf := make([]parquet.Row, 1)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		n, err := rows.ReadRows(rowBuf)
 		if err != nil && err != io.EOF {
 			t.Fatalf("Failed to read debug row %d: %v", i, err)
@@ -1817,7 +1814,7 @@ func createRowGroupWithFieldOrder(fieldOrder []string, rows ...Person) parquet.R
 }
 
 // createPersonSubsetRowGroup creates a row group with only a subset of Person fields
-func createPersonSubsetRowGroup(fields []string, rows ...interface{}) parquet.RowGroup {
+func createPersonSubsetRowGroup(fields []string, rows ...any) parquet.RowGroup {
 	buf := parquet.NewBuffer()
 	for _, row := range rows {
 		buf.Write(row)
@@ -1857,7 +1854,7 @@ type NestedType2 struct {
 }
 
 // createNestedRowGroupWithFieldOrder creates a nested row group using different struct orders
-func createNestedRowGroupWithFieldOrder(fieldOrders map[string][]string, values map[string]interface{}) parquet.RowGroup {
+func createNestedRowGroupWithFieldOrder(fieldOrders map[string][]string, values map[string]any) parquet.RowGroup {
 	userID := values["user.id"].(int64)
 	userName := utf8string(values["user.name"].(string))
 	created := utf8string(values["metadata.created"].(string))

--- a/merge_test.go
+++ b/merge_test.go
@@ -337,7 +337,7 @@ func TestMergeRowGroups(t *testing.T) {
 					if merged.NumRows() != test.output.NumRows() {
 						t.Fatalf("the number of rows mismatch: want=%d got=%d", merged.NumRows(), test.output.NumRows())
 					}
-					if merged.Schema() != test.output.Schema() {
+					if !parquet.SameNodes(merged.Schema(), test.output.Schema()) {
 						t.Fatalf("the row group schemas mismatch:\n%v\n%v", test.output.Schema(), merged.Schema())
 					}
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -1109,12 +1109,12 @@ func TestMergeNodes(t *testing.T) {
 func TestMergeRowGroupsWithOverlappingAndMissingFields(t *testing.T) {
 	// Define structs for testing overlapping and missing fields
 	type UserProfile struct {
-		UserID   int         // Overlapping field - present in both schemas
-		Username utf8string  // Unique to first schema - missing from second
+		UserID   int        // Overlapping field - present in both schemas
+		Username utf8string // Unique to first schema - missing from second
 	}
 
 	type UserStats struct {
-		UserID    int // Overlapping field - present in both schemas  
+		UserID     int // Overlapping field - present in both schemas
 		LoginCount int // Unique to second schema - missing from first
 	}
 
@@ -1190,10 +1190,10 @@ func TestMergeRowGroupsWithOverlappingAndMissingFields(t *testing.T) {
 	// Validate that all rows have values for the merged schema's fields
 	schemaFields := schema.Fields()
 	expectedFieldCount := len(schemaFields)
-	
+
 	for i := 0; i < n; i++ {
 		row := readBuffer[i]
-		
+
 		// Each row should have values for all fields in the merged schema
 		if len(row) != expectedFieldCount {
 			t.Errorf("Row %d has %d values, expected %d for merged schema", i, len(row), expectedFieldCount)
@@ -1213,12 +1213,12 @@ func TestMergeRowGroupsWithOverlappingAndMissingFields(t *testing.T) {
 	// The detailed field-level validation is covered by the schema structure tests above
 
 	// Also validate that the merge process correctly handled the overlapping and missing fields:
-	// - UserProfile rows (0,1) should have UserID and Username, with LoginCount as zero/default  
+	// - UserProfile rows (0,1) should have UserID and Username, with LoginCount as zero/default
 	// - UserStats rows (2,3) should have UserID and LoginCount, with Username as zero/default
 	// The exact value handling depends on how parquet processes missing fields
 
 	t.Logf("Successfully merged %d rows with overlapping and missing fields", n)
-	t.Logf("Schema validation passed: UserID=required, Username=optional, LoginCount=optional") 
+	t.Logf("Schema validation passed: UserID=required, Username=optional, LoginCount=optional")
 	t.Logf("Merge behavior: Missing fields are handled through schema conversion during merge")
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -317,7 +317,7 @@ func TestEqualNodes(t *testing.T) {
 			name: "complex nested structure - same",
 			node1: Group{
 				"user": Group{
-					"id":      Int(64),
+					"id": Int(64),
 					"profile": Group{
 						"name":  String(),
 						"email": String(),
@@ -334,7 +334,7 @@ func TestEqualNodes(t *testing.T) {
 			},
 			node2: Group{
 				"user": Group{
-					"id":      Int(64),
+					"id": Int(64),
 					"profile": Group{
 						"name":  String(),
 						"email": String(),
@@ -355,7 +355,7 @@ func TestEqualNodes(t *testing.T) {
 			name: "complex nested structure - different deep field",
 			node1: Group{
 				"user": Group{
-					"id":      Int(64),
+					"id": Int(64),
 					"profile": Group{
 						"name":  String(),
 						"email": String(),
@@ -368,7 +368,7 @@ func TestEqualNodes(t *testing.T) {
 			},
 			node2: Group{
 				"user": Group{
-					"id":      Int(64),
+					"id": Int(64),
 					"profile": Group{
 						"name":  String(),
 						"email": String(),
@@ -418,7 +418,7 @@ func TestEqualNodes(t *testing.T) {
 
 		// Logical types vs non-logical groups with same structure
 		{
-			name: "logical map vs regular group with same structure",
+			name:  "logical map vs regular group with same structure",
 			node1: Map(String(), Int(32)),
 			node2: Group{
 				"key_value": Repeated(Group{
@@ -429,7 +429,7 @@ func TestEqualNodes(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "logical list vs regular group with same structure",
+			name:  "logical list vs regular group with same structure",
 			node1: List(String()),
 			node2: Group{
 				"list": Repeated(Group{
@@ -446,7 +446,7 @@ func TestEqualNodes(t *testing.T) {
 					"value": Int(32),
 				}),
 			},
-			node2: Map(String(), Int(32)),
+			node2:    Map(String(), Int(32)),
 			expected: false,
 		},
 		{
@@ -456,7 +456,7 @@ func TestEqualNodes(t *testing.T) {
 					"element": String(),
 				}),
 			},
-			node2: List(String()),
+			node2:    List(String()),
 			expected: false,
 		},
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/parquet-go/parquet-go/compress"
+	"github.com/parquet-go/parquet-go/compress/gzip"
+	"github.com/parquet-go/parquet-go/compress/snappy"
 	"github.com/parquet-go/parquet-go/encoding"
 )
 
@@ -33,6 +35,442 @@ func (m *mockNode) Fields() []Field             { return m.fields() }
 func (m *mockNode) Encoding() encoding.Encoding { return m.enc() }
 func (m *mockNode) Compression() compress.Codec { return m.compression() }
 func (m *mockNode) GoType() reflect.Type        { return m.goType() }
+
+func TestEqualNodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		node1    Node
+		node2    Node
+		expected bool
+	}{
+		// Basic leaf node equality
+		{
+			name:     "same leaf nodes - boolean",
+			node1:    Leaf(BooleanType),
+			node2:    Leaf(BooleanType),
+			expected: true,
+		},
+		{
+			name:     "same leaf nodes - int32",
+			node1:    Leaf(Int32Type),
+			node2:    Leaf(Int32Type),
+			expected: true,
+		},
+		{
+			name:     "same leaf nodes - string",
+			node1:    String(),
+			node2:    String(),
+			expected: true,
+		},
+		{
+			name:     "different leaf types - int32 vs int64",
+			node1:    Leaf(Int32Type),
+			node2:    Leaf(Int64Type),
+			expected: false,
+		},
+		{
+			name:     "different leaf types - string vs json",
+			node1:    String(),
+			node2:    JSON(),
+			expected: false,
+		},
+
+		// Repetition type differences
+		{
+			name:     "same types, different repetition - required vs optional",
+			node1:    Required(String()),
+			node2:    Optional(String()),
+			expected: false,
+		},
+		{
+			name:     "same types, different repetition - optional vs repeated",
+			node1:    Optional(String()),
+			node2:    Repeated(String()),
+			expected: false,
+		},
+		{
+			name:     "same types, same repetition - both optional",
+			node1:    Optional(String()),
+			node2:    Optional(String()),
+			expected: true,
+		},
+		{
+			name:     "same types, same repetition - both repeated",
+			node1:    Repeated(Int(32)),
+			node2:    Repeated(Int(32)),
+			expected: true,
+		},
+
+		// Logical types
+		{
+			name:     "same logical types - int32",
+			node1:    Int(32),
+			node2:    Int(32),
+			expected: true,
+		},
+		{
+			name:     "same logical types - uint64",
+			node1:    Uint(64),
+			node2:    Uint(64),
+			expected: true,
+		},
+		{
+			name:     "different logical types - int32 vs uint32",
+			node1:    Int(32),
+			node2:    Uint(32),
+			expected: false,
+		},
+		{
+			name:     "same temporal types - date",
+			node1:    Date(),
+			node2:    Date(),
+			expected: true,
+		},
+		{
+			name:     "same temporal types - timestamp millis",
+			node1:    Timestamp(Millisecond),
+			node2:    Timestamp(Millisecond),
+			expected: true,
+		},
+		{
+			name:     "different temporal types - timestamp units",
+			node1:    Timestamp(Millisecond),
+			node2:    Timestamp(Microsecond),
+			expected: false,
+		},
+		{
+			name:     "same decimal types",
+			node1:    Decimal(10, 2, Int32Type),
+			node2:    Decimal(10, 2, Int32Type),
+			expected: true,
+		},
+		{
+			name:     "different decimal precision",
+			node1:    Decimal(10, 2, Int32Type),
+			node2:    Decimal(12, 2, Int32Type),
+			expected: false,
+		},
+
+		// Encoding and compression should be ignored
+		{
+			name:     "same types, different encoding (should be equal)",
+			node1:    Encoded(String(), &DeltaLengthByteArray),
+			node2:    Encoded(String(), &Plain),
+			expected: true,
+		},
+		{
+			name:     "same types, different compression (should be equal)",
+			node1:    Compressed(String(), &gzip.Codec{}),
+			node2:    Compressed(String(), &snappy.Codec{}),
+			expected: true,
+		},
+
+		// Field IDs should be ignored
+		{
+			name:     "same types, different field IDs (should be equal)",
+			node1:    FieldID(String(), 1),
+			node2:    FieldID(String(), 2),
+			expected: true,
+		},
+
+		// Group nodes - empty groups
+		{
+			name:     "empty groups",
+			node1:    Group{},
+			node2:    Group{},
+			expected: true,
+		},
+
+		// Group nodes - single field
+		{
+			name: "groups with same single field",
+			node1: Group{
+				"name": String(),
+			},
+			node2: Group{
+				"name": String(),
+			},
+			expected: true,
+		},
+		{
+			name: "groups with different field names",
+			node1: Group{
+				"name": String(),
+			},
+			node2: Group{
+				"title": String(),
+			},
+			expected: false,
+		},
+		{
+			name: "groups with same field name, different types",
+			node1: Group{
+				"name": String(),
+			},
+			node2: Group{
+				"name": Int(32),
+			},
+			expected: false,
+		},
+
+		// Group nodes - multiple fields
+		{
+			name: "groups with same multiple fields",
+			node1: Group{
+				"id":   Int(64),
+				"name": String(),
+				"age":  Int(32),
+			},
+			node2: Group{
+				"id":   Int(64),
+				"name": String(),
+				"age":  Int(32),
+			},
+			expected: true,
+		},
+		{
+			name: "groups with different field count",
+			node1: Group{
+				"id":   Int(64),
+				"name": String(),
+			},
+			node2: Group{
+				"id":   Int(64),
+				"name": String(),
+				"age":  Int(32),
+			},
+			expected: false,
+		},
+
+		// Group nodes with repetition
+		{
+			name: "groups with same repetition",
+			node1: Optional(Group{
+				"name": String(),
+			}),
+			node2: Optional(Group{
+				"name": String(),
+			}),
+			expected: true,
+		},
+		{
+			name: "groups with different repetition",
+			node1: Required(Group{
+				"name": String(),
+			}),
+			node2: Optional(Group{
+				"name": String(),
+			}),
+			expected: false,
+		},
+
+		// Nested groups
+		{
+			name: "nested groups - same structure",
+			node1: Group{
+				"person": Group{
+					"name": String(),
+					"age":  Int(32),
+				},
+			},
+			node2: Group{
+				"person": Group{
+					"name": String(),
+					"age":  Int(32),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "nested groups - different inner structure",
+			node1: Group{
+				"person": Group{
+					"name": String(),
+					"age":  Int(32),
+				},
+			},
+			node2: Group{
+				"person": Group{
+					"name": String(),
+					"age":  Int(64),
+				},
+			},
+			expected: false,
+		},
+
+		// Mixed leaf and group comparisons
+		{
+			name:     "leaf vs group",
+			node1:    String(),
+			node2:    Group{"name": String()},
+			expected: false,
+		},
+		{
+			name:     "group vs leaf",
+			node1:    Group{"name": String()},
+			node2:    String(),
+			expected: false,
+		},
+
+		// Complex nested structures
+		{
+			name: "complex nested structure - same",
+			node1: Group{
+				"user": Group{
+					"id":      Int(64),
+					"profile": Group{
+						"name":  String(),
+						"email": String(),
+						"settings": Group{
+							"theme":         String(),
+							"notifications": Repeated(String()),
+						},
+					},
+				},
+				"metadata": Optional(Group{
+					"created_at": Timestamp(Millisecond),
+					"tags":       Repeated(String()),
+				}),
+			},
+			node2: Group{
+				"user": Group{
+					"id":      Int(64),
+					"profile": Group{
+						"name":  String(),
+						"email": String(),
+						"settings": Group{
+							"theme":         String(),
+							"notifications": Repeated(String()),
+						},
+					},
+				},
+				"metadata": Optional(Group{
+					"created_at": Timestamp(Millisecond),
+					"tags":       Repeated(String()),
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "complex nested structure - different deep field",
+			node1: Group{
+				"user": Group{
+					"id":      Int(64),
+					"profile": Group{
+						"name":  String(),
+						"email": String(),
+						"settings": Group{
+							"theme":         String(),
+							"notifications": Repeated(String()),
+						},
+					},
+				},
+			},
+			node2: Group{
+				"user": Group{
+					"id":      Int(64),
+					"profile": Group{
+						"name":  String(),
+						"email": String(),
+						"settings": Group{
+							"theme":         String(),
+							"notifications": Repeated(Int(32)), // Different type here
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+
+		// Map types (group types with MAP logical type)
+		{
+			name:     "same map types",
+			node1:    Map(String(), Int(32)),
+			node2:    Map(String(), Int(32)),
+			expected: true,
+		},
+		{
+			name:     "different map key types",
+			node1:    Map(String(), Int(32)),
+			node2:    Map(Int(32), Int(32)),
+			expected: false,
+		},
+		{
+			name:     "different map value types",
+			node1:    Map(String(), Int(32)),
+			node2:    Map(String(), String()),
+			expected: false,
+		},
+
+		// List types (group types with LIST logical type)
+		{
+			name:     "same list types",
+			node1:    List(String()),
+			node2:    List(String()),
+			expected: true,
+		},
+		{
+			name:     "different list element types",
+			node1:    List(String()),
+			node2:    List(Int(32)),
+			expected: false,
+		},
+
+		// Logical types vs non-logical groups with same structure
+		{
+			name: "logical map vs regular group with same structure",
+			node1: Map(String(), Int(32)),
+			node2: Group{
+				"key_value": Repeated(Group{
+					"key":   String(),
+					"value": Int(32),
+				}),
+			},
+			expected: false,
+		},
+		{
+			name: "logical list vs regular group with same structure",
+			node1: List(String()),
+			node2: Group{
+				"list": Repeated(Group{
+					"element": String(),
+				}),
+			},
+			expected: false,
+		},
+		{
+			name: "regular group vs logical map with same structure",
+			node1: Group{
+				"key_value": Repeated(Group{
+					"key":   String(),
+					"value": Int(32),
+				}),
+			},
+			node2: Map(String(), Int(32)),
+			expected: false,
+		},
+		{
+			name: "regular group vs logical list with same structure",
+			node1: Group{
+				"list": Repeated(Group{
+					"element": String(),
+				}),
+			},
+			node2: List(String()),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := EqualNodes(test.node1, test.node2)
+			if result != test.expected {
+				t.Errorf("EqualNodes(%v, %v) = %v, expected %v",
+					test.node1, test.node2, result, test.expected)
+			}
+		})
+	}
+}
 
 func TestEncodingOf(t *testing.T) {
 	testCases := []struct {

--- a/row_group_test.go
+++ b/row_group_test.go
@@ -23,9 +23,9 @@ func sortedRowGroup(options []parquet.RowGroupOption, rows ...any) parquet.RowGr
 }
 
 type Person struct {
+	Age       int
 	FirstName utf8string
 	LastName  utf8string
-	Age       int
 }
 
 type LastNameOnly struct {

--- a/type.go
+++ b/type.go
@@ -213,6 +213,30 @@ type Type interface {
 	ConvertValue(val Value, typ Type) (Value, error)
 }
 
+// EqualTypes returns true if type1 and type2 are equal.
+//
+// Types are considered equal if they have the same Kind, Length, and LogicalType.
+// The comparison uses reflect.DeepEqual for LogicalType comparison.
+//
+// Note: This function is designed for leaf types. For complex group types like
+// MAP and LIST, use EqualNodes instead, as those types require structural comparison
+// of their nested fields.
+func EqualTypes(type1, type2 Type) bool {
+	return equalKind(type1, type2) && equalLength(type1, type2) && equalLogicalTypes(type1, type2)
+}
+
+func equalKind(type1, type2 Type) bool {
+	return type1.Kind() == type2.Kind()
+}
+
+func equalLength(type1, type2 Type) bool {
+	return type1.Length() == type2.Length()
+}
+
+func equalLogicalTypes(type1, type2 Type) bool {
+	return reflect.DeepEqual(type1.LogicalType(), type2.LogicalType())
+}
+
 var (
 	BooleanType   Type = booleanType{}
 	Int32Type     Type = int32Type{}

--- a/type_test.go
+++ b/type_test.go
@@ -21,3 +21,313 @@ func TestLogicalTypesEqual(t *testing.T) {
 		}
 	}
 }
+
+func TestEqualTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		type1    parquet.Type
+		type2    parquet.Type
+		expected bool
+	}{
+		// Basic physical types - should be equal
+		{
+			name:     "same boolean types",
+			type1:    parquet.BooleanType,
+			type2:    parquet.BooleanType,
+			expected: true,
+		},
+		{
+			name:     "same int32 types",
+			type1:    parquet.Int32Type,
+			type2:    parquet.Int32Type,
+			expected: true,
+		},
+		{
+			name:     "same int64 types",
+			type1:    parquet.Int64Type,
+			type2:    parquet.Int64Type,
+			expected: true,
+		},
+		{
+			name:     "same float types",
+			type1:    parquet.FloatType,
+			type2:    parquet.FloatType,
+			expected: true,
+		},
+		{
+			name:     "same double types",
+			type1:    parquet.DoubleType,
+			type2:    parquet.DoubleType,
+			expected: true,
+		},
+		{
+			name:     "same byte array types",
+			type1:    parquet.ByteArrayType,
+			type2:    parquet.ByteArrayType,
+			expected: true,
+		},
+		{
+			name:     "same int96 types",
+			type1:    parquet.Int96Type,
+			type2:    parquet.Int96Type,
+			expected: true,
+		},
+
+		// Different physical types - should not be equal
+		{
+			name:     "different kinds - int32 vs int64",
+			type1:    parquet.Int32Type,
+			type2:    parquet.Int64Type,
+			expected: false,
+		},
+		{
+			name:     "different kinds - boolean vs int32",
+			type1:    parquet.BooleanType,
+			type2:    parquet.Int32Type,
+			expected: false,
+		},
+		{
+			name:     "different kinds - float vs double",
+			type1:    parquet.FloatType,
+			type2:    parquet.DoubleType,
+			expected: false,
+		},
+		{
+			name:     "different kinds - byte array vs fixed len byte array",
+			type1:    parquet.ByteArrayType,
+			type2:    parquet.FixedLenByteArrayType(10),
+			expected: false,
+		},
+
+		// Fixed length byte arrays with different lengths
+		{
+			name:     "same fixed len byte array types",
+			type1:    parquet.FixedLenByteArrayType(16),
+			type2:    parquet.FixedLenByteArrayType(16),
+			expected: true,
+		},
+		{
+			name:     "different fixed len byte array lengths",
+			type1:    parquet.FixedLenByteArrayType(16),
+			type2:    parquet.FixedLenByteArrayType(32),
+			expected: false,
+		},
+
+		// Logical types - same underlying physical type
+		{
+			name:     "same string logical types",
+			type1:    parquet.String().Type(),
+			type2:    parquet.String().Type(),
+			expected: true,
+		},
+		{
+			name:     "same int32 logical types",
+			type1:    parquet.Int(32).Type(),
+			type2:    parquet.Int(32).Type(),
+			expected: true,
+		},
+		{
+			name:     "same int64 logical types",
+			type1:    parquet.Int(64).Type(),
+			type2:    parquet.Int(64).Type(),
+			expected: true,
+		},
+		{
+			name:     "same uint32 logical types",
+			type1:    parquet.Uint(32).Type(),
+			type2:    parquet.Uint(32).Type(),
+			expected: true,
+		},
+		{
+			name:     "same uint64 logical types",
+			type1:    parquet.Uint(64).Type(),
+			type2:    parquet.Uint(64).Type(),
+			expected: true,
+		},
+		{
+			name:     "same date logical types",
+			type1:    parquet.Date().Type(),
+			type2:    parquet.Date().Type(),
+			expected: true,
+		},
+		{
+			name:     "same json logical types",
+			type1:    parquet.JSON().Type(),
+			type2:    parquet.JSON().Type(),
+			expected: true,
+		},
+		{
+			name:     "same bson logical types",
+			type1:    parquet.BSON().Type(),
+			type2:    parquet.BSON().Type(),
+			expected: true,
+		},
+
+		// Different logical types with same physical type
+		{
+			name:     "string vs json (both byte array)",
+			type1:    parquet.String().Type(),
+			type2:    parquet.JSON().Type(),
+			expected: false,
+		},
+		{
+			name:     "string vs bson (both byte array)",
+			type1:    parquet.String().Type(),
+			type2:    parquet.BSON().Type(),
+			expected: false,
+		},
+		{
+			name:     "json vs bson (both byte array)",
+			type1:    parquet.JSON().Type(),
+			type2:    parquet.BSON().Type(),
+			expected: false,
+		},
+		{
+			name:     "int32 vs uint32 (same physical kind)",
+			type1:    parquet.Int(32).Type(),
+			type2:    parquet.Uint(32).Type(),
+			expected: false,
+		},
+		{
+			name:     "int64 vs uint64 (same physical kind)",
+			type1:    parquet.Int(64).Type(),
+			type2:    parquet.Uint(64).Type(),
+			expected: false,
+		},
+
+		// Different bit widths for same logical type
+		{
+			name:     "int32 vs int64 logical types",
+			type1:    parquet.Int(32).Type(),
+			type2:    parquet.Int(64).Type(),
+			expected: false,
+		},
+		{
+			name:     "uint32 vs uint64 logical types",
+			type1:    parquet.Uint(32).Type(),
+			type2:    parquet.Uint(64).Type(),
+			expected: false,
+		},
+
+		// Timestamp logical types with different units
+		{
+			name:     "same timestamp millis",
+			type1:    parquet.Timestamp(parquet.Millisecond).Type(),
+			type2:    parquet.Timestamp(parquet.Millisecond).Type(),
+			expected: true,
+		},
+		{
+			name:     "same timestamp micros",
+			type1:    parquet.Timestamp(parquet.Microsecond).Type(),
+			type2:    parquet.Timestamp(parquet.Microsecond).Type(),
+			expected: true,
+		},
+		{
+			name:     "same timestamp nanos",
+			type1:    parquet.Timestamp(parquet.Nanosecond).Type(),
+			type2:    parquet.Timestamp(parquet.Nanosecond).Type(),
+			expected: true,
+		},
+		{
+			name:     "different timestamp units - millis vs micros",
+			type1:    parquet.Timestamp(parquet.Millisecond).Type(),
+			type2:    parquet.Timestamp(parquet.Microsecond).Type(),
+			expected: false,
+		},
+		{
+			name:     "different timestamp units - micros vs nanos",
+			type1:    parquet.Timestamp(parquet.Microsecond).Type(),
+			type2:    parquet.Timestamp(parquet.Nanosecond).Type(),
+			expected: false,
+		},
+
+		// Time logical types with different units
+		{
+			name:     "same time millis",
+			type1:    parquet.Time(parquet.Millisecond).Type(),
+			type2:    parquet.Time(parquet.Millisecond).Type(),
+			expected: true,
+		},
+		{
+			name:     "same time micros",
+			type1:    parquet.Time(parquet.Microsecond).Type(),
+			type2:    parquet.Time(parquet.Microsecond).Type(),
+			expected: true,
+		},
+		{
+			name:     "same time nanos",
+			type1:    parquet.Time(parquet.Nanosecond).Type(),
+			type2:    parquet.Time(parquet.Nanosecond).Type(),
+			expected: true,
+		},
+		{
+			name:     "different time units - millis vs micros",
+			type1:    parquet.Time(parquet.Millisecond).Type(),
+			type2:    parquet.Time(parquet.Microsecond).Type(),
+			expected: false,
+		},
+
+		// Logical type vs physical type
+		{
+			name:     "string logical vs byte array physical",
+			type1:    parquet.String().Type(),
+			type2:    parquet.ByteArrayType,
+			expected: false,
+		},
+		{
+			name:     "int32 logical vs int32 with same logical type",
+			type1:    parquet.Int(32).Type(),
+			type2:    parquet.Int32Type,
+			expected: true, // Both have the same Integer logical type
+		},
+		{
+			name:     "date logical vs int32 physical",
+			type1:    parquet.Date().Type(),
+			type2:    parquet.Int32Type,
+			expected: false,
+		},
+
+		// Decimal logical types with different precision/scale
+		{
+			name:     "same decimal(10,2)",
+			type1:    parquet.Decimal(10, 2, parquet.Int32Type).Type(),
+			type2:    parquet.Decimal(10, 2, parquet.Int32Type).Type(),
+			expected: true,
+		},
+		{
+			name:     "different decimal precision",
+			type1:    parquet.Decimal(10, 2, parquet.Int32Type).Type(),
+			type2:    parquet.Decimal(12, 2, parquet.Int32Type).Type(),
+			expected: false,
+		},
+		{
+			name:     "different decimal scale",
+			type1:    parquet.Decimal(10, 2, parquet.Int32Type).Type(),
+			type2:    parquet.Decimal(10, 3, parquet.Int32Type).Type(),
+			expected: false,
+		},
+		{
+			name:     "same decimal different physical type",
+			type1:    parquet.Decimal(10, 2, parquet.Int32Type).Type(),
+			type2:    parquet.Decimal(10, 2, parquet.Int64Type).Type(),
+			expected: false,
+		},
+
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := parquet.EqualTypes(test.type1, test.type2)
+			if result != test.expected {
+				t.Errorf("EqualTypes(%v, %v) = %v, expected %v", 
+					test.type1, test.type2, result, test.expected)
+				
+				// Additional debugging info
+				t.Logf("Type1: Kind=%v, Length=%v, LogicalType=%v", 
+					test.type1.Kind(), test.type1.Length(), test.type1.LogicalType())
+				t.Logf("Type2: Kind=%v, Length=%v, LogicalType=%v", 
+					test.type2.Kind(), test.type2.Length(), test.type2.LogicalType())
+			}
+		})
+	}
+}

--- a/type_test.go
+++ b/type_test.go
@@ -312,20 +312,19 @@ func TestEqualTypes(t *testing.T) {
 			type2:    parquet.Decimal(10, 2, parquet.Int64Type).Type(),
 			expected: false,
 		},
-
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := parquet.EqualTypes(test.type1, test.type2)
 			if result != test.expected {
-				t.Errorf("EqualTypes(%v, %v) = %v, expected %v", 
+				t.Errorf("EqualTypes(%v, %v) = %v, expected %v",
 					test.type1, test.type2, result, test.expected)
-				
+
 				// Additional debugging info
-				t.Logf("Type1: Kind=%v, Length=%v, LogicalType=%v", 
+				t.Logf("Type1: Kind=%v, Length=%v, LogicalType=%v",
 					test.type1.Kind(), test.type1.Length(), test.type1.LogicalType())
-				t.Logf("Type2: Kind=%v, Length=%v, LogicalType=%v", 
+				t.Logf("Type2: Kind=%v, Length=%v, LogicalType=%v",
 					test.type2.Kind(), test.type2.Length(), test.type2.LogicalType())
 			}
 		})


### PR DESCRIPTION
This change adds a new `MergeNodes` function which combines multiple parquet nodes in a greedy way to retain the most important properties of each node.

I ended up expanding the PR to add `EqualTypes` and tests for `EqualTypes` and `EqualNodes`, as well as fixing an inconsistency in `EqualNodes` (it was checking logical types of leaf nodes but node the logical types of group nodes).