### PR TITLE
fix: boolean typed reading returns false for all values

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -283,7 +283,7 @@ func (c *conversion) Convert(rows []Row) (int, error) {
 				// Fix: If we have a zero Value{}, convert it to a properly typed value
 				// For optional fields, keep as null (kind = 0)
 				// For required fields, convert to typed zero value
-				if columnValues[i].Kind() == Kind(0) && !conv.isOptional {
+				if columnValues[i].IsNull() && !conv.isOptional {
 					columnValues[i] = ZeroValue(conv.targetKind)
 				}
 

--- a/file_test.go
+++ b/file_test.go
@@ -1159,3 +1159,23 @@ func TestRepeatedEmptyGroup(t *testing.T) {
 		// have no columns to store repetition levels
 	}
 }
+
+func TestIssue406(t *testing.T) {
+	type Row struct {
+		A *string `parquet:"a"`
+		B int32   `parquet:"b"`
+		C float64 `parquet:"c"`
+		D bool    `parquet:"d"`
+		E []int32 `parquet:"e,list"`
+	}
+	rows, err := parquet.ReadFile[Row]("./testdata/datapage_v2.snappy.parquet")
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	wantD := []bool{true, true, true, false, true}
+	for i, row := range rows {
+		if got, want := row.D, wantD[i]; got != want {
+			t.Errorf("[%d].d: got %v want %v", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #406: Since v0.26.0, boolean fields are incorrectly read as `false` when using typed reading
- The condition `Kind(0)` equals `Boolean` (first enum constant), causing all boolean values to be incorrectly treated as typed nulls
- Changed to use `IsNull()` to properly detect null values

## Test plan
- [x] Added regression test `TestIssue406` that verifies boolean values are correctly read
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)