### PR TITLE
fix(merge): preserve VARIANT logical type when merging nodes

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -743,6 +743,8 @@ func mergeTwoNodes(a, b Node) Node {
 				merged = &listNode{group}
 			case logicalType.Map != nil:
 				merged = &mapNode{group}
+			case logicalType.Variant != nil:
+				merged = &variantNode{group}
 			}
 		}
 	}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1403,6 +1403,20 @@ func TestMergeNodes(t *testing.T) {
 				"name": parquet.Required(parquet.String()), // STRING preserved
 			}),
 		},
+		{
+			name: "preserve VARIANT logical type",
+			nodes: []parquet.Node{
+				parquet.Group{
+					"attributes": parquet.Variant(),
+				},
+				parquet.Group{
+					"attributes": parquet.Variant(),
+				},
+			},
+			expected: parquet.Required(parquet.Group{
+				"attributes": parquet.Variant(),
+			}),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When testing the `VARIANT` type, I found it's written correctly, but the logical type was lost on merge.

See outout from new test case prior to the fix:

```
    merge_test.go:1441: Expected: message {
        	required group attributes (VARIANT) {
        		required binary metadata;
        		required binary value;
        	}
        }
    merge_test.go:1442: Got:      message {
        	required group attributes {
        		required binary metadata;
        		required binary value;
        	}
        }
```