### PR TITLE
Fix case where NewGenericReader does not pass StructTag options

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -46,7 +46,7 @@ func NewGenericReader[T any](input io.ReaderAt, options ...ReaderOption) *Generi
 		if t == nil {
 			c.Schema = rowGroup.Schema()
 		} else {
-			c.Schema = schemaOf(dereference(t))
+			c.Schema = schemaOf(dereference(t), c.SchemaConfig.StructTags...)
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug in #321 where NewGenericReader wasn't honoring the StructTags when a schema isn't passed. This was a gap in the test coverage, now added.