### PR TITLE
fixes TODOs about handling files with no rows in tests

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -52,9 +52,6 @@ func testGenericReader[Row any](t *testing.T) {
 	var model Row
 	t.Run(reflect.TypeOf(model).Name(), func(t *testing.T) {
 		err := quickCheck(func(rows []Row) bool {
-			if len(rows) == 0 {
-				return true // TODO: fix support for parquet files with zero rows
-			}
 			if err := testGenericReaderRows(rows); err != nil {
 				t.Error(err)
 				return false

--- a/row_buffer_test.go
+++ b/row_buffer_test.go
@@ -103,9 +103,6 @@ func testRowBuffer[Row any](t *testing.T) {
 	var model Row
 	t.Run(reflect.TypeOf(model).Name(), func(t *testing.T) {
 		err := quickCheck(func(rows []Row) bool {
-			if len(rows) == 0 {
-				return true // TODO: fix support for parquet files with zero rows
-			}
 			if err := testRowBufferRows(rows); err != nil {
 				t.Error(err)
 				return false


### PR DESCRIPTION
This makes our tests more robust, addressing TODOs left about handling the edge cases of parquet files with no rows.