### PR TITLE
fix: support non-standard LIST naming in parquet files

### DIFF
--- a/node.go
+++ b/node.go
@@ -499,20 +499,24 @@ func numLeafColumns(node Node, columnIndex int) int {
 
 func listElementOf(node Node) Node {
 	if !node.Leaf() {
-		if list := fieldByName(node, "list"); list != nil {
-			if elem := fieldByName(list, "element"); elem != nil {
-				return elem
-			}
-			// TODO: It should not be named "item", but some versions of pyarrow
-			//       and some versions of polars used that instead of "element".
-			//       https://issues.apache.org/jira/browse/ARROW-11497
-			//       https://github.com/pola-rs/polars/issues/17100
-			if elem := fieldByName(list, "item"); elem != nil {
-				return elem
+		// The spec says the outer group should be named "list" and the inner
+		// element should be named "element", but many implementations use
+		// different names (e.g. "bag"/"array_element", "list"/"item").
+		// Per the spec's backward compatibility rules, we should not enforce
+		// specific names when reading.
+		//
+		// A LIST node should have exactly one child (the repeated group),
+		// and that group should have exactly one child (the element).
+		if fields := node.Fields(); len(fields) == 1 {
+			repeatedGroup := fields[0]
+			if !repeatedGroup.Leaf() && repeatedGroup.Repeated() {
+				if elems := repeatedGroup.Fields(); len(elems) == 1 {
+					return elems[0]
+				}
 			}
 		}
 	}
-	panic("node with logical type LIST is not composed of a repeated .list.element")
+	panic("node with logical type LIST is not composed of a repeated group with a single element")
 }
 
 func mapKeyValueOf(node Node) Node {

--- a/node_internal_test.go
+++ b/node_internal_test.go
@@ -1,0 +1,145 @@
+package parquet
+
+import (
+	"testing"
+
+	"github.com/parquet-go/parquet-go/deprecated"
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+	"github.com/parquet-go/parquet-go/format"
+)
+
+func TestListElementOf(t *testing.T) {
+	tests := []struct {
+		name        string
+		node        Node
+		wantLeaf    bool
+		wantPanic   bool
+		description string
+	}{
+		{
+			name:        "standard naming (list/element)",
+			node:        listNode{Group{"list": Repeated(Group{"element": Leaf(Int32Type)})}},
+			wantLeaf:    true,
+			description: "standard parquet spec naming",
+		},
+		{
+			name:        "athena naming (bag/array_element)",
+			node:        listNode{Group{"bag": Repeated(Group{"array_element": Leaf(Int32Type)})}},
+			wantLeaf:    true,
+			description: "Athena/parquet-mr non-standard naming",
+		},
+		{
+			name:        "pyarrow/polars naming (list/item)",
+			node:        listNode{Group{"list": Repeated(Group{"item": Leaf(Int32Type)})}},
+			wantLeaf:    true,
+			description: "old PyArrow/Polars naming",
+		},
+		{
+			name:        "leaf node",
+			node:        Leaf(Int32Type),
+			wantPanic:   true,
+			description: "leaf nodes should panic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Error("expected panic but did not get one")
+					}
+				}()
+			}
+
+			elem := listElementOf(tt.node)
+
+			if tt.wantPanic {
+				t.Error("expected panic but did not get one")
+				return
+			}
+
+			if got := elem.Leaf(); got != tt.wantLeaf {
+				t.Errorf("listElementOf().Leaf() = %v, want %v", got, tt.wantLeaf)
+			}
+		})
+	}
+}
+
+func TestListElementOfWithOpenColumns(t *testing.T) {
+	// Simulate an Athena-style schema:
+	//   root (NumChildren=2)
+	//     name (BYTE_ARRAY, STRING)
+	//     favorite_numbers (LIST, NumChildren=1)
+	//       bag (REPEATED, NumChildren=1)
+	//         array_element (INT32, OPTIONAL)
+	metadata := &format.FileMetaData{
+		Version: 1,
+		Schema: []format.SchemaElement{
+			{
+				Name:        "root",
+				NumChildren: thrift.New[int32](2),
+			},
+			{
+				Name: "name",
+				Type: thrift.New(format.ByteArray),
+				LogicalType: thrift.New(format.LogicalType{
+					UTF8: new(format.StringType),
+				}),
+			},
+			{
+				Name:        "favorite_numbers",
+				NumChildren: thrift.New[int32](1),
+				LogicalType: thrift.New(format.LogicalType{
+					List: new(format.ListType),
+				}),
+				ConvertedType: thrift.New(deprecated.List),
+			},
+			{
+				Name:           "bag",
+				NumChildren:    thrift.New[int32](1),
+				RepetitionType: thrift.New(format.Repeated),
+			},
+			{
+				Name:           "array_element",
+				Type:           thrift.New(format.Int32),
+				RepetitionType: thrift.New(format.Optional),
+			},
+		},
+		RowGroups: []format.RowGroup{},
+	}
+
+	root, err := openColumns(nil, metadata, nil, nil)
+	if err != nil {
+		t.Fatalf("openColumns failed: %v", err)
+	}
+
+	// Find the favorite_numbers column.
+	var favNumbers *Column
+	for _, col := range root.columns {
+		if col.schema.Name == "favorite_numbers" {
+			favNumbers = col
+			break
+		}
+	}
+	if favNumbers == nil {
+		t.Fatal("favorite_numbers column not found")
+	}
+
+	// Verify it is recognized as a LIST type.
+	if !isList(favNumbers) {
+		t.Fatal("expected favorite_numbers to be a LIST type")
+	}
+
+	// Verify listElementOf returns the element without panicking.
+	elem := listElementOf(favNumbers)
+	if elem == nil {
+		t.Fatal("listElementOf returned nil")
+	}
+	if !elem.Leaf() {
+		t.Error("expected list element to be a leaf node")
+	}
+	if name := elem.(Field).Name(); name != "array_element" {
+		t.Errorf("expected element name %q, got %q", "array_element", name)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace name-based lookups in `listElementOf()` with structure-based matching, per the parquet spec's [backward compatibility rules](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#backward-compatibility-rules)
- Fixes panics when reading files written by Athena (`bag/array_element`), old PyArrow/Polars (`list/item`), and other non-compliant implementations
- Instead of hardcoding `"list"` → `"element"/"item"`, checks the structural pattern: one child → repeated group → one child

Fixes #137

## Test plan

- [x] Unit tests for `listElementOf` with standard, Athena, and PyArrow/Polars naming conventions
- [x] End-to-end test using `openColumns` with Athena-style `format.FileMetaData` schema
- [x] Full test suite passes with no regressions (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)