### PR TITLE
Always write Statistics->NullCount

### DIFF
--- a/format/parquet.go
+++ b/format/parquet.go
@@ -148,7 +148,7 @@ type Statistics struct {
 	Max []byte `thrift:"1"`
 	Min []byte `thrift:"2"`
 	// Count of null value in the column.
-	NullCount int64 `thrift:"3"`
+	NullCount int64 `thrift:"3,required"`
 	// Count of distinct values occurring.
 	DistinctCount int64 `thrift:"4"`
 	// Min and max values for the column, determined by its ColumnOrder.

--- a/format/parquet_test.go
+++ b/format/parquet_test.go
@@ -1,6 +1,7 @@
 package format_test
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
@@ -34,5 +35,24 @@ func TestMarshalUnmarshalSchemaMetadata(t *testing.T) {
 		t.Error("values mismatch:")
 		t.Logf("expected:\n%#v", metadata)
 		t.Logf("found:\n%#v", decoded)
+	}
+}
+
+func TestMarshalStatisticsIncludeZeroNullCount(t *testing.T) {
+	protocol := &thrift.CompactProtocol{}
+	statistics := &format.Statistics{
+		NullCount: 0,
+	}
+	marshalled, err := thrift.Marshal(protocol, statistics)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// [54, 0, 0] is the encoded representation because
+	// 54 = 0011 0110 where 0011 is 3 for the field delta and 0110 is 6 for the int64 type
+	// 0 is the value
+	// 0 is the stop marker
+	if !bytes.Equal(marshalled, []byte{54, 0, 0}) {
+		t.Fatal("marshalled statistics does not match expected value")
 	}
 }


### PR DESCRIPTION
Currently the null count is omitted during serialization if its value is 0. Technically this is correct as the null count is optional according to the parquet [spec](https://github.com/apache/parquet-format/blob/3ab52ff2e4e1cbe4c52a3e25c0512803e860c454/src/main/thrift/parquet.thrift#L291). However, the generated parquet files cannot be queried using a popular query engine due to the footer missing null counts (this is confirmed with their support). Given this comment from the parquet spec,

> 
    * Writers SHOULD always write this field even if it is zero (i.e. no null value)
    * or the column is not nullable.
    * Readers MUST distinguish between null_count not being present and null_count == 0.
    * If null_count is not present, readers MUST NOT assume null_count == 0.

I'm wondering if you'd be open to always writing a value for this field. I believe doing so is safe because the library always tracks the null count, so during serialization if a null count of 0 is encountered it has to be that the column has no nulls as opposed to meaning the library doesn't know the given column has nulls or not.

This PR does so by marking the `NullCount` field in `Statistics` as required. This is done instead of changing the serialization to reduce impact scope (though this impacts page headers as well). I'm also happy to discuss alternatives.  
