### PR TITLE
Fixes row group zero ordinal serialization 

### DIFF
--- a/format/parquet.go
+++ b/format/parquet.go
@@ -1005,7 +1005,10 @@ type RowGroup struct {
 	TotalCompressedSize int64 `thrift:"6,optional"`
 
 	// Row group ordinal in the file.
-	Ordinal int16 `thrift:"7,optional"`
+	// The writezero tag ensures ordinal 0 is serialized; without it, Ordinal=0
+	// would be omitted while Ordinal=1,2,... would be written, which breaks
+	// readers with strict validation for row group ordinals.
+	Ordinal int16 `thrift:"7,optional,writezero"`
 }
 
 // Empty struct to signal the order defined by the physical or logical type.


### PR DESCRIPTION
Row group ordinal with value 0 is not currently serialized. 

The latest Rust `parquet v57.1.0`  reader (https://crates.io/crates/parquet/57.1.0) introduces stricter row group ordinal validation which results in the following error:
```text
Error: General("Inconsistent ordinal assignment: first_has_ordinal is set to false but row-group with actual ordinal 1 has rg_has_ordinal set to true")
```

You can verify this with the reproducer here: https://github.com/jcsherin/row-group-zero-serialization

After applying the fix, ordinal 0 is serialized and the parquet files can be read by Rust `parquet` v57.1.0.