### PR TITLE
Fix tiny typos in error messages

### DIFF
--- a/column_test.go
+++ b/column_test.go
@@ -179,7 +179,7 @@ func checkColumnChunkColumnIndex(columnChunk parquet.ColumnChunk) error {
 
 		nullCount := columnIndex.NullCount(pagesRead)
 		if numNulls != nullCount {
-			return fmt.Errorf("number of null values mimatch: index=%d page=%d", nullCount, numNulls)
+			return fmt.Errorf("number of null values mismatch: index=%d page=%d", nullCount, numNulls)
 		}
 
 		nullPage := columnIndex.NullPage(pagesRead)

--- a/writer.go
+++ b/writer.go
@@ -105,7 +105,7 @@ func NewGenericWriter[T any](output io.Writer, options ...WriterOption) *Generic
 	var genWriteErr error
 	if t != nil {
 		if columnName, ok := validateColumns(dereference(t)); !ok {
-			genWriteErr = fmt.Errorf("caonnot write %v: it has columns with the same parquet column name %q", t, columnName)
+			genWriteErr = fmt.Errorf("cannot write %v: it has columns with the same parquet column name %q", t, columnName)
 		}
 	}
 
@@ -1987,7 +1987,7 @@ func (c *ColumnWriter) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 	}
 	if isCompressed(c.compression) {
 		if err := buf.compress(c.compression); err != nil {
-			return fmt.Errorf("copmressing parquet dictionary page: %w", err)
+			return fmt.Errorf("compressing parquet dictionary page: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `caonnot` → `cannot` in `writer.go`
- `copmressing` → `compressing` in `writer.go`
- `mimatch` → `mismatch` in `column_test.go`

Tiny typo fixes in `fmt.Errorf` calls, no functional impact.