### PR TITLE
fix: prevent infinite loop when reading corrupted byte array pages

### DIFF
--- a/page_optional.go
+++ b/page_optional.go
@@ -92,7 +92,12 @@ func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 		}
 
 		if n < i {
-			for j, err = r.values.ReadValues(values[n:i]); j > 0; j-- {
+			j, err := r.values.ReadValues(values[n:i])
+			if j == 0 && err == io.EOF {
+				// Underlying page exhausted before definitionLevels - corrupted file
+				return n, io.EOF
+			}
+			for ; j > 0; j-- {
 				values[n].definitionLevel = maxDefinitionLevel
 				r.offset++
 				n++

--- a/page_repeated.go
+++ b/page_repeated.go
@@ -152,7 +152,12 @@ func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 
 		// Copy all the non-zero values in this run.
 		if n < i {
-			for j, err = r.values.ReadValues(values[n:i]); j > 0; j-- {
+			j, err := r.values.ReadValues(values[n:i])
+			if j == 0 && err == io.EOF {
+				// Underlying page exhausted before definitionLevels - corrupted file
+				return n, io.EOF
+			}
+			for ; j > 0; j-- {
 				values[n].repetitionLevel = repetitionLevels[r.offset]
 				values[n].definitionLevel = maxDefinitionLevel
 				r.offset++


### PR DESCRIPTION
## Summary

- Fix infinite loop in `optionalPageValues.ReadValues` and `repeatedPageValues.ReadValues` when reading corrupted parquet files
- Detect when underlying page reader returns EOF with no values and return EOF immediately

## Problem

When a parquet file has corrupted byte array pages where `len(offsets) < numValues + 1`, the optional and repeated page value readers enter an infinite loop:

1. `definitionLevels` has `numValues` entries (from page header)
2. The underlying `byteArrayPage` only has `len(offsets)-1` values
3. After exhausting the underlying page, `ReadValues` returns EOF with 0 values
4. The loop ignores EOF to continue reading nulls, but `r.offset` never advances since no values were read
5. Loop condition `r.offset < len(definitionLevels)` remains true forever

This was discovered when running `iceberg optimize table` on tables with corrupted parquet files (written before PR #461 fix). The warning observed was:
```
parquet: warning: column 3 byte array page has 5 offsets but numValues is 28 (expected 29 offsets)
```

## Fix

Detect when the underlying reader returns EOF with no values read (`j == 0 && err == io.EOF`) and return EOF immediately instead of continuing the loop.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Tested with corrupted CloudWatch logs table - now returns error instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)