### PR TITLE
fix: support *int32 with date tag and *int64 with timestamp tag

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1122,10 +1122,13 @@ func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, ta
 				case reflect.Int32:
 					setNode(Date())
 				case reflect.Ptr:
-					// Support *time.Time with date tag
-					if t.Elem() == reflect.TypeFor[time.Time]() {
+					elem := t.Elem()
+					switch {
+					case elem == reflect.TypeFor[time.Time]():
 						setNode(Optional(Date()))
-					} else {
+					case elem.Kind() == reflect.Int32:
+						setNode(Optional(Date()))
+					default:
 						throwInvalidTag(t, name, option)
 					}
 				default:
@@ -1195,15 +1198,21 @@ func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, ta
 					}
 					setNode(TimestampAdjusted(timeUnit, adjusted))
 				case reflect.Ptr:
-					// Support *time.Time with timestamp tags
-					if t.Elem() == reflect.TypeFor[time.Time]() {
+					elem := t.Elem()
+					switch {
+					case elem == reflect.TypeFor[time.Time]():
 						timeUnit, adjusted, err := parseTimestampArgs(args)
 						if err != nil {
 							throwInvalidTag(t, name, option+args)
 						}
-						// Wrap in Optional for schema correctness (nil pointers = NULL values)
 						setNode(Optional(TimestampAdjusted(timeUnit, adjusted)))
-					} else {
+					case elem.Kind() == reflect.Int64:
+						timeUnit, adjusted, err := parseTimestampArgs(args)
+						if err != nil {
+							throwInvalidTag(t, name, option+args)
+						}
+						setNode(Optional(TimestampAdjusted(timeUnit, adjusted)))
+					default:
 						throwInvalidTag(t, name, option)
 					}
 				default:

--- a/schema_test.go
+++ b/schema_test.go
@@ -476,6 +476,26 @@ func TestSchemaOf(t *testing.T) {
 	required int32 u16 (INT(16,false));
 }`,
 		},
+
+		// Optional pointer with date tag (*int32)
+		{
+			value: new(struct {
+				Date *int32 `parquet:"date,date"`
+			}),
+			print: `message {
+	optional int32 date (DATE);
+}`,
+		},
+
+		// Optional pointer with timestamp tag (*int64)
+		{
+			value: new(struct {
+				Timestamp *int64 `parquet:"timestamp,timestamp"`
+			}),
+			print: `message {
+	optional int64 timestamp (TIMESTAMP(isAdjustedToUTC=true,unit=MILLIS));
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/type_test.go
+++ b/type_test.go
@@ -590,6 +590,72 @@ func TestIssue155(t *testing.T) {
 	}
 }
 
+// TestIssue45 reproduces https://github.com/parquet-go/parquet-go/issues/45
+// Issue #45: using *int32 with date tag or *int64 with timestamp tag causes a panic.
+func TestIssue45(t *testing.T) {
+	type Record struct {
+		ID        int32  `parquet:"id"`
+		Date      *int32 `parquet:"date,date"`
+		Timestamp *int64 `parquet:"timestamp,timestamp(microsecond)"`
+	}
+
+	// This should not panic - pointer types should support date/timestamp tags
+	schema := parquet.SchemaOf(Record{})
+	if schema == nil {
+		t.Fatal("schema should not be nil")
+	}
+	t.Logf("Schema: %s", schema)
+
+	// Test writing and reading
+	buffer := new(bytes.Buffer)
+	dateVal := int32(19735)       // 2024-01-10 (days since epoch)
+	tsVal := int64(1704844800000) // some microsecond timestamp
+
+	writer := parquet.NewGenericWriter[Record](buffer, schema)
+	_, err := writer.Write([]Record{
+		{ID: 1, Date: &dateVal, Timestamp: &tsVal},
+		{ID: 2, Date: nil, Timestamp: nil}, // NULL values
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back
+	reader := parquet.NewGenericReader[Record](bytes.NewReader(buffer.Bytes()))
+	rows := make([]Record, 2)
+	n, err := reader.Read(rows)
+	if err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 rows, got %d", n)
+	}
+
+	// Verify first row has values
+	if rows[0].Date == nil {
+		t.Error("expected first row to have non-nil Date")
+	} else if *rows[0].Date != dateVal {
+		t.Errorf("date mismatch: got %d, want %d", *rows[0].Date, dateVal)
+	}
+	if rows[0].Timestamp == nil {
+		t.Error("expected first row to have non-nil Timestamp")
+	} else if *rows[0].Timestamp != tsVal {
+		t.Errorf("timestamp mismatch: got %d, want %d", *rows[0].Timestamp, tsVal)
+	}
+
+	// Verify second row has NULLs
+	if rows[1].Date != nil {
+		t.Errorf("expected second row to have nil Date, got %d", *rows[1].Date)
+	}
+	if rows[1].Timestamp != nil {
+		t.Errorf("expected second row to have nil Timestamp, got %d", *rows[1].Timestamp)
+	}
+}
+
 // TestIssue326 reproduces https://github.com/parquet-go/parquet-go/issues/326
 // Issue #326: using *time.Time (pointer) with timestamp(millisecond) tag causes a panic.
 func TestIssue326(t *testing.T) {


### PR DESCRIPTION
## Summary
- Extend `date` tag handling to accept `*int32` pointer types (produces optional DATE column)
- Extend `timestamp` tag handling to accept `*int64` pointer types (produces optional TIMESTAMP column)
- Add schema tests for both new pointer type combinations
- Add `TestIssue45` encode/decode round-trip test verifying non-nil and nil (NULL) values

Fixes #45

## Test plan
- [x] `go test -run TestSchemaOf` — schema tests pass including new `*int32` date and `*int64` timestamp cases
- [x] `go test -run TestIssue45` — round-trip test passes (write + read with nil and non-nil values)
- [x] `make test` — full test suite passes with race detector
- [x] `make format` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)