### PR TITLE
support decimal logical type for byte_array

### DIFF
--- a/column.go
+++ b/column.go
@@ -418,13 +418,15 @@ func schemaElementTypeOf(s *format.SchemaElement) Type {
 					typ = Int32Type
 				case Int64:
 					typ = Int64Type
+				case ByteArray:
+					typ = ByteArrayType
 				case FixedLenByteArray:
 					if s.TypeLength == nil {
 						panic("DECIMAL using FIXED_LEN_BYTE_ARRAY must specify a length")
 					}
 					typ = FixedLenByteArrayType(int(*s.TypeLength))
 				default:
-					panic("DECIMAL must be of type INT32, INT64, or FIXED_LEN_BYTE_ARRAY but got " + kind.String())
+					panic("DECIMAL must be of type INT32, INT64, BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY but got " + kind.String())
 				}
 				return &decimalType{
 					decimal: *lt.Decimal,

--- a/schema_test.go
+++ b/schema_test.go
@@ -547,20 +547,17 @@ func TestSchemaRoundTrip(t *testing.T) {
 			name: "floats_and_decimals",
 			schema: parquet.NewSchema("root", parquet.Group{
 				"floats_and_decimals": parquet.Optional(parquet.Group{
+					"decimal_bytes30": parquet.Decimal(3, 30, parquet.ByteArrayType),
 					"decimal_fixed20": parquet.Decimal(2, 20, parquet.FixedLenByteArrayType(9)),
 					"decimal_int15":   parquet.Decimal(1, 15, parquet.Int64Type),
 					"decimal_int5":    parquet.Decimal(0, 5, parquet.Int32Type),
-					// TODO: Decimal field backed by byte array.
-					//       Spec allows it (https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal),
-					//       but parquet-go currently panics:
-					//			DECIMAL node must annotate Int32, Int64 or FixedLenByteArray but got BYTE_ARRAY
-					//"decimal_bytes30": parquet.Decimal(3, 30, parquet.ByteArrayType),
-					"double": parquet.Leaf(parquet.DoubleType),
-					"float":  parquet.Leaf(parquet.FloatType),
+					"double":          parquet.Leaf(parquet.DoubleType),
+					"float":           parquet.Leaf(parquet.FloatType),
 				}),
 			}),
 			roundTripped: `message root {
 	optional group floats_and_decimals {
+		required binary decimal_bytes30 (DECIMAL(30,3));
 		required fixed_len_byte_array(9) decimal_fixed20 (DECIMAL(20,2));
 		required int64 decimal_int15 (DECIMAL(15,1));
 		required int32 decimal_int5 (DECIMAL(5,0));

--- a/type_decimal.go
+++ b/type_decimal.go
@@ -11,9 +11,9 @@ import (
 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal
 func Decimal(scale, precision int, typ Type) Node {
 	switch typ.Kind() {
-	case Int32, Int64, FixedLenByteArray:
+	case Int32, Int64, ByteArray, FixedLenByteArray:
 	default:
-		panic("DECIMAL node must annotate Int32, Int64 or FixedLenByteArray but got " + typ.String())
+		panic("DECIMAL node must annotate Int32, Int64, ByteArray or FixedLenByteArray but got " + typ.String())
 	}
 	return Leaf(&decimalType{
 		decimal: format.DecimalType{


### PR DESCRIPTION
This pull request simply allows the base type for the Decimal logical type to be of type byte_array, see https://github.com/parquet-go/parquet-go/issues/65.

I don't really see any other places in the code that needs to be updated, and I have verified that this works in combination with Iceberg.