### PR TITLE
thrift: treat '2' as false in bool types'

### DIFF
--- a/encoding/thrift/binary.go
+++ b/encoding/thrift/binary.go
@@ -46,7 +46,8 @@ func (r *binaryReader) Reader() io.Reader {
 
 func (r *binaryReader) ReadBool() (bool, error) {
 	v, err := r.ReadByte()
-	return v != 0, err
+	// Thrift protocol treats both 0 and 2 as false.
+	return v != 0 && v != 2, err
 }
 
 func (r *binaryReader) ReadInt8() (int8, error) {

--- a/encoding/thrift/protocol_test.go
+++ b/encoding/thrift/protocol_test.go
@@ -202,3 +202,40 @@ func testProtocolReadWriteValues(t *testing.T, p thrift.Protocol) {
 		})
 	}
 }
+
+// TestBoolDecoding tests that the boolean decoder treats both 0 and 2 as false.
+func TestBoolDecoding(t *testing.T) {
+	for _, test := range protocols {
+		t.Run(test.name, func(t *testing.T) {
+			testCases := []struct {
+				byteValue     byte
+				expectedValue bool
+				description   string
+			}{
+				{0, false, "byte value 0 should decode as false"},
+				{1, true, "byte value 1 should decode as true"},
+				{2, false, "byte value 2 should decode as false"},
+				{3, true, "byte value 3 should decode as true"},
+				{255, true, "byte value 255 should decode as true"},
+			}
+
+			for _, tc := range testCases {
+				t.Run(tc.description, func(t *testing.T) {
+					// Create a buffer with the test byte value.
+					b := bytes.NewBuffer([]byte{tc.byteValue})
+					r := test.proto.NewReader(b)
+
+					// Read the boolean value.
+					result, err := r.ReadBool()
+					if err != nil {
+						t.Fatalf("failed to read bool: %v", err)
+					}
+
+					if result != tc.expectedValue {
+						t.Errorf("byte value %d: expected %v, got %v", tc.byteValue, tc.expectedValue, result)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
The thrift format has been updated to represent `false` booleans as the byte 2, not 0: https://github.com/apache/thrift/commit/2c29c5665bc442e703480bb0ee60fe925ffe02e8.

For backwards compatibility we need to make sure both `0` and `2` are considered false by the decoder. I am reluctant to change the encoder since it could easily break older readers.