### PR TITLE
Set a list element name with the tag `parquet-element`

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -182,7 +182,11 @@ func (v *onceValue[T]) load(f func() *T) *T {
 //	  Attributes []string `parquet:",id(1),list" parquet-element:",id(2)"`
 //	}
 //
-// Note that the name of the element cannot be changed.
+// Note that the name of the element of a list defaults to "element" and can be changed:
+//
+//	type Item struct {
+//	  Attributes []string `parquet:",list" parquet-element:"item"`
+//	}
 //
 // The schema name is the Go type name of the value.
 func SchemaOf(model any, opts ...SchemaOption) *Schema {
@@ -930,12 +934,13 @@ var (
 
 func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, tagReplacements []StructTagOption) Node {
 	var (
-		node       Node
-		optional   bool
-		list       bool
-		encoded    encoding.Encoding
-		compressed compress.Codec
-		fieldID    int
+		node            Node
+		optional        bool
+		list            bool
+		listElementName string
+		encoded         encoding.Encoding
+		compressed      compress.Codec
+		fieldID         int
 	)
 
 	setNode := func(n Node) {
@@ -1052,7 +1057,14 @@ func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, ta
 					if t == reflect.TypeFor[json.RawMessage]() {
 						throwInvalidTag(t, name, option)
 					}
-					element := makeNodeOf(append(path, "list", "element"), t.Elem(), t.Name(), tags.getListElementNodeTags(), tagReplacements)
+					elementTags := tags.getListElementNodeTags()
+					listElementName = "element"
+					if tag := elementTags.parquet; tag != "" {
+						if name, _ := split(tag); name != "" {
+							listElementName = name
+						}
+					}
+					element := makeNodeOf(append(path, "list", listElementName), t.Elem(), t.Name(), elementTags, tagReplacements)
 					setNode(element)
 					setList()
 				default:
@@ -1322,7 +1334,7 @@ func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, ta
 	}
 
 	if list {
-		node = List(node)
+		node = ListElement(listElementName, node)
 	}
 
 	if node.Repeated() && !list {

--- a/schema_test.go
+++ b/schema_test.go
@@ -327,6 +327,24 @@ func TestSchemaOf(t *testing.T) {
 		},
 		{
 			value: new(struct {
+				List1 []int32 `parquet:"list1,list" parquet-element:"item"`
+				List2 []int32 `parquet:"list2,list"`
+			}),
+			print: `message {
+	required group list1 (LIST) {
+		repeated group list {
+			required int32 item (INT(32,true));
+		}
+	}
+	required group list2 (LIST) {
+		repeated group list {
+			required int32 element (INT(32,true));
+		}
+	}
+}`,
+		},
+		{
+			value: new(struct {
 				ArrayOfArrays [][]int32 `parquet:"array_of_arrays,list" parquet-element:",list"`
 			}),
 			print: `message {

--- a/tags_test.go
+++ b/tags_test.go
@@ -44,6 +44,13 @@ func TestFromStructTag(t *testing.T) {
 				parquetElement: ",id(2)",
 			},
 		},
+		{
+			structTag: reflect.StructTag(`parquet:"name,list" parquet-element:"item,optional"`),
+			expected: parquetTags{
+				parquet:        "name,list",
+				parquetElement: "item,optional",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -107,6 +114,18 @@ func TestGetNodeTags(t *testing.T) {
 			},
 			expected: parquetTags{
 				parquet: ",id(2)",
+			},
+		},
+		{
+			input: parquetTags{
+				parquet:        "list_name,list",
+				parquetElement: "item_name",
+			},
+			getNodeTags: func(p parquetTags) parquetTags {
+				return p.getListElementNodeTags()
+			},
+			expected: parquetTags{
+				parquet: "item_name",
 			},
 		},
 	}

--- a/type_list.go
+++ b/type_list.go
@@ -12,7 +12,12 @@ import (
 //
 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
 func List(of Node) Node {
-	return listNode{Group{"list": Repeated(Group{"element": of})}}
+	return ListElement("element", of)
+}
+
+// ListElement constructs a node of LIST logical type with a custom element name.
+func ListElement(elementName string, of Node) Node {
+	return listNode{Group{"list": Repeated(Group{elementName: of})}}
 }
 
 type listNode struct{ Group }


### PR DESCRIPTION
This allows parquet files with lists not using the standard "element" name for the element items to be parsed (namely HuggingFace dataset parquet files).

Updated comment in `SchemaOf()`.

### Testing

- Added tests that tags `parquet-element:name` are properly parsed.
- Added tests that the parquet-element name makes to the schema.

