### PR TITLE
Support uuid logical type for string and [16]byte types

### DIFF
--- a/row_test.go
+++ b/row_test.go
@@ -513,6 +513,21 @@ func TestDeconstructionReconstruction(t *testing.T) {
 				},
 			},
 		},
+		{
+			scenario: "uuids",
+			input: struct {
+				A [16]byte `parquet:",uuid"`
+				B string   `parquet:",uuid"`
+			}{A: uuid.MustParse("a65b576d-9299-4769-9d93-04be0583f027"), B: "a65b576d-9299-4769-9d93-04be0583f027"},
+			values: [][]parquet.Value{
+				0: {
+					parquet.ValueOf(uuid.MustParse("a65b576d-9299-4769-9d93-04be0583f027")).Level(0, 0, 0),
+				},
+				1: {
+					parquet.ValueOf(uuid.MustParse("a65b576d-9299-4769-9d93-04be0583f027")).Level(0, 0, 1),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/schema.go
+++ b/schema.go
@@ -946,6 +946,9 @@ func makeNodeOf(t reflect.Type, name string, tags parquetTags) Node {
 					if t.Elem().Kind() != reflect.Uint8 || t.Len() != 16 {
 						throwInvalidTag(t, name, option)
 					}
+					setNode(UUID())
+				case reflect.String:
+					setNode(UUID())
 				default:
 					throwInvalidTag(t, name, option)
 				}

--- a/schema_test.go
+++ b/schema_test.go
@@ -306,6 +306,16 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+		{
+			value: new(struct {
+				A [16]byte `parquet:",uuid"`
+				B string   `parquet:",uuid"`
+			}),
+			print: `message {
+	required fixed_len_byte_array(16) A (UUID);
+	required fixed_len_byte_array(16) B (UUID);
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/value.go
+++ b/value.go
@@ -336,7 +336,15 @@ func makeValue(k Kind, lt *format.LogicalType, v reflect.Value) Value {
 
 	case FixedLenByteArray:
 		switch v.Kind() {
-		case reflect.String: // uuid
+		case reflect.String:
+			if lt.UUID != nil { // uuid
+				uuidStr := v.String()
+				encoded, err := uuid.MustParse(uuidStr).MarshalBinary()
+				if err != nil {
+					panic(fmt.Errorf("error marshalling uuid: %w", err))
+				}
+				return makeValueByteArray(k, unsafe.SliceData(encoded), len(encoded))
+			}
 			return makeValueString(k, v.String())
 		case reflect.Array:
 			if v.Type().Elem().Kind() == reflect.Uint8 {


### PR DESCRIPTION
Currently setting the uuid option on a string field will result in a panic. Setting it on a `[16]byte` field works but the generated parquet file doesn't not have the uuid logical type. This fixes both. Note that the physical type is always going to be `[16]byte` for uuid columns, but one can choose to create parquet files from inputs with string uuids.

Regarding the implementation, I added a `isUUID` flag to `be128Type` because it can be used for non uuid columns.

With this change we can see the uuid logical type in the schema of the generated parquet files.

<img width="1723" height="195" alt="Screenshot 2025-09-08 at 15 39 45" src="https://github.com/user-attachments/assets/8335c7df-db51-4de8-a883-8aa774d70f49" />
