### PR TITLE
update jsonlite to v0.14.0

### DIFF
--- a/column_buffer_json.go
+++ b/column_buffer_json.go
@@ -86,7 +86,7 @@ func writeJSONToRepeated(columns []ColumnBuffer, levels columnLevels, val *jsonl
 		levels.repetitionDepth++
 		levels.definitionLevel++
 
-		for elem := range val.Array() {
+		for elem := range val.Array {
 			elementWriter(columns, levels, reflect.ValueOf(elem))
 			levels.repetitionLevel = levels.repetitionDepth
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/klauspost/compress v1.17.9
 	github.com/parquet-go/bitpack v0.2.0
-	github.com/parquet-go/jsonlite v0.13.0
+	github.com/parquet-go/jsonlite v0.14.0
 	github.com/pierrec/lz4/v4 v4.1.21
 	golang.org/x/sys v0.38.0
 	google.golang.org/protobuf v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/parquet-go/bitpack v0.2.0 h1:1qA39QcA+HeExChZOATm78XMs5W2NY/Y2l17M5kDUuE=
 github.com/parquet-go/bitpack v0.2.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
-github.com/parquet-go/jsonlite v0.13.0 h1:9dY5yJFe6Uv1jvXu1Giykh4R1xtII6OY7donjk1KjGY=
-github.com/parquet-go/jsonlite v0.13.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
+github.com/parquet-go/jsonlite v0.14.0 h1:KkcaCGdA7ZqcLNBgVvjc/7NCH/WXXx1zybJqT0ft3nI=
+github.com/parquet-go/jsonlite v0.14.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=


### PR DESCRIPTION
This update reduces heap allocations when writing json arrays to repeated columns, because the Go compiler is able to generate better code with the simpler range function.