### PR TITLE
support writing nested map into parquet groups

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -2377,17 +2377,19 @@ func writeRowsFuncOfMapToGroup(t reflect.Type, schema *Schema, path columnPath, 
 			fieldPathCopy := fieldPath
 			writeValue := func(columns []ColumnBuffer, mapValue reflect.Value, levels columnLevels) error {
 				actualValue := mapValue
-				if actualValue.Kind() == reflect.Interface && !actualValue.IsNil() {
+				actualValueKind := actualValue.Kind()
+				if actualValueKind == reflect.Interface && !actualValue.IsNil() {
 					actualValue = actualValue.Elem()
+					actualValueKind = actualValue.Kind()
 				}
-
-				if !actualValue.IsValid() || (actualValue.Kind() == reflect.Pointer && actualValue.IsNil()) {
+				if !actualValue.IsValid() || (actualValueKind == reflect.Pointer && actualValue.IsNil()) {
 					// Nil interface or nil pointer - write null
 					empty := sparse.Array{}
 					return writeNull(columns, empty, levels)
 				}
-
-				// Write the actual value based on its runtime type
+				if actualValueKind == reflect.Pointer {
+					actualValue = actualValue.Elem()
+				}
 				return writeInterfaceValue(columns, actualValue, fieldCopy, schema, fieldPathCopy, levels)
 			}
 

--- a/column_buffer_test.go
+++ b/column_buffer_test.go
@@ -553,7 +553,7 @@ func TestGenericWriterMapAnyToDeeplyNestedGroups(t *testing.T) {
 				Level2 struct {
 					Value string `parquet:",optional"`
 				} `parquet:",optional"`
-				Name string `parquet:",optional"`
+				Name *string `parquet:",optional"`
 			} `parquet:",optional"`
 		}
 	}
@@ -564,6 +564,7 @@ func TestGenericWriterMapAnyToDeeplyNestedGroups(t *testing.T) {
 	// Try to write using NewGenericWriter with the map type
 	buf := new(bytes.Buffer)
 	writer := NewGenericWriter[RecordWithMap](buf, desiredSchema)
+	strPtr := func(s string) *string { return &s }
 
 	// Attempt to write values with deeply nested maps
 	records := []RecordWithMap{
@@ -571,7 +572,7 @@ func TestGenericWriterMapAnyToDeeplyNestedGroups(t *testing.T) {
 			Root: map[string]any{
 				"Level1": map[string]any{
 					"Level2": map[string]any{
-						"Value": "deep_value",
+						"Value": strPtr("deep_value"),
 					},
 					"Name": "level1_name",
 				},
@@ -611,8 +612,8 @@ func TestGenericWriterMapAnyToDeeplyNestedGroups(t *testing.T) {
 	if result1.Root.Level1.Level2.Value != "deep_value" {
 		t.Errorf("row 1 deep value incorrect: %s", result1.Root.Level1.Level2.Value)
 	}
-	if result1.Root.Level1.Name != "level1_name" {
-		t.Errorf("row 1 level1 name incorrect: %s", result1.Root.Level1.Name)
+	if *result1.Root.Level1.Name != "level1_name" {
+		t.Errorf("row 1 level1 name incorrect: %s", *result1.Root.Level1.Name)
 	}
 
 	var result2 RecordWithStruct
@@ -623,7 +624,7 @@ func TestGenericWriterMapAnyToDeeplyNestedGroups(t *testing.T) {
 	if result2.Root.Level1.Level2.Value != "" {
 		t.Errorf("row 2 deep value should be empty: %s", result2.Root.Level1.Level2.Value)
 	}
-	if result2.Root.Level1.Name != "another_name" {
-		t.Errorf("row 2 level1 name incorrect: %s", result2.Root.Level1.Name)
+	if *result2.Root.Level1.Name != "another_name" {
+		t.Errorf("row 2 level1 name incorrect: %s", *result2.Root.Level1.Name)
 	}
 }


### PR DESCRIPTION
This change expands the support for dynamic mapping of Go values to parquet columns using `map`.

Prior to this change, only strongly typed maps were supported in `GenericWriter`. With this change, `parquet-go` now handles using the infamous `map[string]any` to dynamically map the Go values to parquet columns using reflection.