### PR TITLE
fix: support *time.Duration with time tag

### DIFF
--- a/column_buffer_reflect_test.go
+++ b/column_buffer_reflect_test.go
@@ -1241,6 +1241,136 @@ func TestTimeDurationRoundTrip(t *testing.T) {
 	}
 }
 
+// TestTimeDurationPointerRoundTrip tests that *time.Duration with time tag roundtrips correctly (issue #442)
+func TestTimeDurationPointerRoundTrip(t *testing.T) {
+	type Row struct {
+		Duration *time.Duration `parquet:",time"`
+	}
+
+	testDuration := 14*time.Hour + 30*time.Minute + 45*time.Second + 123456789*time.Nanosecond
+
+	// Test with non-nil value
+	t.Run("non-nil", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		writer := NewGenericWriter[Row](buf)
+
+		rows := []Row{{Duration: &testDuration}}
+		n, err := writer.Write(rows)
+		if err != nil {
+			t.Fatalf("failed to write: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("expected to write 1 row, wrote %d", n)
+		}
+
+		if err := writer.Close(); err != nil {
+			t.Fatalf("failed to close writer: %v", err)
+		}
+
+		reader := NewReader(bytes.NewReader(buf.Bytes()))
+		defer reader.Close()
+
+		var got Row
+		if err := reader.Read(&got); err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+
+		if got.Duration == nil {
+			t.Fatal("expected non-nil duration, got nil")
+		}
+		if *got.Duration != testDuration {
+			t.Errorf("expected %v, got %v", testDuration, *got.Duration)
+		}
+	})
+
+	// Test with nil value
+	t.Run("nil", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		writer := NewGenericWriter[Row](buf)
+
+		rows := []Row{{Duration: nil}}
+		n, err := writer.Write(rows)
+		if err != nil {
+			t.Fatalf("failed to write: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("expected to write 1 row, wrote %d", n)
+		}
+
+		if err := writer.Close(); err != nil {
+			t.Fatalf("failed to close writer: %v", err)
+		}
+
+		reader := NewReader(bytes.NewReader(buf.Bytes()))
+		defer reader.Close()
+
+		var got Row
+		if err := reader.Read(&got); err != nil {
+			t.Fatalf("failed to read: %v", err)
+		}
+
+		if got.Duration != nil {
+			t.Errorf("expected nil duration, got %v", *got.Duration)
+		}
+	})
+
+	// Test with mixed nil and non-nil values
+	t.Run("mixed", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		writer := NewGenericWriter[Row](buf)
+
+		dur1 := 5 * time.Minute
+		dur2 := 10 * time.Hour
+
+		rows := []Row{
+			{Duration: &dur1},
+			{Duration: nil},
+			{Duration: &dur2},
+		}
+		n, err := writer.Write(rows)
+		if err != nil {
+			t.Fatalf("failed to write: %v", err)
+		}
+		if n != 3 {
+			t.Fatalf("expected to write 3 rows, wrote %d", n)
+		}
+
+		if err := writer.Close(); err != nil {
+			t.Fatalf("failed to close writer: %v", err)
+		}
+
+		reader := NewReader(bytes.NewReader(buf.Bytes()))
+		defer reader.Close()
+
+		// Row 0: non-nil
+		var got0 Row
+		if err := reader.Read(&got0); err != nil {
+			t.Fatalf("failed to read row 0: %v", err)
+		}
+		if got0.Duration == nil || *got0.Duration != dur1 {
+			t.Errorf("row 0: expected %v, got %v", dur1, got0.Duration)
+		}
+
+		// Row 1: nil
+		var got1 Row
+		if err := reader.Read(&got1); err != nil {
+			t.Fatalf("failed to read row 1: %v", err)
+		}
+		if got1.Duration != nil {
+			t.Errorf("row 1: expected nil, got %v", *got1.Duration)
+		}
+
+		// Row 2: non-nil
+		var got2 Row
+		if err := reader.Read(&got2); err != nil {
+			t.Fatalf("failed to read row 2: %v", err)
+		}
+		if got2.Duration == nil || *got2.Duration != dur2 {
+			t.Errorf("row 2: expected %v, got %v", dur2, got2.Duration)
+		}
+	})
+}
+
 // TestTimeTypesWithMultipleRows tests writing and reading multiple rows with time types
 func TestTimeTypesWithMultipleRows(t *testing.T) {
 	type Event struct {

--- a/schema.go
+++ b/schema.go
@@ -1152,6 +1152,21 @@ func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, ta
 							throwInvalidTag(t, name, option+args)
 						}
 						setNode(TimeAdjusted(timeUnit, adjusted))
+					case reflect.Ptr:
+						// Support *time.Duration with time tag
+						if t.Elem() == reflect.TypeFor[time.Duration]() {
+							timeUnit, adjusted, err := parseTimestampArgs(args)
+							if err != nil {
+								throwInvalidTag(t, name, option+args)
+							}
+							if args == "()" {
+								timeUnit = Nanosecond
+								adjusted = true
+							}
+							setNode(Optional(TimeAdjusted(timeUnit, adjusted)))
+						} else {
+							throwInvalidTag(t, name, option)
+						}
 					default:
 						throwInvalidTag(t, name, option)
 					}

--- a/schema_test.go
+++ b/schema_test.go
@@ -131,6 +131,24 @@ func TestSchemaOf(t *testing.T) {
 }`,
 		},
 
+		// Issue #442: Test *time.Duration with time tag
+		{
+			value: new(struct {
+				Inner struct {
+					TimeDurPtr   *time.Duration `parquet:"time_dur_ptr,time"`
+					TimeDurPtrMs *time.Duration `parquet:"time_dur_ptr_ms,time(millisecond)"`
+					TimeDurPtrUs *time.Duration `parquet:"time_dur_ptr_us,time(microsecond)"`
+				} `parquet:"inner,optional"`
+			}),
+			print: `message {
+	optional group inner {
+		optional int64 time_dur_ptr (TIME(isAdjustedToUTC=true,unit=NANOS));
+		optional int32 time_dur_ptr_ms (TIME(isAdjustedToUTC=true,unit=MILLIS));
+		optional int64 time_dur_ptr_us (TIME(isAdjustedToUTC=true,unit=MICROS));
+	}
+}`,
+		},
+
 		{
 			value: new(struct {
 				Name string `parquet:",json"`


### PR DESCRIPTION
## Summary

Fixes #442 - Panic when using `*time.Duration` with time tag.

- Add `reflect.Ptr` case to the "time" tag handling in schema.go
- Follow the same pattern used by the "date" case for handling `*time.Time`
- Wrap pointer types with `Optional(TimeAdjusted(...))` to handle nil as NULL

## Test plan

- [x] Added schema generation test for `*time.Duration` with various time units
- [x] Added round-trip tests for non-nil, nil, and mixed values
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)