### PR TITLE
Fix panic when merging nothing

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -30,6 +30,9 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 
 	schema := config.Schema
 	if len(rowGroups) == 0 {
+		if schema == nil {
+			return nil, fmt.Errorf("cannot merge empty row groups without a schema")
+		}
 		return newEmptyRowGroup(schema), nil
 	}
 	if schema == nil {

--- a/merge_test.go
+++ b/merge_test.go
@@ -45,7 +45,7 @@ func TestMergeRowGroups(t *testing.T) {
 		output   parquet.RowGroup
 	}{
 		{
-			scenario: "no row groups",
+			scenario: "no row groups with schema",
 			options: []parquet.RowGroupOption{
 				parquet.SchemaOf(Person{}),
 			},
@@ -915,6 +915,19 @@ func equalSortingColumns(a, b []parquet.SortingColumn) bool {
 	}
 
 	return true
+}
+
+// TestMergeRowGroupsEmptyWithoutSchema tests that MergeRowGroups returns an error
+// when called with an empty slice and no schema option (issue #322)
+func TestMergeRowGroupsEmptyWithoutSchema(t *testing.T) {
+	_, err := parquet.MergeRowGroups([]parquet.RowGroup{})
+	if err == nil {
+		t.Fatal("expected error when merging empty row groups without schema, got nil")
+	}
+	expectedErrMsg := "cannot merge empty row groups without a schema"
+	if err.Error() != expectedErrMsg {
+		t.Errorf("expected error message %q, got %q", expectedErrMsg, err.Error())
+	}
 }
 
 func TestMergeRowGroupsCursorsAreClosed(t *testing.T) {


### PR DESCRIPTION
Fixes #322

This change adds a check to return an error when MergeRowGroups is called with an empty slice of RowGroups and no schema option is provided. Previously, this would result in a nil pointer dereference when attempting to create an empty row group with a nil schema.

We could support this use case later and stop erroring, for now it's a simple improvement over the current behavior which is to panic.