### PR TITLE
Skip conversion for equal nodes

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -363,6 +363,9 @@ func isDirectLevelMapping(levels []byte) bool {
 // ConvertRowGroup constructs a wrapper of the given row group which applies
 // the given schema conversion to its rows.
 func ConvertRowGroup(rowGroup RowGroup, conv Conversion) RowGroup {
+	if EqualNodes(rowGroup.Schema(), conv.Schema()) {
+		return rowGroup
+	}
 	schema := conv.Schema()
 	numRows := rowGroup.NumRows()
 	rowGroupColumns := rowGroup.ColumnChunks()


### PR DESCRIPTION
When converting a row group to a target schema, we can skip the conversion process if the source and target schemas match.

Fixes https://github.com/parquet-go/parquet-go/issues/368.