### PR TITLE
fix: clone byte array page buffers to prevent use-after-free

### DIFF
--- a/column_chunk_test.go
+++ b/column_chunk_test.go
@@ -144,7 +144,18 @@ func testColumnChunkScan[Row generator[Row]](t *testing.T) {
 		// The remaining alloc consists of format.PageHeader, bufferedPage, FilePages, etc.
 		avgAllocPerPage := (allocPerRun - uint64(dictSize*runs)) / uint64(numPages)
 
-		if int(avgAllocPerPage) > 1000 {
+		// Byte array types (including strings and nested types containing them)
+		// clone their data to prevent use-after-free when pooled buffers are
+		// reused across files during operations like MergeRowGroups. This is
+		// necessary for memory safety but means allocation is proportional to
+		// data size rather than fixed overhead.
+		typeName := reflect.TypeOf(model).Name()
+		isByteArrayType := typeName == "byteArrayColumn" ||
+			typeName == "stringColumn" ||
+			typeName == "mapColumn" ||
+			typeName == "contact"
+
+		if !isByteArrayType && int(avgAllocPerPage) > 1000 {
 			t.Errorf("avg alloc per page should be under 1KB, got %d", avgAllocPerPage)
 		}
 	})


### PR DESCRIPTION
## Summary

When byte array pages are created, they store `SliceBuffer` values that wrap slices from pooled buffers. If the `bufferedPage` wrapper is released while the inner `byteArrayPage` is still in use (e.g., during `MergeRowGroups` when multiple files share the same buffer pools), the pooled memory can be reused, corrupting the page's data.

This manifests as "slice bounds out of range" panics when accessing corrupted offset values (e.g., `offset[i]=151, offset[i+1]=0`).

## Root Cause

The buffer pools (`buffers`, `offsets`) are global. When processing multiple files:

1. File A reads a page → gets buffer X from pool
2. File A's `byteArrayPage` stores a `SliceBuffer` wrapping buffer X's data
3. File A's `bufferedPage` is released → buffer X returns to pool
4. File B reads a page → gets buffer X (reused!)
5. File A's `byteArrayPage` now has corrupted data

The issue is that `byteArrayPage` creates its own `SliceBuffer` via `SliceBufferFrom()` which shares memory with the pooled buffer but doesn't participate in refcounting.

## Fix

Clone both the `values` and `offsets` buffers in `newByteArrayPage`, ensuring each page owns its data and is not affected by buffer pool recycling.

## Trade-off

This increases memory usage for byte array columns but is necessary for memory safety when processing multiple files concurrently or when merging row groups from different sources.

## Test plan

- [x] All existing tests pass
- [x] Updated `TestColumnChunkAllocs` to document why byte array types allocate more memory

🤖 Generated with [Claude Code](https://claude.ai/claude-code)