### PR TITLE
Fix parquet-go issue 406 bug

### DIFF
--- a/dictionary_boolean.go
+++ b/dictionary_boolean.go
@@ -93,7 +93,7 @@ func (d *booleanDictionary) insert(indexes []int32, rows sparse.Array) {
 func (d *booleanDictionary) Lookup(indexes []int32, values []Value) {
 	model := d.makeValue(false)
 	memsetValues(values, model)
-	d.lookup(indexes, makeArrayValue(values, offsetOfU64))
+	d.lookup(indexes, makeArrayValue(values, offsetOfBool))
 }
 
 func (d *booleanDictionary) lookup(indexes []int32, rows sparse.Array) {


### PR DESCRIPTION
The Lookup function in booleanDictionary was using offsetOfU64 instead of offsetOfBool when creating the sparse array for writing boolean values. This inconsistency with the Insert function (which uses offsetOfBool) could cause incorrect boolean values to be read on big-endian systems.

The fix changes offsetOfU64 to offsetOfBool in the Lookup function to match the Insert function's behavior and ensure proper boolean value handling across all architectures.

Added tests for:
- Boolean dictionary lookup to verify correct offset usage
- Reading boolean fields in typed structs (reproduces issue #406)

Fixes: https://github.com/parquet-go/parquet-go/issues/406