### PR TITLE
Fix DataPageV2 crash when dictionary falls back to plain

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -2008,7 +2008,15 @@ func (c *ColumnWriter) fallbackDictionaryToPlain() error {
 		c.columnType = indexedType.Type
 	}
 	if c.plainColumnBuffer == nil {
-		c.plainColumnBuffer = c.columnType.NewColumnBuffer(int(c.bufferIndex), int(c.bufferSize))
+		base := c.columnType.NewColumnBuffer(int(c.bufferIndex), int(c.bufferSize))
+		switch {
+		case c.maxRepetitionLevel > 0:
+			c.plainColumnBuffer = newRepeatedColumnBuffer(base, c.maxRepetitionLevel, c.maxDefinitionLevel, nullsGoLast)
+		case c.maxDefinitionLevel > 0:
+			c.plainColumnBuffer = newOptionalColumnBuffer(base, c.maxDefinitionLevel, nullsGoLast)
+		default:
+			c.plainColumnBuffer = base
+		}
 	}
 	c.columnBuffer = c.plainColumnBuffer
 	c.encoding = &plain.Encoding{}


### PR DESCRIPTION
This fixes a nil deref panic in decodeDataPageV2 when a column switches from dictionary encoding to PLAIN after exceeding the dictionary size limit. The fallback path was allocating a plain column buffer without wrapping optional/repeated buffers, which caused definition levels to be omitted from DataPageV2. The reader then dereferenced a nil definitionLevels buffer.

Code to repro:

```go
package main

import (
    "fmt"
    "io"
    "os"
    "strings"

    "github.com/parquet-go/parquet-go"
)

func main() {
    path := "repro.parquet"
    _ = os.Remove(path)

    schema := parquet.NewSchema("row", parquet.Group{
        "properties": parquet.Optional(parquet.String()),
    })

    f, err := os.Create(path)
    if err != nil {
        panic(err)
    }

    w := parquet.NewWriter(f,
        schema,
        parquet.DefaultEncoding(&parquet.RLEDictionary),
        parquet.DataPageVersion(2),
        parquet.PageBufferSize(256),
        parquet.DictionaryMaxBytes(128),
    )

    const rows = 2000
    for i := 0; i < rows; i++ {
        s := fmt.Sprintf("%s-%04d", strings.Repeat("x", 16), i)
        row := parquet.Row{parquet.ValueOf(s).Level(0, 1, 0)}
        if _, err := w.WriteRows([]parquet.Row{row}); err != nil {
            panic(err)
        }
    }

    if err := w.Close(); err != nil {
        panic(err)
    }
    if err := f.Close(); err != nil {
        panic(err)
    }

    rf, err := os.Open(path)
    if err != nil {
        panic(err)
    }
    defer rf.Close()

    reader := parquet.NewReader(rf)
    defer reader.Close()

    buf := make([]parquet.Row, 128)
    for {
        _, err := reader.ReadRows(buf)
        if err != nil {
            if err == io.EOF {
                fmt.Println("OK: read completed without panic")
            } else {
                fmt.Printf("read stopped with error: %v\n", err)
            }
            break
        }
    }
}

```