### PR TITLE
fix(rle): raise maxSupportedValueCount to match Parquet spec limit

### DIFF
--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"unsafe"
 
 	"golang.org/x/sys/cpu"
@@ -21,13 +22,9 @@ import (
 )
 
 const (
-	// This limit is intended to prevent unbounded memory allocations when
-	// decoding runs.
-	//
-	// We use a generous limit which allows for over 16 million values per page
-	// if there is only one run to encode the repetition or definition levels
-	// (this should be uncommon).
-	maxSupportedValueCount = 16 * 1024 * 1024
+	// This limit prevents unbounded memory allocations when decoding runs.
+	// It is set to the largest run length the Parquet specification permits in an RLE header.
+	maxSupportedValueCount = math.MaxInt32
 )
 
 type Encoding struct {

--- a/encoding/rle/rle_test.go
+++ b/encoding/rle/rle_test.go
@@ -68,3 +68,28 @@ func benchmarkEncodeInt32IndexEqual8Contiguous(b *testing.B, f func([][8]int32) 
 	}
 	b.SetBytes(32 * int64(len(words)))
 }
+
+func TestDecodeInt32LargeRun(t *testing.T) {
+	enc := &Encoding{BitWidth: 1}
+	count := 16_777_217 // one more than old maxSupportedValueCount
+	src := make([]int32, count)
+	for i := range src {
+		src[i] = 1
+	}
+	encoded, err := enc.EncodeInt32(nil, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := enc.DecodeInt32(make([]int32, count), encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != count {
+		t.Fatalf("expected %d values, got %d", count, len(decoded))
+	}
+	for i, v := range decoded {
+		if v != 1 {
+			t.Fatalf("value at index %d: expected 1, got %d", i, v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Raise `maxSupportedValueCount` in `encoding/rle/rle.go` from `16 * 1024 * 1024` (16M) to `math.MaxInt32` (2,147,483,647), matching the Parquet specification limit for RLE run lengths
- Update the comment to reference the Parquet specification's signed 32-bit integer limit
- Add test verifying decoding of RLE runs exceeding the previous 16M limit

The current 16M limit causes legitimate parquet files with large row groups containing optional or repeated columns to fail decoding with:

```
RLE: decoded run-length block cannot have more than 16777216 values
```

The Parquet specification explicitly permits RLE run lengths up to 2^31-1 (encoded as signed 32-bit integers):

> bit-packed-run-len and rle-run-len must be in the range [1, 2^31 - 1]

https://parquet.apache.org/docs/file-format/data-pages/encodings/

The previous limit of 16M was introduced as a defensive heuristic but is 128x smaller than the specification allows. Real-world data (e.g., parquet files with large row groups and optional/repeated columns) can legitimately produce pages with >16M definition or repetition level values.

## Test plan

- [x] Existing tests pass (`go test ./encoding/rle/ -count=1`)
- [x] Added `TestDecodeInt32LargeRun` verifying encode/decode of 16,777,217 (16M + 1) int32 values
- [x] Code passes `go fmt` and `go vet`