### PR TITLE
Convert parquet schema using parquet field map to improve performance

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -334,6 +334,23 @@ func Convert(to, from Node) (conv Conversion, err error) {
 	sourceMapping, sourceColumns := columnMappingOf(from)
 	columns := make([]conversionColumn, len(targetColumns))
 
+	targetFieldCache := make(map[Node]map[string]Field)
+	sourceFieldCache := make(map[Node]map[string]Field)
+
+	// Helper function to get or build field map for a node
+	getFieldMap := func(cache map[Node]map[string]Field, node Node) map[string]Field {
+		if fieldMap, ok := cache[node]; ok {
+			return fieldMap
+		}
+		fields := node.Fields()
+		fieldMap := make(map[string]Field, len(fields))
+		for _, f := range fields {
+			fieldMap[f.Name()] = f
+		}
+		cache[node] = fieldMap
+		return fieldMap
+	}
+
 	for i, path := range targetColumns {
 		targetColumn := targetMapping.lookup(path)
 		sourceColumn := sourceMapping.lookup(path)
@@ -359,8 +376,8 @@ func Convert(to, from Node) (conv Conversion, err error) {
 			sourceNode := from
 
 			for j := range path {
-				targetNode = fieldByName(targetNode, path[j])
-				sourceNode = fieldByName(sourceNode, path[j])
+				targetNode = getFieldMap(targetFieldCache, targetNode)[path[j]]
+				sourceNode = getFieldMap(sourceFieldCache, sourceNode)[path[j]]
 
 				targetRepetitionLevel, targetDefinitionLevel = applyFieldRepetitionType(
 					fieldRepetitionTypeOf(targetNode),


### PR DESCRIPTION
Fixes https://github.com/parquet-go/parquet-go/issues/420.

The benchmark shows 100X improvement when converting schema with 30K columns.

### Benchmark results

Before

```
go test -bench=BenchmarkConvertLargeSchemaDifferent -run=^$ -benchtime=10s -count 1  .
goos: darwin
goarch: arm64
pkg: github.com/parquet-go/parquet-go
cpu: Apple M1 Pro
BenchmarkConvertLargeSchemaDifferent-10                1        250350369000 ns/op
PASS
ok      github.com/parquet-go/parquet-go        250.737s
```

After

```
go test -bench=BenchmarkConvertLargeSchemaDifferent -run=^$ -benchtime=10s -count 1  .
goos: darwin
goarch: arm64
pkg: github.com/parquet-go/parquet-go
cpu: Apple M1 Pro
BenchmarkConvertLargeSchemaDifferent-10                6        2090377076 ns/op
PASS
ok      github.com/parquet-go/parquet-go        13.022s
```