### PR TITLE
fix: parquet tag name should take precedence over protobuf tag name

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -516,6 +516,7 @@ func appendStructFields(path []string, t reflect.Type, fields []reflect.StructFi
 
 		ftags := fromStructTag(f.Tag)
 
+		parquetNameSet := false
 		if tag := ftags.parquet; tag != "" {
 			name, _ := split(tag)
 			if tag != "-," && name == "-" {
@@ -523,13 +524,14 @@ func appendStructFields(path []string, t reflect.Type, fields []reflect.StructFi
 			}
 			if name != "" {
 				f.Name = name
+				parquetNameSet = true
 			}
 		}
 
 		// If no explicit parquet name was set, check for protobuf tag name.
 		// This allows protobuf-generated structs to use their proto field names
 		// (typically snake_case) as parquet column names.
-		if f.Name == t.Field(i).Name { // Name wasn't changed by parquet tag
+		if !parquetNameSet {
 			if protoName := protoFieldNameFromTag(f.Tag); protoName != "" {
 				f.Name = protoName
 			}

--- a/schema_test.go
+++ b/schema_test.go
@@ -374,6 +374,16 @@ func TestSchemaOf(t *testing.T) {
 }`,
 		},
 
+		// Test that explicit parquet tag name takes precedence over protobuf tag name when go field name matches parquet name
+		{
+			value: new(struct {
+				MyKey int64 `protobuf:"varint,1,opt,name=my_key,proto3" parquet:"MyKey"` // Index into string table
+			}),
+			print: `message {
+	required int64 MyKey (INT(64,true));
+}`,
+		},
+
 		// Test protobuf tags with nested structs
 		{
 			value: new(struct {


### PR DESCRIPTION
When a struct field has both a parquet tag and a protobuf tag, the parquet tag name was being silently overridden by the protobuf tag name if both names happened to be equal to the Go field name.

The condition introduced in #432 used `f.Name == t.Field(i).Name` to detect whether the parquet tag had set a name. This broke when the parquet tag name matched the Go struct field name (e.g. `parquet:"Key"` on a field named `Key`), causing the protobuf name to win. 

Fix by tracking `parquetNameSet` explicitly instead of relying on the name comparison.
