### PR TITLE
fix: MergeRowGroups multi-segment ordering and DropDuplicatedRows

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -166,10 +166,10 @@ func overlappingRowGroups(rowGroups []RowGroup, schema *Schema, sorting []Sortin
 		currentMax := rowGroupRanges[0].maxRow
 
 		for _, rr := range rowGroupRanges[1:] {
-			if cmp := compare(rr.minRow, currentMax); cmp <= 0 {
+			if compare(rr.minRow, currentMax) <= 0 {
 				// Overlapping - add to current segment and extend max if necessary
 				currentSegment = append(currentSegment, rr.rowGroup)
-				if cmp > 0 {
+				if compare(rr.maxRow, currentMax) > 0 {
 					currentMax = rr.maxRow
 				}
 			} else {

--- a/merge_test.go
+++ b/merge_test.go
@@ -3303,3 +3303,45 @@ func TestMergeRowGroupsDropDuplicatedRows(t *testing.T) {
 		}
 	})
 }
+
+// TestMergeRowGroupsMultipleSequentialOverlappingSegments tests that chained
+// overlaps are correctly merged into a single segment. Group1 overlaps Group2,
+// Group2 overlaps Group3, but Group1 does not directly overlap Group3. Without
+// extending currentMax in overlappingRowGroups, Group3 would be incorrectly
+// treated as a separate non-overlapping segment.
+func TestMergeRowGroupsMultipleSequentialOverlappingSegments(t *testing.T) {
+	type Record struct {
+		Value int64 `parquet:"value"`
+	}
+
+	sortingOptions := []parquet.RowGroupOption{
+		parquet.SortingRowGroupConfig(
+			parquet.SortingColumns(
+				parquet.Ascending("value"),
+			),
+		),
+	}
+
+	// Group1: [1,3,5]  - overlaps Group2 (max=5, Group2 min=4)
+	// Group2: [4,6,12] - overlaps Group3 (max=12, Group3 min=10)
+	// Group3: [10,15,20]
+	// All three should be merged into one segment.
+	// Expected output: [1,3,4,5,6,10,12,15,20]
+	group1 := fileRowGroup(sortedRowGroup(sortingOptions, Record{1}, Record{3}, Record{5}))
+	group2 := fileRowGroup(sortedRowGroup(sortingOptions, Record{4}, Record{6}, Record{12}))
+	group3 := fileRowGroup(sortedRowGroup(sortingOptions, Record{10}, Record{15}, Record{20}))
+
+	merged, err := parquet.MergeRowGroups([]parquet.RowGroup{group1, group2, group3}, sortingOptions...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rows := merged.Rows()
+	defer rows.Close()
+
+	got := readAllInt64Values(t, rows)
+	expected := []int64{1, 3, 4, 5, 6, 10, 12, 15, 20}
+	if !slices.Equal(got, expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #471 — two bugs in `MergeRowGroups`:

- **Multi-segment merge produced unsorted output.** When `MergeRowGroups` had both non-overlapping and overlapping segments (e.g., groups `[1,2,3]`, `[4,6,8]`, `[5,7,9]`), it wrapped them in a `multiRowGroup` whose `Rows()` read column pages directly — bypassing the heap merge in `mergedRowGroup.Rows()`. Added `sortedSegmentRowGroup` that overrides `Rows()` to concatenate each segment's own reader, preserving merge ordering within `mergedRowGroup` segments.
- **`DropDuplicatedRows` was ignored.** The flag was accepted via `RowGroupConfig.Sorting` but never applied by `MergeRowGroups`. Now `mergedRowGroup`, `sortedSegmentRowGroup`, and a new `dedupRowGroup` all wrap their readers with `DedupeRowReader` when the flag is set.

## Test plan

- [x] `TestMergeRowGroupsOverlappingSegments` — 3 groups with mixed overlapping/non-overlapping segments, verifies correct sorted order
- [x] `TestMergeRowGroupsDropDuplicatedRows` — 3 subtests covering overlapping groups with dupes, multi-segment with dupes, and single group with dupes
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)