### PR TITLE
feat: configuration option to defer bloom filters to end of file

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -113,8 +113,9 @@ func (buf *errorBuffer) WriteTo(io.Writer) (int64, error)  { return 0, buf.err }
 func (buf *errorBuffer) Seek(int64, int) (int64, error)    { return 0, buf.err }
 
 var (
-	defaultColumnBufferPool  = memoryBufferPool{size: defaultChunkSize}
-	defaultSortingBufferPool = memoryBufferPool{size: defaultChunkSize}
+	defaultColumnBufferPool         = memoryBufferPool{size: defaultChunkSize}
+	defaultSortingBufferPool        = memoryBufferPool{size: defaultChunkSize}
+	defaultDeferredBloomFiltersPool = memoryBufferPool{size: defaultChunkSize}
 
 	_ io.ReaderFrom = (*errorBuffer)(nil)
 	_ io.WriterTo   = (*errorBuffer)(nil)

--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -113,9 +113,8 @@ func (buf *errorBuffer) WriteTo(io.Writer) (int64, error)  { return 0, buf.err }
 func (buf *errorBuffer) Seek(int64, int) (int64, error)    { return 0, buf.err }
 
 var (
-	defaultColumnBufferPool         = memoryBufferPool{size: defaultChunkSize}
-	defaultSortingBufferPool        = memoryBufferPool{size: defaultChunkSize}
-	defaultDeferredBloomFiltersPool = memoryBufferPool{size: defaultChunkSize}
+	defaultColumnBufferPool  = memoryBufferPool{size: defaultChunkSize}
+	defaultSortingBufferPool = memoryBufferPool{size: defaultChunkSize}
 
 	_ io.ReaderFrom = (*errorBuffer)(nil)
 	_ io.WriterTo   = (*errorBuffer)(nil)

--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ const (
 	DefaultSkipBloomFilters     = false
 	DefaultMaxRowsPerRowGroup   = math.MaxInt64
 	DefaultReadMode             = ReadModeSync
+	DefaultDeferredBloomFilter  = false
 )
 
 const (
@@ -225,6 +226,8 @@ type WriterConfig struct {
 	KeyValueMetadata             map[string]string
 	Schema                       *Schema
 	BloomFilters                 []BloomFilterColumn
+	DeferredBloomFilters         bool
+	DeferredBloomFiltersBuffer   BufferPool
 	Compression                  compress.Codec
 	Sorting                      SortingConfig
 	SkipPageBounds               [][]string
@@ -250,6 +253,8 @@ func DefaultWriterConfig() *WriterConfig {
 		Sorting: SortingConfig{
 			SortingBuffers: &defaultSortingBufferPool,
 		},
+		DeferredBloomFilters:       DefaultDeferredBloomFilter,
+		DeferredBloomFiltersBuffer: &defaultDeferredBloomFiltersPool,
 	}
 }
 
@@ -302,6 +307,8 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 		KeyValueMetadata:             keyValueMetadata,
 		Schema:                       coalesceSchema(c.Schema, config.Schema),
 		BloomFilters:                 coalesceSlices(c.BloomFilters, config.BloomFilters),
+		DeferredBloomFilters:         coalesceBool(c.DeferredBloomFilters, config.DeferredBloomFilters),
+		DeferredBloomFiltersBuffer:   coalesceBufferPool(c.DeferredBloomFiltersBuffer, config.DeferredBloomFiltersBuffer),
 		Compression:                  coalesceCompression(c.Compression, config.Compression),
 		Sorting:                      coalesceSortingConfig(c.Sorting, config.Sorting),
 		SkipPageBounds:               coalesceSlices(c.SkipPageBounds, config.SkipPageBounds),
@@ -689,6 +696,27 @@ func KeyValueMetadata(key, value string) WriterOption {
 func BloomFilters(filters ...BloomFilterColumn) WriterOption {
 	filters = slices.Clone(filters)
 	return writerOption(func(config *WriterConfig) { config.BloomFilters = filters })
+}
+
+// DeferredBloomFilters creates a configuration option which delays the writing
+// of Bloom filters until the end of the file. This can be beneficial for files
+// read from remote storage, as an optimistic read can capture the file footer
+// along with the bloom filters.
+//
+// When this option is enabled, the accumulated bloom filters need to be retained
+// until the file is closed, see DeferredBloomFiltersBuffer for memory management
+// options.
+func DeferredBloomFilters(deferBlooms bool) WriterOption {
+	return writerOption(func(config *WriterConfig) { config.DeferredBloomFilters = deferBlooms })
+}
+
+// DeferredBloomFiltersBuffer creates a configuration option to customize the
+// buffer pool used when retaining deferred bloom filters during file creation. This can be used to
+// provide on-disk buffers as swap space to manage memory usage during file creation.
+//
+// Defaults to using in-memory buffers.
+func DeferredBloomFiltersBuffer(buffer BufferPool) WriterOption {
+	return writerOption(func(config *WriterConfig) { config.DeferredBloomFiltersBuffer = buffer })
 }
 
 // Compression creates a configuration option which sets the default compression

--- a/config.go
+++ b/config.go
@@ -34,7 +34,6 @@ const (
 	DefaultSkipBloomFilters     = false
 	DefaultMaxRowsPerRowGroup   = math.MaxInt64
 	DefaultReadMode             = ReadModeSync
-	DefaultDeferredBloomFilter  = false
 )
 
 const (
@@ -226,7 +225,6 @@ type WriterConfig struct {
 	KeyValueMetadata             map[string]string
 	Schema                       *Schema
 	BloomFilters                 []BloomFilterColumn
-	DeferredBloomFilters         bool
 	DeferredBloomFiltersBuffer   BufferPool
 	Compression                  compress.Codec
 	Sorting                      SortingConfig
@@ -253,8 +251,6 @@ func DefaultWriterConfig() *WriterConfig {
 		Sorting: SortingConfig{
 			SortingBuffers: &defaultSortingBufferPool,
 		},
-		DeferredBloomFilters:       DefaultDeferredBloomFilter,
-		DeferredBloomFiltersBuffer: &defaultDeferredBloomFiltersPool,
 	}
 }
 
@@ -307,7 +303,6 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 		KeyValueMetadata:             keyValueMetadata,
 		Schema:                       coalesceSchema(c.Schema, config.Schema),
 		BloomFilters:                 coalesceSlices(c.BloomFilters, config.BloomFilters),
-		DeferredBloomFilters:         coalesceBool(c.DeferredBloomFilters, config.DeferredBloomFilters),
 		DeferredBloomFiltersBuffer:   coalesceBufferPool(c.DeferredBloomFiltersBuffer, config.DeferredBloomFiltersBuffer),
 		Compression:                  coalesceCompression(c.Compression, config.Compression),
 		Sorting:                      coalesceSortingConfig(c.Sorting, config.Sorting),
@@ -698,24 +693,17 @@ func BloomFilters(filters ...BloomFilterColumn) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.BloomFilters = filters })
 }
 
-// DeferredBloomFilters creates a configuration option which delays the writing
+// DeferBloomFiltersWithBuffer creates a configuration option which delays the writing
 // of Bloom filters until the end of the file. This can be beneficial for files
 // read from remote storage, as an optimistic read can capture the file footer
 // along with the bloom filters.
 //
 // When this option is enabled, the accumulated bloom filters need to be retained
-// until the file is closed, see DeferredBloomFiltersBuffer for memory management
-// options.
-func DeferredBloomFilters(deferBlooms bool) WriterOption {
-	return writerOption(func(config *WriterConfig) { config.DeferredBloomFilters = deferBlooms })
-}
-
-// DeferredBloomFiltersBuffer creates a configuration option to customize the
-// buffer pool used when retaining deferred bloom filters during file creation. This can be used to
-// provide on-disk buffers as swap space to manage memory usage during file creation.
+// until the file is closed; it is therefore required to provide a buffer when
+// using this option.
 //
-// Defaults to using in-memory buffers.
-func DeferredBloomFiltersBuffer(buffer BufferPool) WriterOption {
+// Defaults to false; bloom filters are written immediately after each row group.
+func DeferBloomFiltersWithBuffer(buffer BufferPool) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.DeferredBloomFiltersBuffer = buffer })
 }
 

--- a/config.go
+++ b/config.go
@@ -225,7 +225,7 @@ type WriterConfig struct {
 	KeyValueMetadata             map[string]string
 	Schema                       *Schema
 	BloomFilters                 []BloomFilterColumn
-	DeferredBloomFiltersBuffer   BufferPool
+	DeferredBloomFiltersBuffers  BufferPool
 	Compression                  compress.Codec
 	Sorting                      SortingConfig
 	SkipPageBounds               [][]string
@@ -303,7 +303,7 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 		KeyValueMetadata:             keyValueMetadata,
 		Schema:                       coalesceSchema(c.Schema, config.Schema),
 		BloomFilters:                 coalesceSlices(c.BloomFilters, config.BloomFilters),
-		DeferredBloomFiltersBuffer:   coalesceBufferPool(c.DeferredBloomFiltersBuffer, config.DeferredBloomFiltersBuffer),
+		DeferredBloomFiltersBuffers:  coalesceBufferPool(c.DeferredBloomFiltersBuffers, config.DeferredBloomFiltersBuffers),
 		Compression:                  coalesceCompression(c.Compression, config.Compression),
 		Sorting:                      coalesceSortingConfig(c.Sorting, config.Sorting),
 		SkipPageBounds:               coalesceSlices(c.SkipPageBounds, config.SkipPageBounds),
@@ -693,7 +693,7 @@ func BloomFilters(filters ...BloomFilterColumn) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.BloomFilters = filters })
 }
 
-// DeferBloomFiltersWithBuffer creates a configuration option which delays the
+// DeferBloomFiltersWithBuffers creates a configuration option which delays the
 // writing of bloom filters until the end of the file. This can be beneficial for
 // files read from remote storage, as an optimistic read can capture the file
 // footer along with the bloom filters.
@@ -703,8 +703,8 @@ func BloomFilters(filters ...BloomFilterColumn) WriterOption {
 // using this option.
 //
 // Defaults to nil; bloom filters are written immediately after each row group.
-func DeferBloomFiltersWithBuffer(buffer BufferPool) WriterOption {
-	return writerOption(func(config *WriterConfig) { config.DeferredBloomFiltersBuffer = buffer })
+func DeferBloomFiltersWithBuffers(buffer BufferPool) WriterOption {
+	return writerOption(func(config *WriterConfig) { config.DeferredBloomFiltersBuffers = buffer })
 }
 
 // Compression creates a configuration option which sets the default compression

--- a/config.go
+++ b/config.go
@@ -695,8 +695,8 @@ func BloomFilters(filters ...BloomFilterColumn) WriterOption {
 
 // DeferBloomFiltersWithBuffers creates a configuration option which delays the
 // writing of bloom filters until the end of the file. This can be beneficial for
-// files read from remote storage, as an optimistic read can capture the file
-// footer along with the bloom filters.
+// files read from remote storage with a custom reader, as an optimistic read can
+// capture the file footer along with the bloom filters in a single request.
 //
 // When this option is enabled, the accumulated bloom filters need to be retained
 // until the file is closed; it is therefore required to provide a buffer when

--- a/config.go
+++ b/config.go
@@ -693,16 +693,16 @@ func BloomFilters(filters ...BloomFilterColumn) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.BloomFilters = filters })
 }
 
-// DeferBloomFiltersWithBuffer creates a configuration option which delays the writing
-// of Bloom filters until the end of the file. This can be beneficial for files
-// read from remote storage, as an optimistic read can capture the file footer
-// along with the bloom filters.
+// DeferBloomFiltersWithBuffer creates a configuration option which delays the
+// writing of bloom filters until the end of the file. This can be beneficial for
+// files read from remote storage, as an optimistic read can capture the file
+// footer along with the bloom filters.
 //
 // When this option is enabled, the accumulated bloom filters need to be retained
 // until the file is closed; it is therefore required to provide a buffer when
 // using this option.
 //
-// Defaults to false; bloom filters are written immediately after each row group.
+// Defaults to nil; bloom filters are written immediately after each row group.
 func DeferBloomFiltersWithBuffer(buffer BufferPool) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.DeferredBloomFiltersBuffer = buffer })
 }

--- a/writer.go
+++ b/writer.go
@@ -1146,21 +1146,24 @@ func (w *writer) writeFileHeader() error {
 }
 
 func (w *writer) writeDeferredBloomFilters() error {
+	defer func() {
+		// Reset here to ensure a re-used closed writer doesn't double return buffers.
+		for _, bf := range w.deferredBloomFilters {
+			bf.reset()
+		}
+		w.deferredBloomFilters = w.deferredBloomFilters[:0]
+		w.deferredBloomFilterSize = 0
+	}()
 	for _, bf := range w.deferredBloomFilters {
 		c := &w.rowGroups[bf.rowGroup].Columns[bf.column]
 		bloomFilterOffset := w.writer.offset
 		c.MetaData.BloomFilterOffset = bloomFilterOffset
 		if _, err := w.writer.ReadFrom(bf.buf); err != nil {
-			bf.reset()
 			return err
 		}
 		bloomFilterLength := w.writer.offset - bloomFilterOffset
 		c.MetaData.BloomFilterLength = int32(bloomFilterLength)
-		bf.reset()
 	}
-	// Clear here to ensure a re-used closed writer doesn't double return buffers.
-	w.deferredBloomFilters = w.deferredBloomFilters[:0]
-	w.deferredBloomFilterSize = 0
 	return nil
 }
 

--- a/writer.go
+++ b/writer.go
@@ -1317,7 +1317,7 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 			continue
 		}
 
-		if rg.config.DeferredBloomFilters {
+		if rg.config.DeferredBloomFiltersBuffer != nil {
 			buf := rg.config.DeferredBloomFiltersBuffer.GetBuffer()
 			reset := func() { rg.config.DeferredBloomFiltersBuffer.PutBuffer(buf) }
 

--- a/writer.go
+++ b/writer.go
@@ -596,7 +596,7 @@ func (w *Writer) Size() int64 {
 	if w.writer == nil {
 		return 0
 	}
-	return w.writer.writer.offset + w.writer.currentRowGroup.Size()
+	return w.writer.writer.offset + w.writer.currentRowGroup.Size() + w.writer.deferredBloomFilterSize
 }
 
 // SetKeyValueMetadata sets a key/value pair in the Parquet file metadata.
@@ -979,8 +979,18 @@ type writer struct {
 	offsetIndexes  [][]format.OffsetIndex
 	sortingColumns []format.SortingColumn
 
+	deferredBloomFilters    []deferredBloomFilter
+	deferredBloomFilterSize int64
+
 	fileMetaData format.FileMetaData
 	footer       [8]byte
+}
+
+type deferredBloomFilter struct {
+	rowGroup int
+	column   int
+	buf      io.ReadWriteSeeker
+	reset    func()
 }
 
 func newWriter(output io.Writer, config *WriterConfig) *writer {
@@ -1067,6 +1077,11 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 }
 
 func (w *writer) reset(writer io.Writer) {
+	for _, bf := range w.deferredBloomFilters {
+		bf.reset()
+	}
+	w.deferredBloomFilters = w.deferredBloomFilters[:0]
+	w.deferredBloomFilterSize = 0
 	if w.buffer == nil {
 		w.writer.Reset(writer)
 	} else {
@@ -1102,6 +1117,9 @@ func (w *writer) close() error {
 	if err := w.flush(); err != nil {
 		return err
 	}
+	if err := w.writeDeferredBloomFilters(); err != nil {
+		return err
+	}
 	if err := w.writeFileFooter(); err != nil {
 		return err
 	}
@@ -1123,6 +1141,22 @@ func (w *writer) writeFileHeader() error {
 	if w.writer.offset == 0 {
 		_, err := w.writer.WriteString("PAR1")
 		return err
+	}
+	return nil
+}
+
+func (w *writer) writeDeferredBloomFilters() error {
+	for _, bf := range w.deferredBloomFilters {
+		c := &w.rowGroups[bf.rowGroup].Columns[bf.column]
+		bloomFilterOffset := w.writer.offset
+		c.MetaData.BloomFilterOffset = bloomFilterOffset
+		if _, err := w.writer.ReadFrom(bf.buf); err != nil {
+			bf.reset()
+			return err
+		}
+		bloomFilterLength := w.writer.offset - bloomFilterOffset
+		c.MetaData.BloomFilterLength = int32(bloomFilterLength)
+		bf.reset()
 	}
 	return nil
 }
@@ -1275,16 +1309,45 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 		}
 	}
 
-	for _, c := range rg.columns {
-		if len(c.filter) > 0 {
-			bloomFilterOffset := w.writer.offset
-			c.columnChunk.MetaData.BloomFilterOffset = bloomFilterOffset
-			if err := c.writeBloomFilter(&w.writer); err != nil {
+	for i, c := range rg.columns {
+		if len(c.filter) == 0 {
+			continue
+		}
+
+		if rg.config.DeferredBloomFilters {
+			buf := rg.config.DeferredBloomFiltersBuffer.GetBuffer()
+			reset := func() { rg.config.DeferredBloomFiltersBuffer.PutBuffer(buf) }
+
+			if err := c.writeBloomFilter(buf); err != nil {
+				reset()
 				return 0, err
 			}
-			bloomFilterLength := w.writer.offset - bloomFilterOffset
-			c.columnChunk.MetaData.BloomFilterLength = int32(bloomFilterLength)
+			size, err := buf.Seek(0, io.SeekCurrent)
+			if err != nil {
+				reset()
+				return 0, err
+			}
+			if _, err := buf.Seek(0, io.SeekStart); err != nil {
+				reset()
+				return 0, err
+			}
+			w.deferredBloomFilterSize += size
+			w.deferredBloomFilters = append(w.deferredBloomFilters, deferredBloomFilter{
+				rowGroup: rowGroupIndex,
+				column:   i,
+				buf:      buf,
+				reset:    reset,
+			})
+			continue
 		}
+
+		bloomFilterOffset := w.writer.offset
+		c.columnChunk.MetaData.BloomFilterOffset = bloomFilterOffset
+		if err := c.writeBloomFilter(&w.writer); err != nil {
+			return 0, err
+		}
+		bloomFilterLength := w.writer.offset - bloomFilterOffset
+		c.columnChunk.MetaData.BloomFilterLength = int32(bloomFilterLength)
 	}
 
 	totalByteSize := int64(0)

--- a/writer.go
+++ b/writer.go
@@ -1317,9 +1317,9 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 			continue
 		}
 
-		if rg.config.DeferredBloomFiltersBuffer != nil {
-			buf := rg.config.DeferredBloomFiltersBuffer.GetBuffer()
-			reset := func() { rg.config.DeferredBloomFiltersBuffer.PutBuffer(buf) }
+		if rg.config.DeferredBloomFiltersBuffers != nil {
+			buf := rg.config.DeferredBloomFiltersBuffers.GetBuffer()
+			reset := func() { rg.config.DeferredBloomFiltersBuffers.PutBuffer(buf) }
 
 			if err := c.writeBloomFilter(buf); err != nil {
 				reset()

--- a/writer.go
+++ b/writer.go
@@ -1158,6 +1158,9 @@ func (w *writer) writeDeferredBloomFilters() error {
 		c.MetaData.BloomFilterLength = int32(bloomFilterLength)
 		bf.reset()
 	}
+	// Clear here to ensure a re-used closed writer doesn't double return buffers.
+	w.deferredBloomFilters = w.deferredBloomFilters[:0]
+	w.deferredBloomFilterSize = 0
 	return nil
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"math/rand"
 	"os"
@@ -1805,6 +1806,49 @@ func TestBloomFilterForDict(t *testing.T) {
 	}
 	if !ok {
 		t.Error("bloom filter should have contained 'test'")
+	}
+}
+
+func TestDeferredBloomFilter(t *testing.T) {
+	type testStruct struct {
+		A int `parquet:"a"`
+	}
+
+	schema := parquet.SchemaOf(&testStruct{})
+
+	b := bytes.NewBuffer(nil)
+	w := parquet.NewWriter(
+		b,
+		schema,
+		parquet.BloomFilters(parquet.SplitBlockFilter(10, "a")),
+		parquet.DeferredBloomFilters(true),
+		parquet.MaxRowsPerRowGroup(5), // Ensure we have multiple groups.
+	)
+	for i := range 50 {
+		err := w.Write(&testStruct{A: i})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := parquet.OpenFile(bytes.NewReader(b.Bytes()), int64(b.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bloomFiltersStart, dataPagesEnd := int64(math.MaxInt64), int64(math.MinInt64)
+	for _, rg := range f.Metadata().RowGroups {
+		bloomFilterOffset := rg.Columns[0].MetaData.BloomFilterOffset
+		bloomFiltersStart = min(bloomFiltersStart, bloomFilterOffset)
+
+		dataPageOffset := rg.Columns[0].MetaData.DataPageOffset + rg.Columns[0].MetaData.TotalCompressedSize
+		dataPagesEnd = max(dataPagesEnd, dataPageOffset)
+	}
+	if bloomFiltersStart != dataPagesEnd {
+		t.Fatalf("expected bloom filters to be written after data pages: %d != %d", bloomFiltersStart, dataPagesEnd)
 	}
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -1821,7 +1821,7 @@ func TestDeferredBloomFilter(t *testing.T) {
 		b,
 		schema,
 		parquet.BloomFilters(parquet.SplitBlockFilter(10, "a")),
-		parquet.DeferredBloomFilters(true),
+		parquet.DeferBloomFiltersWithBuffer(parquet.NewBufferPool()),
 		parquet.MaxRowsPerRowGroup(5), // Ensure we have multiple groups.
 	)
 	for i := range 20 {

--- a/writer_test.go
+++ b/writer_test.go
@@ -1824,7 +1824,7 @@ func TestDeferredBloomFilter(t *testing.T) {
 		parquet.DeferredBloomFilters(true),
 		parquet.MaxRowsPerRowGroup(5), // Ensure we have multiple groups.
 	)
-	for i := range 50 {
+	for i := range 20 {
 		err := w.Write(&testStruct{A: i})
 		if err != nil {
 			t.Fatal(err)
@@ -1839,6 +1839,7 @@ func TestDeferredBloomFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Validate file structure.
 	bloomFiltersStart, dataPagesEnd := int64(math.MaxInt64), int64(math.MinInt64)
 	for _, rg := range f.Metadata().RowGroups {
 		bloomFilterOffset := rg.Columns[0].MetaData.BloomFilterOffset
@@ -1849,6 +1850,15 @@ func TestDeferredBloomFilter(t *testing.T) {
 	}
 	if bloomFiltersStart != dataPagesEnd {
 		t.Fatalf("expected bloom filters to be written after data pages: %d != %d", bloomFiltersStart, dataPagesEnd)
+	}
+
+	// Validate bloom filter contents.
+	ok, err := f.RowGroups()[0].ColumnChunks()[0].BloomFilter().Check(parquet.ValueOf(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("bloom filter should have contained '3'")
 	}
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -1821,7 +1821,7 @@ func TestDeferredBloomFilter(t *testing.T) {
 		b,
 		schema,
 		parquet.BloomFilters(parquet.SplitBlockFilter(10, "a")),
-		parquet.DeferBloomFiltersWithBuffer(parquet.NewBufferPool()),
+		parquet.DeferBloomFiltersWithBuffers(parquet.NewBufferPool()),
 		parquet.MaxRowsPerRowGroup(5), // Ensure we have multiple groups.
 	)
 	for i := range 20 {


### PR DESCRIPTION
Related to https://github.com/parquet-go/parquet-go/issues/135.

This PR adds `parquet.DeferBloomFiltersWithBuffer(...)` to enable defering the writing of bloom filters until after the data pages. 

Note, I'm not super happy with the buffer management approach, suggestions welcome. 