### PR TITLE
fix panic when merging 3+ files with different schemas

### DIFF
--- a/row_builder.go
+++ b/row_builder.go
@@ -89,9 +89,11 @@ func (b *RowBuilder) configure(node Node, columnIndex int16, level columnLevel, 
 		// FIXED_LEN_BYTE_ARRAY is the only type which needs to be given a
 		// non-nil zero-value if the field is required.
 		if kind == FixedLenByteArray {
-			zero := make([]byte, typ.Length())
-			model.ptr = &zero[0]
-			model.u64 = uint64(len(zero))
+			if length := typ.Length(); length != 0 {
+				zero := make([]byte, length)
+				model.ptr = &zero[0]
+				model.u64 = uint64(length)
+			}
 		}
 		group.members = append(group.members, columnIndex)
 		b.models[columnIndex] = model


### PR DESCRIPTION
This is a fix for a panic that occurred when merging 3+ files with different schemas:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x498d80]

goroutine 1 [running]:
...
panic({0x4014280?, 0x7d7e290?})
	/usr/local/go/src/runtime/panic.go:783 +0x132
github.com/parquet-go/parquet-go.(*byteArrayColumnBuffer).writeValues(0xc000670140, {0x58?, 0x99?, 0x55?}, {{0xc0450e4428?, 0xc0011367b0?, 0x126bc51?}})
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/column_buffer_byte_array.go:171 +0x251
github.com/parquet-go/parquet-go.(*byteArrayColumnBuffer).WriteValues(0xc046b5b000?, {0xc0450e4428?, 0x2, 0xc000407680?})
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/column_buffer_byte_array.go:138 +0x2f
github.com/parquet-go/parquet-go.(*optionalColumnBuffer).WriteValues(0xc000407800, {0xc0450e4308, 0x2a, 0x4a})
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/column_buffer_optional.go:198 +0x10f
github.com/parquet-go/parquet-go.(*ColumnWriter).WriteRowValues(0xc03792e508, {0xc0450e4308, 0x2a, 0x4a})
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/writer.go:1706 +0xad
github.com/parquet-go/parquet-go.(*writerRowGroup).WriteRows.func1(0xc001136a68?, 0x12cc8ba?)
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/writer.go:883 +0x156
github.com/parquet-go/parquet-go.(*writerRowGroup).writeRows(0xc0010add60, 0x2a, 0xc003e949c8)
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/writer.go:917 +0x71
github.com/parquet-go/parquet-go.(*writerRowGroup).WriteRows(0xc0007a22d0?, {0xc0378bbc08?, 0xaa?, 0x7b?})
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/writer.go:863 +0x52
github.com/parquet-go/parquet-go.(*writer).WriteRows(0xc0009296c0, {0xc0378bbc08?, 0x2a?, 0x2a?})
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/writer.go:1296 +0x6d
github.com/parquet-go/parquet-go.copyRows({0x526d4a0, 0xc0009296c0}, {0x7f83e26f2ed0, 0xc0007a22d0}, {0xc0378bbc08, 0x2a, 0x2a})
	/go/pkg/mod/github.com/parquet-go/parquet-go@v0.26.3-0.20251212021117-d94ebbc05f39/row.go:349 +0x495
github.com/parquet-go/parquet-go.(*Writer).ReadRowsFrom(0xc037911d80, {0x7f83e26f2ed0, 0xc0007a22d0})
...
```