### PR TITLE
Convert ConcurrentRowGroupWriter interface to concrete type

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -302,27 +302,16 @@ func (w *GenericWriter[T]) File() FileView {
 //
 // While multiple row groups can be created concurrently, a single row group must be written
 // sequentially.
-type ConcurrentRowGroupWriter interface {
-	RowWriterWithSchema
-
-	// Flush flushes any buffered data in the row group's column writers.
-	// This could be called before Commit to ensure all data pages are flushed.
-	Flush() error
-
-	// ColumnWriters returns the column writers for this row group, allowing
-	// direct access to write values to individual columns.
-	ColumnWriters() []*ColumnWriter
-
-	// Commit commits the row group to the parent writer, returning the number
-	// of rows written and an error if any. This method must be called serially
-	// (not concurrently) to maintain row group order in the file.
-	//
-	// If the parent writer has any pending rows buffered, they will be flushed
-	// before this row group is written.
-	//
-	// After Commit returns successfully, the row group will be empty and can
-	// be reused.
-	Commit() (int64, error)
+type ConcurrentRowGroupWriter struct {
+	writer      *writer
+	config      *WriterConfig
+	values      [][]Value
+	numRows     int64
+	maxRows     int64
+	columns     []*ColumnWriter
+	columnChunk []format.ColumnChunk
+	columnIndex []format.ColumnIndex
+	offsetIndex []format.OffsetIndex
 }
 
 // BeginRowGroup returns a new ConcurrentRowGroupWriter that can be written to in parallel with
@@ -332,7 +321,7 @@ type ConcurrentRowGroupWriter interface {
 // Example usage could look something like:
 //
 //	writer := parquet.NewGenericWriter[any](...)
-//	rgs := make([]parquet.ConcurrentRowGroupWriter, 5)
+//	rgs := make([]*parquet.ConcurrentRowGroupWriter, 5)
 //	var wg sync.WaitGroup
 //	for i := range rgs {
 //	  rg := writer.BeginRowGroup()
@@ -350,8 +339,8 @@ type ConcurrentRowGroupWriter interface {
 //	  }
 //	}
 //	return writer.Close()
-func (w *GenericWriter[T]) BeginRowGroup() ConcurrentRowGroupWriter {
-	return newWriterRowGroup(w.base.writer, w.base.config)
+func (w *GenericWriter[T]) BeginRowGroup() *ConcurrentRowGroupWriter {
+	return newConcurrentRowGroupWriter(w.base.writer, w.base.config)
 }
 
 var (
@@ -366,8 +355,6 @@ var (
 	_ RowWriterWithSchema = (*GenericWriter[map[struct{}]struct{}])(nil)
 	_ RowReaderFrom       = (*GenericWriter[map[struct{}]struct{}])(nil)
 	_ RowGroupWriter      = (*GenericWriter[map[struct{}]struct{}])(nil)
-
-	_ ConcurrentRowGroupWriter = (*writerRowGroup)(nil)
 )
 
 // Deprecated: A Writer uses a parquet schema and sequence of Go values to
@@ -600,8 +587,8 @@ func (w *Writer) ColumnWriters() []*ColumnWriter { return w.writer.currentRowGro
 // BeginRowGroup returns a new ConcurrentRowGroupWriter that can be written to in parallel with
 // other row groups. However these need to be committed back to the writer serially using the
 // Commit method on the row group.
-func (w *Writer) BeginRowGroup() ConcurrentRowGroupWriter {
-	return newWriterRowGroup(w.writer, w.config)
+func (w *Writer) BeginRowGroup() *ConcurrentRowGroupWriter {
+	return newConcurrentRowGroupWriter(w.writer, w.config)
 }
 
 type writerFileView struct {
@@ -673,20 +660,8 @@ func (w *writerFileView) RowGroups() []RowGroup {
 	return nil
 }
 
-type writerRowGroup struct {
-	writer      *writer
-	config      *WriterConfig
-	values      [][]Value
-	numRows     int64
-	maxRows     int64
-	columns     []*ColumnWriter
-	columnChunk []format.ColumnChunk
-	columnIndex []format.ColumnIndex
-	offsetIndex []format.OffsetIndex
-}
-
-func newWriterRowGroup(w *writer, config *WriterConfig) *writerRowGroup {
-	rg := &writerRowGroup{
+func newConcurrentRowGroupWriter(w *writer, config *WriterConfig) *ConcurrentRowGroupWriter {
+	rg := &ConcurrentRowGroupWriter{
 		writer:  w,
 		config:  config,
 		maxRows: config.MaxRowsPerRowGroup,
@@ -803,14 +778,14 @@ func newWriterRowGroup(w *writer, config *WriterConfig) *writerRowGroup {
 	return rg
 }
 
-func (rg *writerRowGroup) reset() {
+func (rg *ConcurrentRowGroupWriter) reset() {
 	rg.numRows = 0
 	for _, c := range rg.columns {
 		c.reset()
 	}
 }
 
-func (rg *writerRowGroup) configureBloomFilters(columnChunks []ColumnChunk) {
+func (rg *ConcurrentRowGroupWriter) configureBloomFilters(columnChunks []ColumnChunk) {
 	for i, c := range rg.columns {
 		if c.columnFilter != nil {
 			c.resizeBloomFilter(columnChunks[i].NumValues())
@@ -818,15 +793,20 @@ func (rg *writerRowGroup) configureBloomFilters(columnChunks []ColumnChunk) {
 	}
 }
 
-func (rg *writerRowGroup) Schema() *Schema {
+// Schema returns the schema for this row group.
+func (rg *ConcurrentRowGroupWriter) Schema() *Schema {
 	return rg.config.Schema
 }
 
-func (rg *writerRowGroup) ColumnWriters() []*ColumnWriter {
+// ColumnWriters returns the column writers for this row group, allowing
+// direct access to write values to individual columns.
+func (rg *ConcurrentRowGroupWriter) ColumnWriters() []*ColumnWriter {
 	return rg.columns
 }
 
-func (rg *writerRowGroup) Flush() error {
+// Flush flushes any buffered data in the row group's column writers.
+// This could be called before Commit to ensure all data pages are flushed.
+func (rg *ConcurrentRowGroupWriter) Flush() error {
 	for _, c := range rg.columns {
 		if err := c.Flush(); err != nil {
 			return err
@@ -835,14 +815,24 @@ func (rg *writerRowGroup) Flush() error {
 	return nil
 }
 
-func (rg *writerRowGroup) Commit() (int64, error) {
+// Commit commits the row group to the parent writer, returning the number
+// of rows written and an error if any. This method must be called serially
+// (not concurrently) to maintain row group order in the file.
+//
+// If the parent writer has any pending rows buffered, they will be flushed
+// before this row group is written.
+//
+// After Commit returns successfully, the row group will be empty and can
+// be reused.
+func (rg *ConcurrentRowGroupWriter) Commit() (int64, error) {
 	if err := rg.writer.flush(); err != nil {
 		return 0, err
 	}
 	return rg.writer.writeRowGroup(rg, nil, nil)
 }
 
-func (rg *writerRowGroup) WriteRows(rows []Row) (int, error) {
+// WriteRows writes rows to the row group.
+func (rg *ConcurrentRowGroupWriter) WriteRows(rows []Row) (int, error) {
 	return rg.writeRows(len(rows), func(start, end int) (int, error) {
 		defer func() {
 			for i, values := range rg.values {
@@ -873,7 +863,7 @@ func (rg *writerRowGroup) WriteRows(rows []Row) (int, error) {
 	})
 }
 
-func (rg *writerRowGroup) writeRows(numRows int, write func(i, j int) (int, error)) (int, error) {
+func (rg *ConcurrentRowGroupWriter) writeRows(numRows int, write func(i, j int) (int, error)) (int, error) {
 	written := 0
 
 	for written < numRows {
@@ -911,7 +901,7 @@ func (rg *writerRowGroup) writeRows(numRows int, write func(i, j int) (int, erro
 type writer struct {
 	buffer          *bufio.Writer
 	writer          offsetTrackingWriter
-	currentRowGroup *writerRowGroup
+	currentRowGroup *ConcurrentRowGroupWriter
 
 	createdBy string
 	metadata  []format.KeyValue
@@ -978,7 +968,7 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 		})
 	})
 
-	w.currentRowGroup = newWriterRowGroup(w, config)
+	w.currentRowGroup = newConcurrentRowGroupWriter(w, config)
 
 	if len(config.Sorting.SortingColumns) > 0 {
 		forEachLeafColumnOf(config.Schema, func(leaf leafColumn) {
@@ -1130,7 +1120,7 @@ func (w *writer) writeFileFooter() error {
 	return err
 }
 
-func (w *writer) writeRowGroup(rg *writerRowGroup, rowGroupSchema *Schema, rowGroupSortingColumns []SortingColumn) (int64, error) {
+func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Schema, rowGroupSortingColumns []SortingColumn) (int64, error) {
 	if len(rg.columns) == 0 {
 		return 0, nil
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -2036,7 +2036,7 @@ func TestConcurrentRowGroupWriter(t *testing.T) {
 		writer := parquet.NewGenericWriter[Row](buf, parquet.MaxRowsPerRowGroup(10))
 
 		const numGroups = 5
-		rgs := make([]parquet.ConcurrentRowGroupWriter, numGroups)
+		rgs := make([]*parquet.ConcurrentRowGroupWriter, numGroups)
 
 		// Create row groups sequentially
 		for i := range rgs {
@@ -2097,7 +2097,7 @@ func TestConcurrentRowGroupWriter(t *testing.T) {
 		writer := parquet.NewGenericWriter[Row](buf, parquet.MaxRowsPerRowGroup(10))
 
 		const numGroups = 5
-		rgs := make([]parquet.ConcurrentRowGroupWriter, numGroups)
+		rgs := make([]*parquet.ConcurrentRowGroupWriter, numGroups)
 
 		// Create all row groups
 		for i := range rgs {
@@ -2110,7 +2110,7 @@ func TestConcurrentRowGroupWriter(t *testing.T) {
 		errs := make([]error, numGroups)
 		for i := range rgs {
 			wg.Add(1)
-			go func(index int, rg parquet.ConcurrentRowGroupWriter) {
+			go func(index int, rg *parquet.ConcurrentRowGroupWriter) {
 				defer wg.Done()
 				for j := range 10 {
 					rows := []parquet.Row{
@@ -2294,7 +2294,7 @@ func TestConcurrentRowGroupWriterWithColumnWriters(t *testing.T) {
 		writer := parquet.NewGenericWriter[Row](buf)
 
 		const numGroups = 3
-		rgs := make([]parquet.ConcurrentRowGroupWriter, numGroups)
+		rgs := make([]*parquet.ConcurrentRowGroupWriter, numGroups)
 
 		// Create row groups
 		for i := range rgs {
@@ -2305,7 +2305,7 @@ func TestConcurrentRowGroupWriterWithColumnWriters(t *testing.T) {
 		var wg sync.WaitGroup
 		for i := range rgs {
 			wg.Add(1)
-			go func(index int, rg parquet.ConcurrentRowGroupWriter) {
+			go func(index int, rg *parquet.ConcurrentRowGroupWriter) {
 				defer wg.Done()
 
 				cols := rg.ColumnWriters()


### PR DESCRIPTION
I initially suggested that we should use an interface because it looked similar to other types that we already had, however, after using it for a bit, it looks like the concurrent row group writer is a very special case and we wouldn't have any ways of abstracting this with the change. 

@rockwotj let me know if you have any concerns.