### PR TITLE
writer: support concurrent row group construction

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -859,10 +859,9 @@ func (rg *writerRowGroup) WriteRows(rows []Row) (int, error) {
 		// using the writer after getting an error, but maybe we could ensure that
 		// we are preventing further use as well?
 		for _, row := range rows[start:end] {
-			row.Range(func(columnIndex int, columnValues []Value) bool {
+			for columnIndex, columnValues := range row.Range {
 				rg.values[columnIndex] = append(rg.values[columnIndex], columnValues...)
-				return true
-			})
+			}
 		}
 
 		for i, values := range rg.values {


### PR DESCRIPTION
There are times when creating very large parquet files when the bottleneck is creating the files themselves. Currently a lot of the work in the existing APIs can be parallelized (for example record shredding can be done externally, etc), but the final step of actually serializing the values and compressing the rows must be done serially.

This change introduces new APIs that allows writing different row groups concurrently, as long as they are "committed" back to the original writer serially. This allows for offloading expensive work (like compression, etc) that has been shown to be a bottleneck to multiple threads, as the last step is mostly just moving/copying around some buffers.

Currently in [Redpanda Connect][1], we parallelize the construction of parquet files in some places, but this requires we hold the entire matrix of parquet.Value in memory, which is very expensive. This patch will allow us to reduce the required buffering, and instead we keep around compressed pages for each row group in memory instead.

This work is heavily based on work by Luke Alonso (which no longer applies cleanly on the tip of `main`): https://github.com/parquet-go/parquet-go/issues/123#issuecomment-2088667600

Fixes: https://github.com/parquet-go/parquet-go/issues/123

[1]: https://github.com/redpanda-data/connect/blob/71fbd3f33eaf4d16597bfe50d2495be432bf897a/internal/impl/snowflake/streaming/streaming.go#L352-L370