### PR TITLE
feat(file): new option to enable prefetch of bloom filters

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ const (
 	DefaultSkipMagicBytes       = false
 	DefaultSkipPageIndex        = false
 	DefaultSkipBloomFilters     = false
-	DefaultLazyLoadBloomFilters = true
+	DefaultPrefetchBloomFilters = false
 	DefaultMaxRowsPerRowGroup   = math.MaxInt64
 	DefaultReadMode             = ReadModeSync
 )
@@ -99,7 +99,7 @@ type FileConfig struct {
 	SkipMagicBytes       bool
 	SkipPageIndex        bool
 	SkipBloomFilters     bool
-	LazyLoadBloomFilters bool
+	PrefetchBloomFilters bool
 	OptimisticRead       bool
 	ReadBufferSize       int
 	ReadMode             ReadMode
@@ -113,7 +113,7 @@ func DefaultFileConfig() *FileConfig {
 		SkipMagicBytes:       DefaultSkipMagicBytes,
 		SkipPageIndex:        DefaultSkipPageIndex,
 		SkipBloomFilters:     DefaultSkipBloomFilters,
-		LazyLoadBloomFilters: DefaultLazyLoadBloomFilters,
+		PrefetchBloomFilters: DefaultPrefetchBloomFilters,
 		ReadBufferSize:       defaultReadBufferSize,
 		ReadMode:             DefaultReadMode,
 		Schema:               nil,
@@ -144,7 +144,7 @@ func (c *FileConfig) ConfigureFile(config *FileConfig) {
 		SkipMagicBytes:       c.SkipMagicBytes,
 		SkipPageIndex:        c.SkipPageIndex,
 		SkipBloomFilters:     c.SkipBloomFilters,
-		LazyLoadBloomFilters: c.LazyLoadBloomFilters,
+		PrefetchBloomFilters: c.PrefetchBloomFilters,
 		ReadBufferSize:       coalesceInt(c.ReadBufferSize, config.ReadBufferSize),
 		ReadMode:             ReadMode(coalesceInt(int(c.ReadMode), int(config.ReadMode))),
 		Schema:               coalesceSchema(c.Schema, config.Schema),
@@ -506,15 +506,15 @@ func SkipBloomFilters(skip bool) FileOption {
 	return fileOption(func(config *FileConfig) { config.SkipBloomFilters = skip })
 }
 
-// LazyLoadBloomFilters is a file configuration option that controls whether the
+// PrefetchBloomFilters is a file configuration option that controls whether the
 // bloom filter contents are loaded into memory when a file is opened. By
 // default, only the headers are parsed, requiring further reads to the file to
-// probe the filter. Disabling this option when using OptimisticRead can be
-// useful when reading from remote storage, reducing network round trips.
+// probe the filter. Using this option with OptimisticRead can be useful when
+// reading from remote storage, reducing network round trips.
 //
-// Defaults to true.
-func LazyLoadBloomFilters(lazyLoad bool) FileOption {
-	return fileOption(func(config *FileConfig) { config.LazyLoadBloomFilters = lazyLoad })
+// Defaults to false.
+func PrefetchBloomFilters(prefetch bool) FileOption {
+	return fileOption(func(config *FileConfig) { config.PrefetchBloomFilters = prefetch })
 }
 
 // OptimisticRead configures a file to optimistically perform larger buffered

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ const (
 	DefaultSkipMagicBytes       = false
 	DefaultSkipPageIndex        = false
 	DefaultSkipBloomFilters     = false
+	DefaultLazyLoadBloomFilters = true
 	DefaultMaxRowsPerRowGroup   = math.MaxInt64
 	DefaultReadMode             = ReadModeSync
 )
@@ -95,25 +96,27 @@ func formatCreatedBy(application, version, build string) string {
 //		ReadMode:         ReadModeAsync,
 //	})
 type FileConfig struct {
-	SkipMagicBytes   bool
-	SkipPageIndex    bool
-	SkipBloomFilters bool
-	OptimisticRead   bool
-	ReadBufferSize   int
-	ReadMode         ReadMode
-	Schema           *Schema
+	SkipMagicBytes       bool
+	SkipPageIndex        bool
+	SkipBloomFilters     bool
+	LazyLoadBloomFilters bool
+	OptimisticRead       bool
+	ReadBufferSize       int
+	ReadMode             ReadMode
+	Schema               *Schema
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
 // default file configuration.
 func DefaultFileConfig() *FileConfig {
 	return &FileConfig{
-		SkipMagicBytes:   DefaultSkipMagicBytes,
-		SkipPageIndex:    DefaultSkipPageIndex,
-		SkipBloomFilters: DefaultSkipBloomFilters,
-		ReadBufferSize:   defaultReadBufferSize,
-		ReadMode:         DefaultReadMode,
-		Schema:           nil,
+		SkipMagicBytes:       DefaultSkipMagicBytes,
+		SkipPageIndex:        DefaultSkipPageIndex,
+		SkipBloomFilters:     DefaultSkipBloomFilters,
+		LazyLoadBloomFilters: DefaultLazyLoadBloomFilters,
+		ReadBufferSize:       defaultReadBufferSize,
+		ReadMode:             DefaultReadMode,
+		Schema:               nil,
 	}
 }
 
@@ -138,12 +141,13 @@ func (c *FileConfig) Apply(options ...FileOption) {
 // ConfigureFile applies configuration options from c to config.
 func (c *FileConfig) ConfigureFile(config *FileConfig) {
 	*config = FileConfig{
-		SkipMagicBytes:   c.SkipMagicBytes,
-		SkipPageIndex:    c.SkipPageIndex,
-		SkipBloomFilters: c.SkipBloomFilters,
-		ReadBufferSize:   coalesceInt(c.ReadBufferSize, config.ReadBufferSize),
-		ReadMode:         ReadMode(coalesceInt(int(c.ReadMode), int(config.ReadMode))),
-		Schema:           coalesceSchema(c.Schema, config.Schema),
+		SkipMagicBytes:       c.SkipMagicBytes,
+		SkipPageIndex:        c.SkipPageIndex,
+		SkipBloomFilters:     c.SkipBloomFilters,
+		LazyLoadBloomFilters: c.LazyLoadBloomFilters,
+		ReadBufferSize:       coalesceInt(c.ReadBufferSize, config.ReadBufferSize),
+		ReadMode:             ReadMode(coalesceInt(int(c.ReadMode), int(config.ReadMode))),
+		Schema:               coalesceSchema(c.Schema, config.Schema),
 	}
 }
 
@@ -493,13 +497,24 @@ func SkipPageIndex(skip bool) FileOption {
 }
 
 // SkipBloomFilters is a file configuration option which prevents automatically
-// reading the bloom filters when opening a parquet file, when set to true.
-// This is useful as an optimization when programs know that they will not need
-// to consume the bloom filters.
+// reading the bloom filter headers when opening a parquet file, when set to
+// true. This is useful as an optimization when programs know that they will not
+// need to consume the bloom filters.
 //
 // Defaults to false.
 func SkipBloomFilters(skip bool) FileOption {
 	return fileOption(func(config *FileConfig) { config.SkipBloomFilters = skip })
+}
+
+// LazyLoadBloomFilters is a file configuration option that controls whether the
+// bloom filter contents are loaded into memory when a file is opened. By
+// default, only the headers are parsed, requiring further reads to the file to
+// probe the filter. Disabling this option when using OptimisticRead can be
+// useful when reading from remote storage, reducing network round trips.
+//
+// Defaults to true.
+func LazyLoadBloomFilters(lazyLoad bool) FileOption {
+	return fileOption(func(config *FileConfig) { config.LazyLoadBloomFilters = lazyLoad })
 }
 
 // OptimisticRead configures a file to optimistically perform larger buffered

--- a/file.go
+++ b/file.go
@@ -2,6 +2,7 @@ package parquet
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -153,9 +154,9 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 			g := &rowGroups[i]
 
 			for j := range g.columns {
-				c := g.columns[j].(*FileColumnChunk)
+				cc := g.columns[j].(*FileColumnChunk)
 
-				if offset := c.chunk.MetaData.BloomFilterOffset; offset > 0 {
+				if offset := cc.chunk.MetaData.BloomFilterOffset; offset > 0 {
 					section.Seek(offset, io.SeekStart)
 					rbuf.Reset(section)
 
@@ -168,12 +169,22 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 					offset -= int64(rbuf.Buffered())
 
 					if cast, ok := r.(interface{ SetBloomFilterSection(offset, length int64) }); ok {
-						bloomFilterOffset := c.chunk.MetaData.BloomFilterOffset
+						bloomFilterOffset := cc.chunk.MetaData.BloomFilterOffset
 						bloomFilterLength := (offset - bloomFilterOffset) + int64(header.NumBytes)
 						cast.SetBloomFilterSection(bloomFilterOffset, bloomFilterLength)
 					}
 
-					c.bloomFilter.Store(newBloomFilter(r, offset, &header))
+					if c.LazyLoadBloomFilters {
+						cc.bloomFilter.Store(newBloomFilter(f, offset, &header))
+					} else {
+						// Eagerly load bloom filter into memory
+						bloomData := make([]byte, header.NumBytes)
+						if _, err := io.ReadFull(rbuf, bloomData); err != nil {
+							return nil, fmt.Errorf("reading bloom filter data: %w", err)
+						}
+						// Create bloom filter using in-memory data
+						cc.bloomFilter.Store(newBloomFilter(bytes.NewReader(bloomData), 0, &header))
+					}
 				}
 			}
 		}

--- a/file.go
+++ b/file.go
@@ -141,7 +141,7 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	f.rowGroups = makeRowGroups(rowGroups)
 
 	if !c.SkipBloomFilters {
-		section := io.NewSectionReader(r, 0, size)
+		section := io.NewSectionReader(f.reader, 0, size)
 		rbuf, rbufpool := getBufioReader(section, c.ReadBufferSize)
 		defer putBufioReader(rbuf, rbufpool)
 

--- a/file.go
+++ b/file.go
@@ -174,16 +174,15 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 						cast.SetBloomFilterSection(bloomFilterOffset, bloomFilterLength)
 					}
 
-					if c.LazyLoadBloomFilters {
-						cc.bloomFilter.Store(newBloomFilter(f, offset, &header))
-					} else {
-						// Eagerly load bloom filter into memory
+					if c.PrefetchBloomFilters {
 						bloomData := make([]byte, header.NumBytes)
 						if _, err := io.ReadFull(rbuf, bloomData); err != nil {
 							return nil, fmt.Errorf("reading bloom filter data: %w", err)
 						}
-						// Create bloom filter using in-memory data
+						// Create bloom filter using in-memory data.
 						cc.bloomFilter.Store(newBloomFilter(bytes.NewReader(bloomData), 0, &header))
+					} else {
+						cc.bloomFilter.Store(newBloomFilter(f, offset, &header))
 					}
 				}
 			}

--- a/file_test.go
+++ b/file_test.go
@@ -321,7 +321,7 @@ func TestOpenFileOptimisticRead(t *testing.T) {
 	}
 }
 
-func TestOpenFileOptimisticReadWithLazyBloomLoading(t *testing.T) {
+func TestOpenFileOptimisticReadWithPrefetchBloomFilters(t *testing.T) {
 	f, err := os.Open(filepath.Join("testdata", "data_index_bloom_encoding_stats.parquet"))
 	if err != nil {
 		t.Fatal(err)
@@ -334,19 +334,19 @@ func TestOpenFileOptimisticReadWithLazyBloomLoading(t *testing.T) {
 
 	for _, tt := range []struct {
 		OptimisticRead       bool
-		LazyLoadBloomFilters bool
+		PrefetchBloomFilters bool
 		ExpectedReads        int64
 	}{
-		{false, true, 6},
-		{true, true, 2},
-		{true, false, 1},
+		{false, false, 6},
+		{true, false, 2},
+		{true, true, 1},
 	} {
 		r := &measuredReaderAt{reader: f}
 		pf, err := parquet.OpenFile(r, s.Size(),
 			parquet.OptimisticRead(tt.OptimisticRead),
 			parquet.SkipMagicBytes(true),
 			parquet.ReadBufferSize(int(s.Size())),
-			parquet.LazyLoadBloomFilters(tt.LazyLoadBloomFilters),
+			parquet.PrefetchBloomFilters(tt.PrefetchBloomFilters),
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/file_test.go
+++ b/file_test.go
@@ -290,27 +290,34 @@ func TestFileTypes(t *testing.T) {
 }
 
 func TestOpenFileOptimisticRead(t *testing.T) {
-	f, err := os.Open("testdata/alltypes_tiny_pages_plain.parquet")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close()
-	s, err := f.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, filename := range []string{
+		"alltypes_tiny_pages_plain.parquet",
+		"data_index_bloom_encoding_stats.parquet",
+	} {
+		t.Run(filename, func(t *testing.T) {
+			f, err := os.Open(filepath.Join("testdata", filename))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			s, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	r := &measuredReaderAt{reader: f}
-	if _, err := parquet.OpenFile(r, s.Size(),
-		parquet.OptimisticRead(true),
-		parquet.SkipMagicBytes(true),
-		parquet.ReadBufferSize(int(s.Size()/2)),
-	); err != nil {
-		t.Fatal(err)
-	}
+			r := &measuredReaderAt{reader: f}
+			if _, err := parquet.OpenFile(r, s.Size(),
+				parquet.OptimisticRead(true),
+				parquet.SkipMagicBytes(true),
+				parquet.ReadBufferSize(int(s.Size())),
+			); err != nil {
+				t.Fatal(err)
+			}
 
-	if reads := r.reads.Load(); reads != 1 {
-		t.Errorf("expected 1 read, got %d", reads)
+			if reads := r.reads.Load(); reads != 1 {
+				t.Errorf("expected 1 read, got %d", reads)
+			}
+		})
 	}
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -321,6 +321,54 @@ func TestOpenFileOptimisticRead(t *testing.T) {
 	}
 }
 
+func TestOpenFileOptimisticReadWithLazyBloomLoading(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "data_index_bloom_encoding_stats.parquet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	s, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		OptimisticRead       bool
+		LazyLoadBloomFilters bool
+		ExpectedReads        int64
+	}{
+		{false, true, 6},
+		{true, true, 2},
+		{true, false, 1},
+	} {
+		r := &measuredReaderAt{reader: f}
+		pf, err := parquet.OpenFile(r, s.Size(),
+			parquet.OptimisticRead(tt.OptimisticRead),
+			parquet.SkipMagicBytes(true),
+			parquet.ReadBufferSize(int(s.Size())),
+			parquet.LazyLoadBloomFilters(tt.LazyLoadBloomFilters),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rg := range pf.RowGroups() {
+			for _, cc := range rg.ColumnChunks() {
+				if bf := cc.BloomFilter(); bf != nil {
+					_, err := bf.Check(parquet.NullValue())
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+		}
+
+		if reads := r.reads.Load(); reads != tt.ExpectedReads {
+			t.Errorf("expected %d read, got %d", tt.ExpectedReads, reads)
+		}
+	}
+}
+
 func TestIssue229(t *testing.T) {
 	// https://github.com/grafana/tempo/blob/5cae77c9cf8da51e0db7c5556b19d305130ea9c4/tempodb/encoding/vparquet2/schema.go
 	type Attribute struct {


### PR DESCRIPTION
This is a follow on from https://github.com/parquet-go/parquet-go/pull/492, split the PRs, but if this is accepted the original can be disregarded. 

Currently today, the library will always lazy load bloom filters. When reading from object storage, this means additional HTTP requests for each probe of the filter. Added a new option `PrefetchBloomFilters(bool)` to enable prefetching filters into memory.

The combination of this change with optimistic read mean a file can be opened, bloom filters loaded and probed with a single optimistic request. This is very significant for my workload, where 100s of files are accessed using this pattern simultaneously. 