### PR TITLE
fix(file): improve optimistic bloom reader

### DIFF
--- a/file.go
+++ b/file.go
@@ -141,7 +141,7 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	f.rowGroups = makeRowGroups(rowGroups)
 
 	if !c.SkipBloomFilters {
-		section := io.NewSectionReader(r, 0, size)
+		section := io.NewSectionReader(f.reader, 0, size)
 		rbuf, rbufpool := getBufioReader(section, c.ReadBufferSize)
 		defer putBufioReader(rbuf, rbufpool)
 

--- a/file_test.go
+++ b/file_test.go
@@ -290,27 +290,34 @@ func TestFileTypes(t *testing.T) {
 }
 
 func TestOpenFileOptimisticRead(t *testing.T) {
-	f, err := os.Open("testdata/alltypes_tiny_pages_plain.parquet")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close()
-	s, err := f.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, filename := range []string{
+		"alltypes_tiny_pages_plain.parquet",
+		"data_index_bloom_encoding_stats.parquet",
+	} {
+		t.Run(filename, func(t *testing.T) {
+			f, err := os.Open(filepath.Join("testdata", filename))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			s, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	r := &measuredReaderAt{reader: f}
-	if _, err := parquet.OpenFile(r, s.Size(),
-		parquet.OptimisticRead(true),
-		parquet.SkipMagicBytes(true),
-		parquet.ReadBufferSize(int(s.Size()/2)),
-	); err != nil {
-		t.Fatal(err)
-	}
+			r := &measuredReaderAt{reader: f}
+			if _, err := parquet.OpenFile(r, s.Size(),
+				parquet.OptimisticRead(true),
+				parquet.SkipMagicBytes(true),
+				parquet.ReadBufferSize(int(s.Size())),
+			); err != nil {
+				t.Fatal(err)
+			}
 
-	if reads := r.reads.Load(); reads != 1 {
-		t.Errorf("expected 1 read, got %d", reads)
+			if reads := r.reads.Load(); reads != 1 {
+				t.Errorf("expected 1 read, got %d", reads)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
When opening files with bloom filters using optimistic read, the bloom filter setup would always perform further reads to the file, even if we already had the filter bytes in memory.