### PR TITLE
Fix Slice Bounds Out Of Range

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1085,7 +1085,7 @@ func (w *writer) writeRows(numRows int, write func(i, j int) (int, error)) (int,
 		remain := w.maxRows - w.numRows
 		length := numRows - written
 
-		if remain == 0 {
+		if remain <= 0 {
 			remain = w.maxRows
 
 			if err := w.flush(); err != nil {

--- a/writer_go_slice_bounds_bug_test.go
+++ b/writer_go_slice_bounds_bug_test.go
@@ -1,0 +1,145 @@
+package parquet_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+// TestRecord defines the schema for our test data
+type TestRecord struct {
+	ID     int64   `parquet:"id"`
+	Name   string  `parquet:"name"`
+	Age    int32   `parquet:"age"`
+	Score  float64 `parquet:"score"`
+	Active bool    `parquet:"active"`
+}
+
+// TestSliceBoundsOutOfRange reproduces the slice bounds out of range bug
+// when MaxRowsPerRowGroup is set to a small value.
+//
+// Bug details:
+// - parquet-go version: v0.25.1
+// - Error: panic: runtime error: slice bounds out of range [64:56:]
+// - Location: writer.go:191 in GenericWriter.Write method
+// - Trigger: Small MaxRowsPerRowGroup + batch size > 64 rows
+//
+// Root cause: In writeRows method, remain = w.maxRows - w.numRows can be negative
+// when w.numRows > w.maxRows due to flush timing issues. This negative value
+// is cast to int and used as slice length, causing invalid slice bounds.
+func TestSliceBoundsOutOfRange(t *testing.T) {
+	// Create temporary file in current directory
+	file, err := os.CreateTemp("./", "parquet_bug_test_*.parquet")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	// Print the file path
+	t.Logf("创建的文件路径: %s", file.Name())
+
+	// Create schema
+	schema := parquet.SchemaOf(TestRecord{})
+
+	// Create writer with small MaxRowsPerRowGroup - this triggers the bug
+	writer := parquet.NewGenericWriter[map[string]interface{}](
+		file,
+		schema,
+		parquet.MaxRowsPerRowGroup(120), // Small value is key to reproducing the bug
+	)
+	defer writer.Close()
+
+	// Test parameters that reproduce the bug
+	batchSize := 100  // Must be > 64 (maxRowsPerWrite) to trigger the bug
+	totalBatches := 1 // Multiple batches to cross row group boundaries
+
+	t.Logf("Test configuration: MaxRowsPerRowGroup=120, BatchSize=%d", batchSize)
+
+	for batch := 0; batch < totalBatches; batch++ {
+		// Generate test data
+		records := make([]map[string]interface{}, batchSize)
+		for i := 0; i < batchSize; i++ {
+			recordID := int64(batch*batchSize + i)
+			records[i] = map[string]interface{}{
+				"id":     recordID,
+				"name":   fmt.Sprintf("user_%d", recordID),
+				"age":    int32(20 + (recordID % 50)),
+				"score":  float64(recordID%100) + 0.5,
+				"active": recordID%2 == 0,
+			}
+		}
+
+		t.Logf("Writing batch %d with %d records", batch+1, len(records))
+
+		// This is where the panic occurs: slice bounds out of range [64:56:]
+		_, err := writer.Write(records)
+		if err != nil {
+			t.Fatalf("Write failed on batch %d: %v", batch+1, err)
+		}
+
+		// Flush after each batch
+		err = writer.Flush()
+		if err != nil {
+			t.Fatalf("Flush failed on batch %d: %v", batch+1, err)
+		}
+
+		t.Logf("Batch %d completed successfully", batch+1)
+	}
+}
+
+// Workaround test: shows that the bug doesn't occur with larger MaxRowsPerRowGroup
+func TestWorkaroundWithLargeMaxRows(t *testing.T) {
+	file, err := os.CreateTemp("./", "parquet_workaround_test_*.parquet")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	// Print the file path
+	t.Logf("创建的文件路径: %s", file.Name())
+
+	schema := parquet.SchemaOf(TestRecord{})
+
+	// Use large MaxRowsPerRowGroup - this avoids the bug
+	writer := parquet.NewGenericWriter[map[string]interface{}](
+		file,
+		schema,
+		parquet.MaxRowsPerRowGroup(10000), // Large value avoids the bug
+	)
+	defer writer.Close()
+
+	batchSize := 100
+	totalBatches := 3
+
+	t.Logf("Workaround test: MaxRowsPerRowGroup=10000, BatchSize=%d", batchSize)
+
+	for batch := 0; batch < totalBatches; batch++ {
+		records := make([]map[string]interface{}, batchSize)
+		for i := 0; i < batchSize; i++ {
+			recordID := int64(batch*batchSize + i)
+			records[i] = map[string]interface{}{
+				"id":     recordID,
+				"name":   fmt.Sprintf("user_%d", recordID),
+				"age":    int32(20 + (recordID % 50)),
+				"score":  float64(recordID%100) + 0.5,
+				"active": recordID%2 == 0,
+			}
+		}
+
+		_, err := writer.Write(records)
+		if err != nil {
+			t.Fatalf("Write failed on batch %d: %v", batch+1, err)
+		}
+
+		err = writer.Flush()
+		if err != nil {
+			t.Fatalf("Flush failed on batch %d: %v", batch+1, err)
+		}
+	}
+
+	t.Log("Workaround test completed successfully - no panic with large MaxRowsPerRowGroup")
+}


### PR DESCRIPTION
# Bug Report: slice bounds out of range with small MaxRowsPerRowGroup

## Summary
When using `parquet.MaxRowsPerRowGroup()` with small values (e.g., 120) and writing batches larger than 64 rows, the library panics with:
```
panic: runtime error: slice bounds out of range [64:56:]
```

## Environment
- **parquet-go version**: v0.25.1
- **Go version**: go1.24.x
- **OS**: macOS (reproduced)

## Error Location
- **File**: `writer.go:191`
- **Method**: `GenericWriter.Write`
- **Line**: `w.write(w, rows[i:j:j])`

## Root Cause Analysis
The issue occurs in the `writeRows` method (`writer.go:1085`):

```go
remain := w.maxRows - w.numRows
```

When `w.numRows` exceeds `w.maxRows` due to flush timing issues, `remain` becomes negative. This negative value is later cast to `int` and used as a slice length parameter, causing the invalid slice bounds `[64:56:]` where start index > end index.

## Reproduction Steps

### Test Code
```go
package main

import (
	"os"
	"testing"
	"fmt"
	"github.com/parquet-go/parquet-go"
)

type TestRecord struct {
	ID        int64   `parquet:"id"`
	Name      string  `parquet:"name"`
	Age       int32   `parquet:"age"`
	Score     float64 `parquet:"score"`
	Active    bool    `parquet:"active"`
}

func TestSliceBoundsOutOfRange(t *testing.T) {
	file, err := os.CreateTemp("", "parquet_bug_test_*.parquet")
	if err != nil {
		t.Fatalf("failed to create temp file: %v", err)
	}
	defer os.Remove(file.Name())
	defer file.Close()

	schema := parquet.SchemaOf(TestRecord{})

	// Small MaxRowsPerRowGroup triggers the bug
	writer := parquet.NewGenericWriter[map[string]interface{}](
		file,
		schema,
		parquet.MaxRowsPerRowGroup(120), // KEY: Small value triggers bug
	)
	defer writer.Close()

	batchSize := 100  // Must be > 64 (maxRowsPerWrite) to trigger bug
	totalBatches := 3

	for batch := 0; batch < totalBatches; batch++ {
		records := make([]map[string]interface{}, batchSize)
		for i := 0; i < batchSize; i++ {
			recordID := int64(batch*batchSize + i)
			records[i] = map[string]interface{}{
				"id":     recordID,
				"name":   fmt.Sprintf("user_%d", recordID),
				"age":    int32(20 + (recordID % 50)),
				"score":  float64(recordID%100) + 0.5,
				"active": recordID%2 == 0,
			}
		}

		// This line panics with slice bounds out of range [64:56:]
		_, err := writer.Write(records)
		if err != nil {
			t.Fatalf("Write failed: %v", err)
		}

		err = writer.Flush()
		if err != nil {
			t.Fatalf("Flush failed: %v", err)
		}
	}
}
```

### Running the Test
```bash
go test -v TestSliceBoundsOutOfRange
```

**Expected Result**: Test should pass without panic  
**Actual Result**: Panic with `slice bounds out of range [64:56:]`

## Workaround
Use a larger `MaxRowsPerRowGroup` value:
```go
parquet.MaxRowsPerRowGroup(10000) // Works fine
```

## Impact
This bug affects any application that:
1. Uses small `MaxRowsPerRowGroup` values for memory optimization
2. Writes batches larger than 64 rows
3. Triggers row group boundaries during writing

## Suggested Fix
Add bounds checking in the `writeRows` method to handle negative `remain` values:

```go
remain := w.maxRows - w.numRows
if remain <= 0 {
    // Handle row group overflow case
    remain = w.maxRows
    if err := w.flush(); err != nil {
        return written, err
    }
}
```

## Reproducibility
This bug is 100% reproducible with the provided test case. The exact trigger conditions are:
- `MaxRowsPerRowGroup` < 200 (approximately)
- Batch size > 64 rows
- Multiple batches that cross row group boundaries

