### PR TITLE
Avoid extra ReadAt calls when seeking pages (sync mode)

### DIFF
--- a/file.go
+++ b/file.go
@@ -1000,6 +1000,12 @@ func (f *FilePages) SeekToRow(rowIndex int64) (err error) {
 		if index < 0 {
 			return ErrSeekOutOfRange
 		}
+
+		if f.index == index {
+			f.skip = rowIndex - pages[index].FirstRowIndex
+			return nil
+		}
+
 		_, err = f.section.Seek(pages[index].Offset-f.baseOffset, io.SeekStart)
 		f.skip = rowIndex - pages[index].FirstRowIndex
 		f.index = index

--- a/file_test.go
+++ b/file_test.go
@@ -606,7 +606,7 @@ func BenchmarkSeekThroughFile(b *testing.B) {
 	opts := []parquet.FileOption{
 		parquet.SkipBloomFilters(true),
 		parquet.FileReadMode(parquet.ReadModeSync), // sync helps with tracking the reads/op
-		parquet.ReadBufferSize(60 * 1024),          // roughly the page size in the 'V' column
+		parquet.ReadBufferSize(90 * 1024),          // roughly 1.5x the page size in the 'V' column
 	}
 
 	f, err := parquet.OpenFile(ctr, int64(len(data)), opts...)

--- a/file_test.go
+++ b/file_test.go
@@ -623,6 +623,8 @@ func BenchmarkSeekThroughFile(b *testing.B) {
 
 			// seek / read through the whole file using Reader
 			b.Run("reader", func(b *testing.B) {
+				row := make([]benchRow, 1)
+
 				for i, stepSize := range steps {
 					name := fmt.Sprintf("step size=%d", stepSize)
 					if stepSize == 0 {
@@ -633,7 +635,7 @@ func BenchmarkSeekThroughFile(b *testing.B) {
 
 						// benchmark loop: read / seek through the whole file
 						for b.Loop() {
-							r := parquet.NewReader(f)
+							r := parquet.NewGenericReader[benchRow](f)
 
 							for j := range numRows {
 								if stepSize > 0 { // if seek is zero, we don't seek at all (baseline)
@@ -646,8 +648,7 @@ func BenchmarkSeekThroughFile(b *testing.B) {
 									}
 								}
 
-								var row benchRow
-								err = r.Read(&row)
+								_, err = r.Read(row)
 								if err != nil {
 									if errors.Is(err, io.EOF) {
 										break


### PR DESCRIPTION
Seeking through a column with small forward steps can trigger a large number of additional `ReadAt` calls. In some cases far more than a sequential scan of the same column

I added the benchmark `BenchmarkSeekThroughFile` to illustrate this: the sequential `no-seek` baseline is at ~84 reads/op, while seeking with small step sizes resulted in up to ~1600k reads/op. This effect appears in both sync and async modes, and with GenericReader (and legacy Reader) as well as Pages.

This PR addresses the issue for async reads with Pages. In this case, the main contributors were in FilePages:
* re-reading the same page after seeks
* resetting bufio.Reader on each seek, discarding prefetched bytes

<details><summary>Benchmark before vs. this fix</summary>

```
goos: linux
goarch: amd64
pkg: github.com/parquet-go/parquet-go
cpu: AMD Ryzen 7 PRO 6850U with Radeon Graphics     
                                              │ bench-seek-01-baseline.txt │  bench-seek-01-fix-sync-pages.txt   │
                                              │           sec/op           │    sec/op     vs base               │
SeekThroughFile/sync/reader/no-seek-16                         36.57m ± 3%    35.86m ± 3%        ~ (p=0.442 n=8)
SeekThroughFile/sync/reader/step_size=7-16                     197.5m ± 2%    206.4m ± 4%   +4.46% (p=0.001 n=8)
SeekThroughFile/sync/reader/step_size=29-16                    44.65m ± 4%    45.52m ± 3%        ~ (p=0.328 n=8)
SeekThroughFile/sync/reader/step_size=61-16                    21.25m ± 2%    22.03m ± 3%   +3.67% (p=0.003 n=8)
SeekThroughFile/sync/reader/step_size=127-16                   9.934m ± 3%   10.301m ± 3%   +3.70% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=251-16                   5.337m ± 1%    5.613m ± 3%   +5.18% (p=0.000 n=8)
SeekThroughFile/sync/pages/no-seek-16                          11.97m ± 2%    12.02m ± 2%        ~ (p=0.798 n=8)
SeekThroughFile/sync/pages/step_size=7-16                     134.35m ± 2%    15.31m ± 2%  -88.61% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=29-16                     31.03m ± 3%    12.62m ± 2%  -59.32% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=61-16                     16.73m ± 8%    10.62m ± 3%  -36.50% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=127-16                    7.244m ± 2%    6.987m ± 1%   -3.55% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=251-16                    3.762m ± 1%    3.797m ± 2%        ~ (p=0.161 n=8)
SeekThroughFile/async/reader/no-seek-16                        29.94m ± 2%    30.43m ± 3%        ~ (p=0.130 n=8)
SeekThroughFile/async/reader/step_size=7-16                    369.7m ± 1%    363.0m ± 2%   -1.81% (p=0.015 n=8)
SeekThroughFile/async/reader/step_size=29-16                   80.84m ± 3%    78.54m ± 2%   -2.86% (p=0.002 n=8)
SeekThroughFile/async/reader/step_size=61-16                   38.20m ± 3%    38.01m ± 3%        ~ (p=0.382 n=8)
SeekThroughFile/async/reader/step_size=127-16                  17.98m ± 3%    18.03m ± 1%        ~ (p=0.721 n=8)
SeekThroughFile/async/reader/step_size=251-16                  9.767m ± 3%    9.667m ± 5%        ~ (p=0.798 n=8)
SeekThroughFile/async/pages/no-seek-16                         13.60m ± 2%    13.61m ± 2%        ~ (p=1.000 n=8)
SeekThroughFile/async/pages/step_size=7-16                     327.3m ± 4%    254.0m ± 5%  -22.39% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=29-16                    70.60m ± 3%    54.29m ± 4%  -23.10% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=61-16                    34.59m ± 2%    26.72m ± 3%  -22.76% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=127-16                   16.06m ± 2%    13.00m ± 4%  -19.06% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=251-16                   8.349m ± 2%    7.276m ± 1%  -12.85% (p=0.000 n=8)
geomean                                                        28.34m         23.45m       -17.26%

                                              │ bench-seek-01-baseline.txt │   bench-seek-01-fix-sync-pages.txt   │
                                              │          reads/op          │  reads/op    vs base                 │
SeekThroughFile/sync/reader/no-seek-16                          89.00 ± 0%    88.00 ± 0%   -1.12% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=7-16                     4.987k ± 0%   3.334k ± 0%  -33.15% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=29-16                    1049.0 ± 0%    701.0 ± 0%  -33.17% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=61-16                     506.0 ± 0%    338.0 ± 0%  -33.20% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=127-16                    231.0 ± 0%    154.0 ± 0%  -33.33% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=251-16                   122.00 ± 0%    82.00 ± 0%  -32.79% (p=0.000 n=8)
SeekThroughFile/sync/pages/no-seek-16                           84.00 ± 0%    84.00 ± 0%        ~ (p=1.000 n=8) ¹
SeekThroughFile/sync/pages/step_size=7-16                     1653.00 ± 0%    83.00 ± 0%  -94.98% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=29-16                     348.00 ± 0%    83.00 ± 0%  -76.15% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=61-16                     168.00 ± 0%    78.00 ± 0%  -53.57% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=127-16                     77.00 ± 0%    66.00 ± 0%  -14.29% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=251-16                     40.00 ± 0%    40.00 ± 0%        ~ (p=1.000 n=8) ¹
SeekThroughFile/async/reader/no-seek-16                         89.00 ± 0%    88.00 ± 0%   -1.12% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=7-16                    6.850k ± 0%   5.172k ± 0%  -24.50% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=29-16                   1.446k ± 0%   1.093k ± 1%  -24.44% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=61-16                    699.4 ± 0%    529.3 ± 1%  -24.31% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=127-16                   321.8 ± 0%    243.9 ± 0%  -24.18% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=251-16                   167.8 ± 0%    127.7 ± 1%  -23.90% (p=0.000 n=8)
SeekThroughFile/async/pages/no-seek-16                          84.00 ± 0%    84.00 ± 0%        ~ (p=1.000 n=8) ¹
SeekThroughFile/async/pages/step_size=7-16                     3.526k ± 1%   3.147k ± 1%  -10.75% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=29-16                     746.1 ± 1%    556.9 ± 2%  -25.37% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=61-16                     363.6 ± 1%    249.3 ± 1%  -31.44% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=127-16                    169.0 ± 1%    108.8 ± 1%  -35.62% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=251-16                    87.81 ± 1%    70.23 ± 1%  -20.01% (p=0.000 n=8)
geomean                                                         342.1         223.5       -34.67%
¹ all samples are equal

                                              │ bench-seek-01-baseline.txt │  bench-seek-01-fix-sync-pages.txt   │
                                              │            B/op            │     B/op      vs base               │
SeekThroughFile/sync/reader/no-seek-16                        79.13Mi ± 0%   79.05Mi ± 0%   -0.10% (p=0.001 n=8)
SeekThroughFile/sync/reader/step_size=7-16                    586.0Mi ± 0%   584.6Mi ± 0%   -0.25% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=29-16                   123.5Mi ± 0%   123.0Mi ± 0%   -0.37% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=61-16                   59.69Mi ± 0%   59.52Mi ± 0%   -0.29% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=127-16                  27.00Mi ± 0%   26.91Mi ± 0%   -0.36% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=251-16                  14.58Mi ± 0%   14.55Mi ± 0%   -0.26% (p=0.000 n=8)
SeekThroughFile/sync/pages/no-seek-16                         36.92Mi ± 0%   36.92Mi ± 0%        ~ (p=1.000 n=8)
SeekThroughFile/sync/pages/step_size=7-16                    455.23Mi ± 0%   37.27Mi ± 0%  -91.81% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=29-16                    96.02Mi ± 0%   36.99Mi ± 0%  -61.47% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=61-16                    46.62Mi ± 0%   31.56Mi ± 0%  -32.31% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=127-16                   21.23Mi ± 0%   20.39Mi ± 0%   -3.95% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=251-16                   11.03Mi ± 0%   11.03Mi ± 0%   -0.02% (p=0.015 n=8)
SeekThroughFile/async/reader/no-seek-16                       79.74Mi ± 0%   79.64Mi ± 0%   -0.12% (p=0.005 n=8)
SeekThroughFile/async/reader/step_size=7-16                   626.6Mi ± 0%   610.2Mi ± 0%   -2.62% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=29-16                  132.8Mi ± 1%   129.3Mi ± 0%   -2.63% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=61-16                  64.22Mi ± 1%   62.61Mi ± 0%   -2.52% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=127-16                 29.26Mi ± 0%   28.58Mi ± 0%   -2.34% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=251-16                 15.84Mi ± 0%   15.48Mi ± 0%   -2.25% (p=0.000 n=8)
SeekThroughFile/async/pages/no-seek-16                        37.28Mi ± 0%   37.21Mi ± 0%        ~ (p=0.083 n=8)
SeekThroughFile/async/pages/step_size=7-16                    483.7Mi ± 0%   461.5Mi ± 0%   -4.59% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=29-16                  102.01Mi ± 0%   98.55Mi ± 0%   -3.39% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=61-16                   49.43Mi ± 1%   48.66Mi ± 0%   -1.55% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=127-16                  22.76Mi ± 0%   22.35Mi ± 1%   -1.81% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=251-16                  11.88Mi ± 0%   11.59Mi ± 0%   -2.44% (p=0.000 n=8)
geomean                                                       62.26Mi        52.33Mi       -15.96%

                                              │ bench-seek-01-baseline.txt │  bench-seek-01-fix-sync-pages.txt  │
                                              │         allocs/op          │  allocs/op   vs base               │
SeekThroughFile/sync/reader/no-seek-16                         470.0k ± 0%   470.0k ± 0%        ~ (p=0.223 n=8)
SeekThroughFile/sync/reader/step_size=7-16                     148.4k ± 0%   145.0k ± 0%   -2.29% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=29-16                    31.09k ± 0%   30.36k ± 0%   -2.34% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=61-16                    15.01k ± 0%   14.66k ± 0%   -2.30% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=127-16                   6.809k ± 0%   6.652k ± 0%   -2.32% (p=0.000 n=8)
SeekThroughFile/sync/reader/step_size=251-16                   3.525k ± 0%   3.445k ± 0%   -2.27% (p=0.000 n=8)
SeekThroughFile/sync/pages/no-seek-16                          1.955k ± 0%   1.955k ± 0%        ~ (p=0.818 n=8)
SeekThroughFile/sync/pages/step_size=7-16                     28.604k ± 0%   6.840k ± 0%  -76.09% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=29-16                     6.045k ± 0%   2.975k ± 0%  -50.79% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=61-16                     2.928k ± 0%   2.145k ± 0%  -26.74% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=127-16                    1.344k ± 0%   1.300k ± 0%   -3.27% (p=0.000 n=8)
SeekThroughFile/sync/pages/step_size=251-16                     699.0 ± 0%    698.0 ± 0%   -0.14% (p=0.001 n=8)
SeekThroughFile/async/reader/no-seek-16                        470.1k ± 0%   470.1k ± 0%   -0.00% (p=0.032 n=8)
SeekThroughFile/async/reader/step_size=7-16                    187.1k ± 0%   183.0k ± 0%   -2.18% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=29-16                   39.36k ± 0%   38.44k ± 0%   -2.33% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=61-16                   19.01k ± 0%   18.60k ± 0%   -2.15% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=127-16                  8.665k ± 0%   8.483k ± 0%   -2.09% (p=0.000 n=8)
SeekThroughFile/async/reader/step_size=251-16                  4.492k ± 0%   4.399k ± 0%   -2.07% (p=0.000 n=8)
SeekThroughFile/async/pages/no-seek-16                         2.006k ± 0%   2.001k ± 0%   -0.25% (p=0.010 n=8)
SeekThroughFile/async/pages/step_size=7-16                     44.51k ± 1%   39.45k ± 1%  -11.36% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=29-16                    9.498k ± 1%   8.252k ± 1%  -13.11% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=61-16                    4.643k ± 0%   4.034k ± 0%  -13.13% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=127-16                   2.179k ± 1%   1.889k ± 1%  -13.27% (p=0.000 n=8)
SeekThroughFile/async/pages/step_size=251-16                   1.141k ± 1%   1.026k ± 1%  -10.08% (p=0.000 n=8)
geomean                                                        11.29k        9.809k       -13.08%
```
</details>

While the benchmark show that this fix reduces the number of reads in all scenarios, it also shows that only the benchmark `SeekThroughFile/sync/pages/` completely eliminates all additional reads. Other scenarios still report thousands of additional reads when seeking with small forward steps. Those could be fixed in a separate PR.



