### PR TITLE
writer: support overriding column index limits per column

### DIFF
--- a/column_index.go
+++ b/column_index.go
@@ -258,22 +258,6 @@ func (i be128ColumnIndex) MaxValue(int) Value  { return makeValueBytes(FixedLenB
 func (i be128ColumnIndex) IsAscending() bool   { return false }
 func (i be128ColumnIndex) IsDescending() bool  { return false }
 
-// ColumnIndexerOverride is used to override the default indexer size limit for a particular path.
-type ColumnIndexSizeOverride struct {
-	Path      []string
-	SizeLimit int
-}
-
-func searchColumnIndexerSizeLimit(sizes []ColumnIndexSizeOverride, defaultSize int, path columnPath) int {
-	for _, s := range sizes {
-		if path.equal(s.Path) {
-			return s.SizeLimit
-		}
-	}
-	return defaultSize
-
-}
-
 // The ColumnIndexer interface is implemented by types that support generating
 // parquet column indexes.
 //

--- a/column_test.go
+++ b/column_test.go
@@ -259,7 +259,7 @@ func testColumnPageIndexWithFile(t *testing.T, rows rows) bool {
 		r := rand.New(rand.NewSource(5))
 		f, err := createParquetFile(rows,
 			parquet.PageBufferSize(r.Intn(49)+1),
-			parquet.ColumnIndexSizeLimit(4096),
+			parquet.ColumnIndexSizeLimit(func(path []string) int { return 4096 }),
 		)
 		if err != nil {
 			t.Error(err)

--- a/writer.go
+++ b/writer.go
@@ -728,7 +728,7 @@ func newWriterRowGroup(w *writer, config *WriterConfig) *writerRowGroup {
 			columnPath:         leaf.path,
 			columnType:         columnType,
 			originalType:       columnType,
-			columnIndex:        columnType.NewColumnIndexer(searchColumnIndexerSizeLimit(config.ColumnIndexSizeLimitOverrides, config.ColumnIndexSizeLimit, leaf.path)),
+			columnIndex:        columnType.NewColumnIndexer(config.ColumnIndexSizeLimit(leaf.path)),
 			columnFilter:       searchBloomFilterColumn(config.BloomFilters, leaf.path),
 			compression:        compression,
 			dictionary:         dictionary,


### PR DESCRIPTION
Currently its not possible to specify column index size limits per column. This would be useful to me so I thought i'd give it a try.