### PR TITLE
Fix panic when merging nodes with incompatible encodings

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -698,7 +698,7 @@ func mergeTwoNodes(a, b Node) Node {
 		if !isPlainEncoding(encoding2) {
 			encoding = encoding2
 		}
-		if encoding != nil {
+		if encoding != nil && canEncode(encoding, merged.Type().Kind()) {
 			merged = Encoded(merged, encoding)
 		}
 	} else {

--- a/merge_test.go
+++ b/merge_test.go
@@ -1417,6 +1417,22 @@ func TestMergeNodes(t *testing.T) {
 				"attributes": parquet.Variant(),
 			}),
 		},
+		{
+			name: "compatible encoding preserved - DELTA_LENGTH_BYTE_ARRAY with ByteArray result",
+			nodes: []parquet.Node{
+				parquet.Encoded(parquet.Leaf(parquet.ByteArrayType), &parquet.DeltaLengthByteArray),
+				parquet.Leaf(parquet.FixedLenByteArrayType(16)),
+			},
+			expected: parquet.Required(parquet.Encoded(parquet.Leaf(parquet.ByteArrayType), &parquet.DeltaLengthByteArray)),
+		},
+		{
+			name: "incompatible encoding fallback - FixedLenByteArray result drops DELTA_LENGTH_BYTE_ARRAY",
+			nodes: []parquet.Node{
+				parquet.Leaf(parquet.FixedLenByteArrayType(16)),
+				parquet.Encoded(parquet.Leaf(parquet.ByteArrayType), &parquet.DeltaLengthByteArray),
+			},
+			expected: parquet.Required(parquet.Leaf(parquet.FixedLenByteArrayType(16))),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- Fix panic in `mergeTwoNodes()` when the selected encoding is incompatible with the merged node's type
- Add `canEncode()` check before applying encoding, falling back to PLAIN if incompatible
- Add test cases for both compatible and incompatible encoding scenarios

## Problem

When merging two leaf nodes, the merge logic would:
1. Select a merged type using `selectLogicalType(b.Type(), a.Type())`
2. Independently apply an encoding from one of the source nodes

This caused a panic when the encoding didn't support the merged node's type:
```
panic: cannot apply DELTA_LENGTH_BYTE_ARRAY to node of type FIXED_LEN_BYTE_ARRAY
```

For example, merging a `ByteArray` with `DELTA_LENGTH_BYTE_ARRAY` encoding and a `FixedLenByteArray(16)` would panic because `DELTA_LENGTH_BYTE_ARRAY` only supports `ByteArray`, not `FixedLenByteArray`.

## Solution

Add a `canEncode()` check before applying the encoding:
```go
if encoding != nil && canEncode(encoding, merged.Type().Kind()) {
    merged = Encoded(merged, encoding)
}
```

If the encoding is incompatible with the merged type, it silently falls back to PLAIN encoding (the universal default).

## Test plan

- [x] New test case verifies compatible encoding is preserved
- [x] New test case verifies incompatible encoding falls back to PLAIN
- [x] All existing merge tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)