### PR TITLE
fix handling of optional byte slice

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -2062,7 +2062,7 @@ func writeRowsFuncOfRequired(t reflect.Type, schema *Schema, path columnPath) wr
 }
 
 func writeRowsFuncOfOptional(t reflect.Type, schema *Schema, path columnPath, writeRows writeRowsFunc) writeRowsFunc {
-	if t.Kind() == reflect.Slice { // assume nested list
+	if t.Kind() == reflect.Slice && t.Elem().Kind() != reflect.Uint8 { // assume nested list; []byte is scalar
 		return func(columns []ColumnBuffer, rows sparse.Array, levels columnLevels) error {
 			if rows.Len() == 0 {
 				return writeRows(columns, rows, levels)
@@ -2306,7 +2306,8 @@ func writeRowsFuncOfStruct(t reflect.Type, schema *Schema, path columnPath) writ
 			kind := f.Type.Kind()
 			switch {
 			case kind == reflect.Pointer:
-			case kind == reflect.Slice && !list:
+			case kind == reflect.Slice && !list && f.Type.Elem().Kind() != reflect.Uint8:
+				// For slices other than []byte, optional applies to the element, not the list
 			default:
 				writeRows = writeRowsFuncOfOptional(f.Type, schema, columnPath, writeRows)
 			}

--- a/writer_test.go
+++ b/writer_test.go
@@ -605,6 +605,37 @@ func TestIssueSegmentio375(t *testing.T) {
 	}
 }
 
+func TestIssue303_OptionalByteSlice(t *testing.T) {
+	type Row struct {
+		Buf []byte `parquet:"buf,optional"`
+	}
+
+	// Write a non-nil, non-empty []byte into an optional BYTE_ARRAY field
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[Row](&buf)
+	in := []Row{{Buf: []byte("test")}}
+	if _, err := w.Write(in); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back and verify it is not NULL and equals the original bytes
+	r := parquet.NewGenericReader[Row](bytes.NewReader(buf.Bytes()))
+	out := make([]Row, 1)
+	if n, err := r.Read(out); n != len(out) {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(out[0].Buf), "test"; got != want {
+		t.Fatalf("optional []byte round-trip mismatch: got=%q want=%q", got, want)
+	}
+}
+
 func TestGenericSetKeyValueMetadata(t *testing.T) {
 	testKey := "test-key"
 	testValue := "test-value"


### PR DESCRIPTION
Previously an optional byte slice would always be written as NULL.

Please let me know if this is the correct place to fix this. I am new to the codebase.

Fixes #303