### PR TITLE
fix pages lifecycle

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -903,6 +903,9 @@ func TestOptionalDictWriteRowGroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestNullsSortFirst(t *testing.T) {

--- a/column_chunk.go
+++ b/column_chunk.go
@@ -78,19 +78,18 @@ type ColumnChunkValueReader interface {
 // NewColumnChunkValueReader creates a new ColumnChunkValueReader for the given
 // column chunk.
 func NewColumnChunkValueReader(column ColumnChunk) ColumnChunkValueReader {
-	return &columnChunkValueReader{pages: column.Pages(), release: Release}
+	return &columnChunkValueReader{pages: column.Pages()}
 }
 
 type columnChunkValueReader struct {
-	pages   Pages
-	page    Page
-	values  ValueReader
-	release func(Page)
+	pages  Pages
+	page   Page
+	values ValueReader
 }
 
 func (r *columnChunkValueReader) clear() {
 	if r.page != nil {
-		r.release(r.page)
+		Release(r.page)
 		r.page = nil
 		r.values = nil
 	}

--- a/column_test.go
+++ b/column_test.go
@@ -602,6 +602,7 @@ func TestColumnPages_SeekToRow(t *testing.T) {
 				t.Errorf("read value of page mismatch, row index %d: got=%d want=%d", idx, values[0], row.ID)
 			}
 
+			parquet.Release(page)
 			idx++
 		}
 	}

--- a/convert.go
+++ b/convert.go
@@ -735,6 +735,19 @@ func (p *convertedPage) Slice(i, j int64) Page {
 	}
 }
 
+func (p *convertedPage) Retain() {
+	Retain(p.page)
+}
+
+func (p *convertedPage) Release() {
+	Release(p.page)
+}
+
+var (
+	_ retainable = (*convertedPage)(nil)
+	_ releasable = (*convertedPage)(nil)
+)
+
 // convertedValueReader wraps a ValueReader to rewrite columnIndex in values.
 type convertedValueReader struct {
 	reader            ValueReader

--- a/file.go
+++ b/file.go
@@ -764,10 +764,8 @@ func (f *FilePages) init(c *FileColumnChunk, reader io.ReaderAt) {
 	f.rbuf, f.rbufpool = getBufioReader(&f.section, f.bufferSize)
 	f.decoder.Reset(f.protocol.NewReader(f.rbuf))
 	f.index = 0
-	if f.lastPage != nil {
-		Release(f.lastPage)
-		f.lastPage = nil
-	}
+	Release(f.lastPage)
+	f.lastPage = nil
 	f.lastPageIndex = -1
 	f.serveLastPage = false
 }
@@ -1098,10 +1096,8 @@ func (f *FilePages) Close() error {
 	f.dataOffset = 0
 	f.dictOffset = 0
 	f.index = 0
-	if f.lastPage != nil {
-		Release(f.lastPage)
-		f.lastPage = nil
-	}
+	Release(f.lastPage)
+	f.lastPage = nil
 	f.lastPageIndex = -1
 	f.serveLastPage = false
 	f.skip = 0

--- a/page_test.go
+++ b/page_test.go
@@ -530,11 +530,13 @@ func TestReslicingBooleanPage(t *testing.T) {
 	rg := pf.RowGroups()[0]
 	cc := rg.ColumnChunks()
 	pgs := cc[0].Pages()
+	defer pgs.Close()
 
 	pg, err := pgs.ReadPage()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer parquet.Release(pg)
 
 	// continue reslicing and reading the values
 	sliceEvery := 3
@@ -550,6 +552,8 @@ func TestReslicingBooleanPage(t *testing.T) {
 
 		// slice the page
 		pg = pg.Slice(low, high)
+		defer parquet.Release(pg)
+
 		v := pg.Values()
 		v.ReadValues(vs)
 

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -253,6 +253,7 @@ func TestIssueSegmentio362ParquetReadFromGenericReaders(t *testing.T) {
 	if err != nil && err != io.EOF {
 		t.Fatal(err)
 	}
+	r1.Close()
 
 	r2 := parquet.NewGenericReader[any](fp)
 	rows2 := make([]any, r2.NumRows())
@@ -260,6 +261,7 @@ func TestIssueSegmentio362ParquetReadFromGenericReaders(t *testing.T) {
 	if err != nil && err != io.EOF {
 		t.Fatal(err)
 	}
+	r2.Close()
 }
 
 func TestIssueSegmentio362ParquetReadFile(t *testing.T) {

--- a/row_group.go
+++ b/row_group.go
@@ -215,22 +215,9 @@ func newRowGroupRows(schema *Schema, columns []ColumnChunk, bufferSize int) *row
 		columns:  make([]columnChunkRows, len(columns)),
 		rowIndex: -1,
 	}
-
 	for i, column := range columns {
-		var release func(Page)
-		// Only release pages that are not byte array because the values
-		// that were read from the page might be retained by the program
-		// after calls to ReadRows.
-		switch column.Type().Kind() {
-		case ByteArray, FixedLenByteArray:
-			release = func(Page) {}
-		default:
-			release = Release
-		}
-		r.columns[i].reader.release = release
 		r.columns[i].reader.pages = column.Pages()
 	}
-
 	// This finalizer is used to ensure that the goroutines started by calling
 	// init on the underlying page readers will be shutdown in the event that
 	// Close isn't called and the rowGroupRows object is garbage collected.

--- a/writer.go
+++ b/writer.go
@@ -1514,7 +1514,7 @@ func (c *ColumnWriter) newColumnBuffer() ColumnBuffer {
 		// Since these buffers are pooled, we can afford to allocate a bit more memory in
 		// order to reduce the risk of needing to resize the buffer.
 		size := int(float64(column.Cap()) * 1.5)
-		c.rowsBuffer = int32Buffers.get(size)
+		c.rowsBuffer = indexes.get(size)
 		c.definitionLevelsBuffer = buffers.get(size)
 		column = newOptionalColumnBuffer(column, c.rowsBuffer.data[:0], c.definitionLevelsBuffer.data[:0], c.maxDefinitionLevel, nullsGoLast)
 	}

--- a/writer_null_only_test.go
+++ b/writer_null_only_test.go
@@ -151,7 +151,10 @@ func TestMergeRowGroupsWithNullOnlyColumns(t *testing.T) {
 	var mergedBuf bytes.Buffer
 	mergedWriter := parquet.NewWriter(&mergedBuf, merged.Schema())
 
-	if _, err := parquet.CopyRows(mergedWriter, merged.Rows()); err != nil {
+	mergedRows := merged.Rows()
+	defer mergedRows.Close()
+
+	if _, err := parquet.CopyRows(mergedWriter, mergedRows); err != nil {
 		t.Fatalf("CopyRows failed: %v", err)
 	}
 


### PR DESCRIPTION
A couple of changes over time had caused issues with lifecycle management of pages (e.g., reference counting via Retain/Release), this PR fixes it.

Some of the issues were tests not properly closing resources, some were internal implementations of `Page` not implementing the Retain/Release methods, and others were missing Release calls. No correctness issues tho, this was only making memory management less efficient.