### PR TITLE
Optimize missing chunks for repetiotion level 0

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -570,8 +570,11 @@ func ConvertRowGroup(rowGroup RowGroup, conv Conversion) RowGroup {
 		isMissing := sourceColumn.node == nil
 
 		if isMissing {
-			// Find adjacent column for mirroring levels
-			adjacentChunk := findAdjacentColumnChunk(schema, i, columns, sourceMapping)
+			var adjacentChunk ColumnChunk
+			if leaf.maxRepetitionLevel > 0 {
+				// Find adjacent column for mirroring levels
+				adjacentChunk = findAdjacentColumnChunk(schema, i, columns, sourceMapping)
+			}
 
 			columns[i] = &missingColumnChunk{
 				typ:                leaf.node.Type(),


### PR DESCRIPTION
The missing chunk reader relies on reading adjacent columns to infer repetition levels. These adjacent reads can be skipped when the max repetition level is zero.