### PR TITLE
Fix DataPageV2 crash when dictionary falls back to plain

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -2008,7 +2008,15 @@ func (c *ColumnWriter) fallbackDictionaryToPlain() error {
 		c.columnType = indexedType.Type
 	}
 	if c.plainColumnBuffer == nil {
-		c.plainColumnBuffer = c.columnType.NewColumnBuffer(int(c.bufferIndex), int(c.bufferSize))
+		base := c.columnType.NewColumnBuffer(int(c.bufferIndex), int(c.bufferSize))
+		switch {
+		case c.maxRepetitionLevel > 0:
+			c.plainColumnBuffer = newRepeatedColumnBuffer(base, c.maxRepetitionLevel, c.maxDefinitionLevel, nullsGoLast)
+		case c.maxDefinitionLevel > 0:
+			c.plainColumnBuffer = newOptionalColumnBuffer(base, c.maxDefinitionLevel, nullsGoLast)
+		default:
+			c.plainColumnBuffer = base
+		}
 	}
 	c.columnBuffer = c.plainColumnBuffer
 	c.encoding = &plain.Encoding{}


### PR DESCRIPTION
## Summary

- Fixes nil pointer dereference when reading DataPageV2 files where a column switched from dictionary encoding to PLAIN after exceeding the dictionary size limit
- The fallback path was allocating a plain column buffer without wrapping it in optional/repeated buffers, causing definition levels to be omitted
- Added unit test that reproduces the issue from PR #456

Supersedes #456 by adding a test case to verify the fix.

## Test plan

- [x] Added `TestIssue456DataPageV2DictFallbackOptional` that reproduces the crash
- [x] Verified test fails without the fix (nil pointer dereference)
- [x] Verified test passes with the fix
- [x] Existing dictionary tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)