### PR TITLE
fix: preserve LIST and MAP types from ConvertedType-only group nodes

### DIFF
--- a/column.go
+++ b/column.go
@@ -366,6 +366,13 @@ func (cl *columnLoader) open(file *File, metadata *format.FileMetaData, columnIn
 		c.typ = &listType{}
 	} else if lt.Valid && lt.V.Variant != nil {
 		c.typ = &variantType{}
+	} else if ct := c.schema.ConvertedType; ct.Valid {
+		switch ct.V {
+		case deprecated.Map:
+			c.typ = &mapType{}
+		case deprecated.List:
+			c.typ = &listType{}
+		}
 	}
 	c.columns = make([]*Column, numChildren)
 

--- a/column_internal_test.go
+++ b/column_internal_test.go
@@ -3,6 +3,7 @@ package parquet
 import (
 	"testing"
 
+	"github.com/parquet-go/parquet-go/deprecated"
 	"github.com/parquet-go/parquet-go/encoding/thrift"
 	"github.com/parquet-go/parquet-go/format"
 )
@@ -158,5 +159,73 @@ func TestRootSchemaRepeatedTypeWithRepeatedChild(t *testing.T) {
 	}
 	if leaf.maxDefinitionLevel != 1 {
 		t.Errorf("repeated leaf maxDefinitionLevel = %d, want 1", leaf.maxDefinitionLevel)
+	}
+}
+
+// TestGroupConvertedTypeFallback verifies that LIST and MAP types are correctly
+// inferred from ConvertedType when LogicalType is not set, as is the case for
+// files written by older parquet writers.
+func TestGroupConvertedTypeFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		convertedType deprecated.ConvertedType
+		wantType      Type
+	}{
+		{
+			name:          "list",
+			convertedType: deprecated.List,
+			wantType:      &listType{},
+		},
+		{
+			name:          "map",
+			convertedType: deprecated.Map,
+			wantType:      &mapType{},
+		},
+		{
+			name:          "map_key_value",
+			convertedType: deprecated.MapKeyValue,
+			wantType:      &groupType{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := &format.FileMetaData{
+				Version: 1,
+				Schema: []format.SchemaElement{
+					{
+						Name:        "root",
+						NumChildren: thrift.New[int32](1),
+					},
+					{
+						Name:          tt.name,
+						NumChildren:   thrift.New[int32](1),
+						ConvertedType: thrift.New(tt.convertedType),
+					},
+					{
+						Name: "element",
+						Type: thrift.New(format.Int64),
+					},
+				},
+				RowGroups: []format.RowGroup{},
+			}
+
+			root, err := openColumns(nil, metadata, nil, nil)
+			if err != nil {
+				t.Fatalf("openColumns failed: %v", err)
+			}
+
+			if len(root.columns) != 1 {
+				t.Fatalf("expected 1 child column, got %d", len(root.columns))
+			}
+
+			group := root.columns[0]
+			gotType := group.Type()
+			wantLogical := tt.wantType.LogicalType()
+
+			if gotType.LogicalType() != wantLogical {
+				t.Errorf("group type LogicalType = %v, want %v", gotType.LogicalType(), wantLogical)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a `ConvertedType` fallback in the group-node path of `openColumns` (`column.go:362-375`) so that `deprecated.Map` and `deprecated.List` are correctly mapped to `&mapType{}` and `&listType{}` when `LogicalType` is absent
- This fixes files from older parquet writers that only set `ConvertedType` (the legacy format) — the leaf-node path (`schemaElementTypeOf`) already handled this correctly, but the group-node path did not
- Adds `TestGroupConvertedTypeFallback` with sub-tests for `list`, `map`, and `map_key_value` converted types

## Test plan

- [x] `go test -run TestGroupConvertedTypeFallback -v .` — new test passes
- [x] `go test -run TestSchemaRoundTrip -v .` — no regressions
- [x] `go test -run TestOpenFile -v .` — testdata files still load correctly
- [x] `go test ./...` — full suite passes

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)