### PR TITLE
Support tags for list elements

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -267,6 +267,11 @@ func TestSchemaOf(t *testing.T) {
 				} `parquet:"a,id(1)"`
 				D []string `parquet:"d,id(4),list"`
 				E []int    `parquet:"e,id(5),list" parquet-element:",id(6)"`
+				F []string `parquet:"f,id(7),list" parquet-element:",id(8),json"`
+				G []struct {
+					H string `parquet:"h,id(12)"`
+					I int    `parquet:"i,id(13)"`
+				} `parquet:"g,id(9),list" parquet-element:",id(11)"`
 			}),
 			print: `message {
 	required group a = 1 {
@@ -284,6 +289,19 @@ func TestSchemaOf(t *testing.T) {
 	required group e (LIST) = 5 {
 		repeated group list {
 			required int64 element (INT(64,true)) = 6;
+		}
+	}
+	required group f (LIST) = 7 {
+		repeated group list {
+			required binary element (JSON) = 8;
+		}
+	}
+	required group g (LIST) = 9 {
+		repeated group list {
+			required group element = 11 {
+				required binary h (STRING) = 12;
+				required int64 i (INT(64,true)) = 13;
+			}
 		}
 	}
 }`,

--- a/schema_test.go
+++ b/schema_test.go
@@ -260,6 +260,34 @@ func TestSchemaOf(t *testing.T) {
 	required binary sb;
 }`,
 		},
+		{
+			value: new(struct {
+				A struct {
+					B []string `parquet:"b,id(2),list" parquet-element:",id(3)"`
+				} `parquet:"a,id(1)"`
+				D []string `parquet:"d,id(4),list"`
+				E []int    `parquet:"e,id(5),list" parquet-element:",id(6)"`
+			}),
+			print: `message {
+	required group a = 1 {
+		required group b (LIST) = 2 {
+			repeated group list {
+				required binary element (STRING) = 3;
+			}
+		}
+	}
+	required group d (LIST) = 4 {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	required group e (LIST) = 5 {
+		repeated group list {
+			required int64 element (INT(64,true)) = 6;
+		}
+	}
+}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR introduces a new `parquet-element` tag. This tag allows for configuring list elements, similar to how `parquet-key` and `parquet-value tags` are used for maps. For us this is need to be able to specify a field id on the list element, but the implementation is done in a way that allows for other supported options.

Fixes https://github.com/parquet-go/parquet-go/issues/281