### PR TITLE
Reduce allocations in writer.writeRowGroup()

### DIFF
--- a/column_index_test.go
+++ b/column_index_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/parquet-go/parquet-go"
-	"github.com/parquet-go/parquet-go/format"
 )
 
 func TestBinaryColumnIndexMinMax(t *testing.T) {
@@ -45,7 +44,7 @@ func TestBinaryColumnIndexMinMax(t *testing.T) {
 			parquet.ValueOf(min),
 			parquet.ValueOf(max),
 		)
-		formatIndex := indexer.ColumnIndex(&format.ColumnIndex{})
+		formatIndex := indexer.ColumnIndex()
 		columnIndex := parquet.NewColumnIndex(kind, &formatIndex)
 		for i := 5; i < len(testCase); i += 2 {
 			value := testCase[i].([]byte)
@@ -68,7 +67,7 @@ func Test_ColumnIndexReuse(t *testing.T) {
 		parquet.ValueOf(min),
 		parquet.ValueOf(max),
 	)
-	before := indexer.ColumnIndex(&format.ColumnIndex{})
+	before := indexer.ColumnIndex()
 	if len(before.NullPages) != 1 {
 		t.Fatalf("expected 1 null page, got %d", len(before.NullPages))
 	}
@@ -88,7 +87,7 @@ func Test_ColumnIndexReuse(t *testing.T) {
 		parquet.ValueOf(min),
 		parquet.ValueOf(max),
 	)
-	after := indexer.ColumnIndex(&format.ColumnIndex{})
+	after := indexer.ColumnIndex()
 
 	if len(after.NullPages) != 2 {
 		t.Fatalf("expected 2 null pages, got %d", len(after.NullPages))

--- a/search_test.go
+++ b/search_test.go
@@ -80,7 +80,7 @@ func testSearch(t *testing.T, pages [][]int32, expectIndex [][]int) {
 		)
 	}
 
-	formatIndex := indexer.ColumnIndex(nil)
+	formatIndex := indexer.ColumnIndex()
 	columnIndex := parquet.NewColumnIndex(parquet.Int32, &formatIndex)
 
 	for _, values := range expectIndex {

--- a/writer.go
+++ b/writer.go
@@ -1188,7 +1188,7 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 	fileOffset := w.writer.offset
 
 	for i, c := range rg.columns {
-		rg.columnIndex[i] = c.columnIndex.ColumnIndex(&rg.columnIndex[i])
+		rg.columnIndex[i] = c.columnIndex.ColumnIndex()
 		rg.columnIndex[i].RepetitionLevelHistogram = append(rg.columnIndex[i].RepetitionLevelHistogram[:0], c.pageRepetitionLevelHistograms...)
 		rg.columnIndex[i].DefinitionLevelHistogram = append(rg.columnIndex[i].DefinitionLevelHistogram[:0], c.pageDefinitionLevelHistograms...)
 


### PR DESCRIPTION
In order to serialize with the best possible performance, allocations should be reduced as much as possible. This PR focuses on writer.writeRowGroup() which was the source of the majority of the allocations (by size) in my testing. There is still some way to go, as ideally there would be zero allocs in such a test. It would be great if zero allocations became a long-term goal of the project.

In my application that uses parquet-go, the changes in this PR reduced average serialization time of a 1MB buffer from between 1-2ms to <1ms.

Notes:
- New TestReuseNumAllocs test that can be used to benchmark any future work on reducing allocations (and indeed to find any changes that increase allocations). It gives an indicative number of allocations when run in verbose mode. It never fails because allocs vary per OS/CPU. 
- Various Reset() methods are modified or added to allow for as much reuse as possible