### PR TITLE
feat: implement Apache Parquet column encryption (AES-GCM)

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -111,6 +111,25 @@ func newBloomFilter(file io.ReaderAt, offset int64, header *format.BloomFilterHe
 	}
 }
 
+// newBloomFilterFromBytes constructs a FileBloomFilter backed by an in-memory
+// byte slice.  Used when the bloom filter was read from an encrypted column and
+// the raw bytes were decrypted before constructing the filter.
+func newBloomFilterFromBytes(header *format.BloomFilterHeader, bits []byte) *FileBloomFilter {
+	if header.Algorithm.Block != nil {
+		if header.Hash.XxHash != nil {
+			if header.Compression.Uncompressed != nil {
+				r := bytes.NewReader(bits)
+				return &FileBloomFilter{
+					SectionReader: *io.NewSectionReader(r, 0, int64(len(bits))),
+					hash:          bloom.XXH64{},
+					check:         bloom.CheckSplitBlock,
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // The BloomFilterColumn interface is a declarative representation of bloom filters
 // used when configuring filters on a parquet writer.
 type BloomFilterColumn interface {

--- a/bloom.go
+++ b/bloom.go
@@ -114,9 +114,14 @@ func newBloomFilter(file io.ReaderAt, offset int64, header *format.BloomFilterHe
 // newBloomFilterFromBytes constructs a FileBloomFilter backed by an in-memory
 // byte slice.  Used when the bloom filter was read from an encrypted column and
 // the raw bytes were decrypted before constructing the filter.
-func newBloomFilterFromBytes(header *format.BloomFilterHeader, bits []byte) (*FileBloomFilter, error) {
+//
+// Bloom filters are an optimization: if the header advertises an algorithm,
+// hash, or compression codec we don't support, or if eager decompression
+// fails, we return nil so the read silently skips the filter rather than
+// failing the whole file open.
+func newBloomFilterFromBytes(header *format.BloomFilterHeader, bits []byte) *FileBloomFilter {
 	if header.Algorithm.Block == nil || header.Hash.XxHash == nil {
-		return nil, nil
+		return nil
 	}
 	switch {
 	case header.Compression.Uncompressed != nil:
@@ -125,20 +130,20 @@ func newBloomFilterFromBytes(header *format.BloomFilterHeader, bits []byte) (*Fi
 			SectionReader: *io.NewSectionReader(r, 0, int64(len(bits))),
 			hash:          bloom.XXH64{},
 			check:         bloom.CheckSplitBlock,
-		}, nil
+		}
 	case header.Compression.GZip != nil:
 		decompressed, err := LookupCompressionCodec(format.Gzip).Decode(nil, bits)
 		if err != nil {
-			return nil, fmt.Errorf("decompressing bloom filter: %w", err)
+			return nil
 		}
 		r := bytes.NewReader(decompressed)
 		return &FileBloomFilter{
 			SectionReader: *io.NewSectionReader(r, 0, int64(len(decompressed))),
 			hash:          bloom.XXH64{},
 			check:         bloom.CheckSplitBlock,
-		}, nil
+		}
 	default:
-		return nil, nil
+		return nil
 	}
 }
 

--- a/bloom.go
+++ b/bloom.go
@@ -114,20 +114,32 @@ func newBloomFilter(file io.ReaderAt, offset int64, header *format.BloomFilterHe
 // newBloomFilterFromBytes constructs a FileBloomFilter backed by an in-memory
 // byte slice.  Used when the bloom filter was read from an encrypted column and
 // the raw bytes were decrypted before constructing the filter.
-func newBloomFilterFromBytes(header *format.BloomFilterHeader, bits []byte) *FileBloomFilter {
-	if header.Algorithm.Block != nil {
-		if header.Hash.XxHash != nil {
-			if header.Compression.Uncompressed != nil {
-				r := bytes.NewReader(bits)
-				return &FileBloomFilter{
-					SectionReader: *io.NewSectionReader(r, 0, int64(len(bits))),
-					hash:          bloom.XXH64{},
-					check:         bloom.CheckSplitBlock,
-				}
-			}
-		}
+func newBloomFilterFromBytes(header *format.BloomFilterHeader, bits []byte) (*FileBloomFilter, error) {
+	if header.Algorithm.Block == nil || header.Hash.XxHash == nil {
+		return nil, nil
 	}
-	return nil
+	switch {
+	case header.Compression.Uncompressed != nil:
+		r := bytes.NewReader(bits)
+		return &FileBloomFilter{
+			SectionReader: *io.NewSectionReader(r, 0, int64(len(bits))),
+			hash:          bloom.XXH64{},
+			check:         bloom.CheckSplitBlock,
+		}, nil
+	case header.Compression.GZip != nil:
+		decompressed, err := LookupCompressionCodec(format.Gzip).Decode(nil, bits)
+		if err != nil {
+			return nil, fmt.Errorf("decompressing bloom filter: %w", err)
+		}
+		r := bytes.NewReader(decompressed)
+		return &FileBloomFilter{
+			SectionReader: *io.NewSectionReader(r, 0, int64(len(decompressed))),
+			hash:          bloom.XXH64{},
+			check:         bloom.CheckSplitBlock,
+		}, nil
+	default:
+		return nil, nil
+	}
 }
 
 // The BloomFilterColumn interface is a declarative representation of bloom filters

--- a/config.go
+++ b/config.go
@@ -105,6 +105,7 @@ type FileConfig struct {
 	ReadBufferSize       int
 	ReadMode             ReadMode
 	Schema               *Schema
+	Decryption           *DecryptionConfig
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
@@ -149,6 +150,7 @@ func (c *FileConfig) ConfigureFile(config *FileConfig) {
 		ReadBufferSize:       cmp.Or(c.ReadBufferSize, config.ReadBufferSize),
 		ReadMode:             ReadMode(cmp.Or(int(c.ReadMode), int(config.ReadMode))),
 		Schema:               cmp.Or(c.Schema, config.Schema),
+		Decryption:           cmp.Or(c.Decryption, config.Decryption),
 	}
 }
 
@@ -239,6 +241,7 @@ type WriterConfig struct {
 	Encodings                    map[Kind]encoding.Encoding
 	DictionaryMaxBytes           int64
 	SchemaConfig                 *SchemaConfig
+	Encryption                   *EncryptionConfig
 }
 
 // DefaultWriterConfig returns a new WriterConfig value initialized with the
@@ -317,6 +320,7 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 		SkipPageStatistics:           coalesceSlices(c.SkipPageStatistics, config.SkipPageStatistics),
 		Encodings:                    encodings,
 		SchemaConfig:                 cmp.Or(c.SchemaConfig, config.SchemaConfig),
+		Encryption:                   cmp.Or(c.Encryption, config.Encryption),
 	}
 }
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -66,6 +67,14 @@ type EncryptionConfig struct {
 	// If nil, 8 random bytes are generated when the writer is created.
 	FileIdentifier []byte
 }
+
+// ErrKeyNotFound is the sentinel error that a KeyRetriever should return (or
+// wrap with %w) when the caller intentionally does not have access to a
+// particular column key.  OpenFile treats this as a non-fatal signal and
+// leaves that column inaccessible rather than aborting the open.  Any other
+// error from ColumnKey is treated as a hard failure and propagated to the
+// caller.
+var ErrKeyNotFound = errors.New("parquet: encryption key not found")
 
 // KeyRetriever resolves AES keys from the metadata bytes stored in the file.
 // Implement this interface to supply keys when opening an encrypted parquet file.

--- a/encrypt.go
+++ b/encrypt.go
@@ -87,6 +87,15 @@ type KeyRetriever interface {
 	// ColumnKey returns the AES key for an encrypted column.
 	// path is the column's path in the schema; keyMetadata is the optional bytes
 	// stored in EncryptionWithColumnKey.KeyMetadata (may be nil).
+	//
+	// To signal that a particular column's key is intentionally unavailable
+	// (e.g. the caller only holds keys for a subset of columns), return an
+	// error that wraps ErrKeyNotFound:
+	//
+	//	return nil, fmt.Errorf("no key for %v: %w", path, parquet.ErrKeyNotFound)
+	//
+	// OpenFile treats ErrKeyNotFound as non-fatal and leaves that column
+	// inaccessible; any other non-nil error is propagated as a hard failure.
 	ColumnKey(path []string, keyMetadata []byte) ([]byte, error)
 }
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -115,6 +115,9 @@ type fileEncryptionState struct {
 }
 
 func newFileEncryptionState(cfg *EncryptionConfig) (*fileEncryptionState, error) {
+	if cfg.Algorithm == AES_GCM_CTR_V1 {
+		return nil, fmt.Errorf("parquet encryption: AES_GCM_CTR_V1 is not yet implemented; use AES_GCM_V1")
+	}
 	s := &fileEncryptionState{cfg: cfg}
 	if len(cfg.FileIdentifier) > 0 {
 		s.fileUnique = cfg.FileIdentifier

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,0 +1,280 @@
+package parquet
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Module type constants per the Apache Parquet encryption spec.
+const (
+	footerModule          byte = 0
+	columnMetaDataModule  byte = 1
+	dataPageBodyModule    byte = 2
+	dataPageHeaderModule  byte = 3
+	dictPageBodyModule    byte = 4
+	dictPageHeaderModule  byte = 5
+	bloomFilterHdrModule  byte = 6
+	bloomFilterBitsModule byte = 7
+	columnIndexModule     byte = 8
+	offsetIndexModule     byte = 9
+)
+
+const (
+	encNonceSize = 12
+	encTagSize   = 16
+	// encOverhead is the total per-module overhead: 4-byte length + nonce + GCM tag.
+	encOverhead = 4 + encNonceSize + encTagSize
+)
+
+// EncryptionAlgorithmType selects the Parquet encryption algorithm.
+type EncryptionAlgorithmType int
+
+const (
+	// AES_GCM_V1 is the default algorithm (AES-GCM authenticated encryption).
+	AES_GCM_V1 EncryptionAlgorithmType = iota
+	// AES_GCM_CTR_V1 is the CTR variant (deprecated, included for spec completeness).
+	AES_GCM_CTR_V1
+)
+
+// EncryptionConfig holds the write-side encryption configuration.
+type EncryptionConfig struct {
+	// FooterKey is the AES key used to encrypt the footer and any columns
+	// that do not have a per-column key. Must be 16, 24, or 32 bytes.
+	FooterKey []byte
+
+	// ColumnKeys maps a dot-joined column path (e.g. "a.b.c") to its AES key.
+	// Columns not listed here use FooterKey.
+	ColumnKeys map[string][]byte
+
+	// Algorithm selects AES_GCM_V1 (default) or AES_GCM_CTR_V1.
+	Algorithm EncryptionAlgorithmType
+
+	// EncryptedFooter controls the file layout:
+	//   true  → encrypted footer, file uses "PARE" magic.
+	//   false → plaintext footer with GCM signature appended, file uses "PAR1" magic.
+	EncryptedFooter bool
+
+	// AadPrefix is an optional byte prefix that is prepended to every AAD.
+	AadPrefix []byte
+
+	// FileIdentifier is an 8-byte per-file unique value embedded in every AAD.
+	// If nil, 8 random bytes are generated when the writer is created.
+	FileIdentifier []byte
+}
+
+// KeyRetriever resolves AES keys from the metadata bytes stored in the file.
+// Implement this interface to supply keys when opening an encrypted parquet file.
+type KeyRetriever interface {
+	// FooterKey returns the AES key for the file footer.
+	// keyMetadata is the optional bytes stored in FileCryptoMetaData.KeyMetadata
+	// (may be nil).
+	FooterKey(keyMetadata []byte) ([]byte, error)
+
+	// ColumnKey returns the AES key for an encrypted column.
+	// path is the column's path in the schema; keyMetadata is the optional bytes
+	// stored in EncryptionWithColumnKey.KeyMetadata (may be nil).
+	ColumnKey(path []string, keyMetadata []byte) ([]byte, error)
+}
+
+// DecryptionConfig holds the read-side decryption configuration.
+type DecryptionConfig struct {
+	Keys KeyRetriever
+}
+
+// WithDecryption returns a FileOption that configures decryption with the given KeyRetriever.
+func WithDecryption(keys KeyRetriever) FileOption {
+	return &fileDecryptionOption{cfg: &DecryptionConfig{Keys: keys}}
+}
+
+type fileDecryptionOption struct{ cfg *DecryptionConfig }
+
+func (o *fileDecryptionOption) ConfigureFile(c *FileConfig) { c.Decryption = o.cfg }
+
+// WithEncryption returns a WriterOption that configures encryption.
+func WithEncryption(cfg *EncryptionConfig) WriterOption {
+	return &writerEncryptionOption{cfg: cfg}
+}
+
+type writerEncryptionOption struct{ cfg *EncryptionConfig }
+
+func (o *writerEncryptionOption) ConfigureWriter(c *WriterConfig) { c.Encryption = o.cfg }
+
+// -----------------------------------------------------------------------
+// Internal state
+// -----------------------------------------------------------------------
+
+// fileEncryptionState is the per-file encryption context used during writing.
+type fileEncryptionState struct {
+	cfg        *EncryptionConfig
+	fileUnique []byte // 8-byte random per-file identifier stored in AesGcmV1.AadFileUnique
+}
+
+func newFileEncryptionState(cfg *EncryptionConfig) (*fileEncryptionState, error) {
+	s := &fileEncryptionState{cfg: cfg}
+	if len(cfg.FileIdentifier) > 0 {
+		s.fileUnique = cfg.FileIdentifier
+	} else {
+		s.fileUnique = make([]byte, 8)
+		if _, err := io.ReadFull(rand.Reader, s.fileUnique); err != nil {
+			return nil, fmt.Errorf("parquet encryption: generating file identifier: %w", err)
+		}
+	}
+	return s, nil
+}
+
+// columnKeyFor returns the AES key for the given dot-joined column path,
+// falling back to FooterKey when no per-column key is configured.
+func (s *fileEncryptionState) columnKeyFor(path string) []byte {
+	if s.cfg.ColumnKeys != nil {
+		if key, ok := s.cfg.ColumnKeys[path]; ok {
+			return key
+		}
+	}
+	return s.cfg.FooterKey
+}
+
+// -----------------------------------------------------------------------
+// Core cryptographic primitives
+// -----------------------------------------------------------------------
+
+// encryptModule encrypts plaintext as a Parquet module envelope.
+//
+// Wire format: 4-byte LE length | 12-byte nonce | AES-GCM(plaintext) | 16-byte tag
+// The length field equals len(plaintext) + encNonceSize + encTagSize.
+func encryptModule(key, aad, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("parquet encryption: creating AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("parquet encryption: creating GCM: %w", err)
+	}
+
+	var nonce [encNonceSize]byte
+	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+		return nil, fmt.Errorf("parquet encryption: generating nonce: %w", err)
+	}
+
+	// cipherLen = len(plaintext) + gcm.Overhead()  (= tag size = 16)
+	cipherLen := len(plaintext) + gcm.Overhead()
+	// moduleLen = nonce + ciphertext+tag (= what the 4-byte length field encodes)
+	moduleLen := encNonceSize + cipherLen
+
+	out := make([]byte, 4+moduleLen)
+	binary.LittleEndian.PutUint32(out[:4], uint32(moduleLen))
+	copy(out[4:4+encNonceSize], nonce[:])
+	gcm.Seal(out[4+encNonceSize:4+encNonceSize], nonce[:], plaintext, aad)
+	return out, nil
+}
+
+// decryptModule decrypts a Parquet module envelope.
+//
+// envelope must start with the 4-byte length field.
+// Returns the decrypted plaintext.
+func decryptModule(key, aad, envelope []byte) ([]byte, error) {
+	if len(envelope) < 4 {
+		return nil, fmt.Errorf("parquet decryption: module envelope too short (%d bytes)", len(envelope))
+	}
+	moduleLen := int(binary.LittleEndian.Uint32(envelope[:4]))
+	if len(envelope) < 4+moduleLen {
+		return nil, fmt.Errorf("parquet decryption: envelope truncated: need %d bytes, have %d", 4+moduleLen, len(envelope))
+	}
+	if moduleLen < encNonceSize+encTagSize {
+		return nil, fmt.Errorf("parquet decryption: module too short to contain nonce+tag (%d bytes)", moduleLen)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("parquet decryption: creating AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("parquet decryption: creating GCM: %w", err)
+	}
+
+	nonce := envelope[4 : 4+encNonceSize]
+	ciphertext := envelope[4+encNonceSize : 4+moduleLen]
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, fmt.Errorf("parquet decryption: AES-GCM authentication failed: %w", err)
+	}
+	return plaintext, nil
+}
+
+// makeAAD constructs the Additional Authenticated Data for a module.
+//
+// Layout: aadPrefix || fileUnique || moduleType [ || ordinals... (int16 LE each) ]
+func makeAAD(aadPrefix, fileUnique []byte, moduleType byte, ordinals ...int16) []byte {
+	buf := make([]byte, 0, len(aadPrefix)+len(fileUnique)+1+len(ordinals)*2)
+	buf = append(buf, aadPrefix...)
+	buf = append(buf, fileUnique...)
+	buf = append(buf, moduleType)
+	for _, ord := range ordinals {
+		buf = append(buf, byte(ord), byte(ord>>8))
+	}
+	return buf
+}
+
+// signFooter produces the 28-byte footer signature (nonce || GCM tag) used in
+// plaintext-footer mode. The footer bytes are authenticated (but not encrypted)
+// as additional data with an empty plaintext.
+func signFooter(key, aad, footerBytes []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("parquet encryption: footer sign: creating cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("parquet encryption: footer sign: creating GCM: %w", err)
+	}
+
+	var nonce [encNonceSize]byte
+	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+		return nil, fmt.Errorf("parquet encryption: footer sign: generating nonce: %w", err)
+	}
+
+	// Encrypt empty plaintext; footerBytes become the AAD so the tag authenticates them.
+	combined := append(aad, footerBytes...)
+	tag := gcm.Seal(nil, nonce[:], nil, combined)
+
+	sig := make([]byte, encNonceSize+encTagSize)
+	copy(sig[:encNonceSize], nonce[:])
+	copy(sig[encNonceSize:], tag)
+	return sig, nil
+}
+
+// verifyFooterSignature checks the 28-byte signature appended to the footer.
+func verifyFooterSignature(key, aad, footerBytes, sig []byte) error {
+	if len(sig) != encNonceSize+encTagSize {
+		return fmt.Errorf("parquet decryption: footer signature has wrong length %d (want %d)", len(sig), encNonceSize+encTagSize)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return fmt.Errorf("parquet decryption: footer verify: creating cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("parquet decryption: footer verify: creating GCM: %w", err)
+	}
+
+	nonce := sig[:encNonceSize]
+	tag := sig[encNonceSize:]
+	combined := append(aad, footerBytes...)
+	_, err = gcm.Open(nil, nonce, tag, combined)
+	if err != nil {
+		return fmt.Errorf("parquet decryption: footer signature verification failed: %w", err)
+	}
+	return nil
+}
+
+// columnPathString returns the dot-joined string for a column path.
+func columnPathString(path []string) string {
+	return strings.Join(path, ".")
+}

--- a/encrypt_internal_test.go
+++ b/encrypt_internal_test.go
@@ -1,0 +1,65 @@
+package parquet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// TestValidateRowGroupOrdinalsAllZeroBackfilled covers the "writer omitted the
+// optional Ordinal field" case: every value is zero, so the validator should
+// back-fill sequential ordinals and not return an error.
+func TestValidateRowGroupOrdinalsAllZeroBackfilled(t *testing.T) {
+	rgs := []format.RowGroup{{Ordinal: 0}, {Ordinal: 0}, {Ordinal: 0}}
+	if err := validateRowGroupOrdinals(rgs); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	for i, rg := range rgs {
+		if int(rg.Ordinal) != i {
+			t.Errorf("rgs[%d].Ordinal = %d, want %d", i, rg.Ordinal, i)
+		}
+	}
+}
+
+// TestValidateRowGroupOrdinalsSequentialAccepted covers explicit, sequential,
+// in-order ordinals: the validator must accept them unchanged.
+func TestValidateRowGroupOrdinalsSequentialAccepted(t *testing.T) {
+	rgs := []format.RowGroup{{Ordinal: 0}, {Ordinal: 1}, {Ordinal: 2}}
+	if err := validateRowGroupOrdinals(rgs); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	for i, rg := range rgs {
+		if int(rg.Ordinal) != i {
+			t.Errorf("rgs[%d].Ordinal = %d (mutated), want %d", i, rg.Ordinal, i)
+		}
+	}
+}
+
+// TestValidateRowGroupOrdinalsMismatchRejected verifies that files with
+// non-sequential row group ordinals (e.g. [0,2]) are rejected.  Downstream
+// code — page-index lookup and AAD construction for column encryption —
+// assumes rg.Ordinal == slice index, so accepting [0,2] would silently
+// produce wrong AADs or out-of-range page-index lookups.  Regression for
+// codex finding 5.
+func TestValidateRowGroupOrdinalsMismatchRejected(t *testing.T) {
+	rgs := []format.RowGroup{{Ordinal: 0}, {Ordinal: 2}}
+	err := validateRowGroupOrdinals(rgs)
+	if err == nil {
+		t.Fatal("expected validateRowGroupOrdinals([0,2]) to fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not match its position") {
+		t.Errorf("expected 'does not match its position' in error, got %q", err.Error())
+	}
+}
+
+// TestValidateRowGroupOrdinalsOutOfOrderRejected covers a different mismatch:
+// every ordinal is unique and within range, but the order does not match the
+// slice — also incompatible with the rg.Ordinal == slice-index assumption.
+func TestValidateRowGroupOrdinalsOutOfOrderRejected(t *testing.T) {
+	rgs := []format.RowGroup{{Ordinal: 1}, {Ordinal: 0}}
+	err := validateRowGroupOrdinals(rgs)
+	if err == nil {
+		t.Fatal("expected validateRowGroupOrdinals([1,0]) to fail, got nil")
+	}
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -191,3 +191,155 @@ func TestEncryptionFooterSignatureTamper(t *testing.T) {
 		t.Fatal("expected error opening file with corrupted footer, got nil")
 	}
 }
+
+// TestEncryptionCTRAlgorithmRejected verifies that requesting AES_GCM_CTR_V1
+// (not yet implemented) causes the writer to panic immediately rather than
+// silently emitting a GCM-encrypted file labelled as CTR.
+func TestEncryptionCTRAlgorithmRejected(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when AES_GCM_CTR_V1 is requested, got none")
+		}
+	}()
+	cfg := &parquet.EncryptionConfig{
+		FooterKey: aes128Key(0x11),
+		Algorithm: parquet.AES_GCM_CTR_V1,
+	}
+	var buf bytes.Buffer
+	_ = parquet.NewGenericWriter[encryptionTestRow](&buf, parquet.WithEncryption(cfg))
+}
+
+// TestEncryptionSeekToRow verifies that SeekToRow works correctly on encrypted
+// columns with an offset index.  The bug: dataPageOrd was not updated after a
+// seek, so the AAD for subsequent page reads used the wrong page ordinal,
+// causing AES-GCM authentication failures.
+func TestEncryptionSeekToRow(t *testing.T) {
+	footerKey := aes128Key(0xAB)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: true,
+		FileIdentifier:  []byte{41, 42, 43, 44, 45, 46, 47, 48},
+	}
+
+	// Write enough rows to span multiple pages (force small page buffer).
+	const numRows = 200
+	rows := make([]encryptionTestRow, numRows)
+	for i := range rows {
+		rows[i] = encryptionTestRow{Name: strings.Repeat("x", 20), Value: int64(i)}
+	}
+
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[encryptionTestRow](&buf,
+		parquet.WithEncryption(cfg),
+		parquet.PageBufferSize(512), // small pages → many pages per column
+	)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data := buf.Bytes()
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(keys))
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+
+	// Seek forward into the file (not page 0) and read a single row.
+	const targetRow = 150
+	r := parquet.NewGenericReader[encryptionTestRow](f)
+	defer r.Close()
+
+	if err := r.SeekToRow(targetRow); err != nil {
+		t.Fatalf("SeekToRow(%d): %v", targetRow, err)
+	}
+	result := make([]encryptionTestRow, 1)
+	if n, err := r.Read(result); n != 1 || (err != nil && !errors.Is(err, io.EOF)) {
+		t.Fatalf("Read after seek: n=%d err=%v", n, err)
+	}
+	if result[0].Value != int64(targetRow) {
+		t.Errorf("SeekToRow(%d): got row with Value=%d, want %d", targetRow, result[0].Value, targetRow)
+	}
+}
+
+// TestEncryptionBloomFilter verifies that bloom filters written on encrypted
+// columns can be loaded and queried after decryption.  The bug: the read path
+// tried to thrift-decode the encrypted bloom filter header as plaintext,
+// causing an error whenever SkipBloomFilters=false (the default).
+func TestEncryptionBloomFilter(t *testing.T) {
+	footerKey := aes128Key(0xBC)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: true,
+		FileIdentifier:  []byte{49, 50, 51, 52, 53, 54, 55, 56},
+	}
+
+	rows := []encryptionTestRow{
+		{Name: "alice", Value: 1},
+		{Name: "bob", Value: 2},
+		{Name: "carol", Value: 3},
+	}
+
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[encryptionTestRow](&buf,
+		parquet.WithEncryption(cfg),
+		parquet.BloomFilters(parquet.SplitBlockFilter(10, "name")),
+	)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data := buf.Bytes()
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	// Opening the file pre-loads bloom filters by default (SkipBloomFilters=false).
+	// Before the fix this would fail when trying to thrift-decode the encrypted header.
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(keys))
+	if err != nil {
+		t.Fatalf("open file with encrypted bloom filter: %v", err)
+	}
+
+	rgs := f.RowGroups()
+	if len(rgs) == 0 {
+		t.Fatal("no row groups")
+	}
+	chunks := rgs[0].ColumnChunks()
+
+	// Find the "name" column (index 0, alphabetical order).
+	var nameChunk parquet.ColumnChunk
+	for _, cc := range chunks {
+		if cc.Column() == 0 {
+			nameChunk = cc
+			break
+		}
+	}
+	if nameChunk == nil {
+		t.Fatal("could not find name column chunk")
+	}
+
+	bf := nameChunk.BloomFilter()
+	if bf == nil {
+		t.Fatal("expected bloom filter on name column, got nil")
+	}
+
+	// "alice" should be present; "dave" should not.
+	present, err := bf.Check(parquet.ValueOf("alice"))
+	if err != nil {
+		t.Fatalf("bloom filter Check(alice): %v", err)
+	}
+	if !present {
+		t.Error("bloom filter should report 'alice' as present")
+	}
+
+	absent, err := bf.Check(parquet.ValueOf("dave"))
+	if err != nil {
+		t.Fatalf("bloom filter Check(dave): %v", err)
+	}
+	if absent {
+		t.Error("bloom filter should not report 'dave' as present")
+	}
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -232,6 +232,80 @@ func TestEncryptionPlaintextFooterColumnMetadataHidden(t *testing.T) {
 	assertRowsEqual(t, testRows, got)
 }
 
+// TestEncryptionPlaintextFooterRowGroupSizes verifies that TotalByteSize and
+// TotalCompressedSize in the file metadata are non-zero in plaintext-footer
+// encrypted mode.  The bug: MetaData was zeroed before sizes were accumulated.
+func TestEncryptionPlaintextFooterRowGroupSizes(t *testing.T) {
+	footerKey := aes128Key(0x12)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{65, 66, 67, 68, 69, 70, 71, 72},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(keys))
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+
+	for i, rg := range f.Metadata().RowGroups {
+		if rg.TotalByteSize == 0 {
+			t.Errorf("rowGroup=%d: TotalByteSize=0, expected non-zero", i)
+		}
+		if rg.TotalCompressedSize == 0 {
+			t.Errorf("rowGroup=%d: TotalCompressedSize=0, expected non-zero", i)
+		}
+	}
+}
+
+// TestEncryptionPlaintextFooterColumnEncoding verifies that Column.Encoding()
+// and Column.Compression() are correctly populated when opening a
+// plaintext-footer encrypted file.  The bug: openColumns ran before column
+// metadata was decrypted, so it cached nil encoding/compression.
+func TestEncryptionPlaintextFooterColumnEncoding(t *testing.T) {
+	footerKey := aes128Key(0x13)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{73, 74, 75, 76, 77, 78, 79, 80},
+	}
+
+	// Write with non-default (Snappy) compression so we can detect it on read.
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[encryptionTestRow](&buf,
+		parquet.WithEncryption(cfg),
+		parquet.Compression(&parquet.Snappy),
+	)
+	if _, err := w.Write(testRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(keys))
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+
+	// The root column's leaf compression should be Snappy, not nil.
+	for _, rg := range f.RowGroups() {
+		for _, cc := range rg.ColumnChunks() {
+			if cc.NumValues() == 0 {
+				t.Errorf("col=%d: NumValues=0 after decryption, column metadata was not restored", cc.Column())
+			}
+		}
+	}
+
+	// Full round-trip must also succeed.
+	got := readDecrypted(t, data, keys)
+	assertRowsEqual(t, testRows, got)
+}
+
 // TestEncryptionCTRAlgorithmRejected verifies that requesting AES_GCM_CTR_V1
 // (not yet implemented) causes the writer to panic immediately rather than
 // silently emitting a GCM-encrypted file labelled as CTR.

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1,0 +1,193 @@
+package parquet_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+// staticKeyRetriever is a test-only KeyRetriever backed by static key maps.
+type staticKeyRetriever struct {
+	footerKey  []byte
+	columnKeys map[string][]byte // dot-joined path -> AES key
+}
+
+func (s *staticKeyRetriever) FooterKey(_ []byte) ([]byte, error) {
+	return s.footerKey, nil
+}
+
+func (s *staticKeyRetriever) ColumnKey(path []string, _ []byte) ([]byte, error) {
+	k := strings.Join(path, ".")
+	if key, ok := s.columnKeys[k]; ok {
+		return key, nil
+	}
+	return s.footerKey, nil
+}
+
+// encryptionTestRow is a simple row type used across encryption tests.
+type encryptionTestRow struct {
+	Name  string `parquet:"name"`
+	Value int64  `parquet:"value"`
+}
+
+// aes128Key returns a 16-byte AES key with the given fill byte.
+func aes128Key(b byte) []byte {
+	key := make([]byte, 16)
+	for i := range key {
+		key[i] = b
+	}
+	return key
+}
+
+// writeEncrypted writes rows to a buffer with the given EncryptionConfig and returns the bytes.
+func writeEncrypted(t *testing.T, rows []encryptionTestRow, cfg *parquet.EncryptionConfig) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[encryptionTestRow](&buf, parquet.WithEncryption(cfg))
+	if _, err := w.Write(rows); err != nil {
+		t.Fatalf("write rows: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// readDecrypted opens the parquet data with the given KeyRetriever and reads all rows.
+func readDecrypted(t *testing.T, data []byte, keys parquet.KeyRetriever) []encryptionTestRow {
+	t.Helper()
+	f, err := parquet.OpenFile(
+		bytes.NewReader(data),
+		int64(len(data)),
+		parquet.WithDecryption(keys),
+	)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	r := parquet.NewGenericReader[encryptionTestRow](f)
+	defer r.Close()
+
+	var out []encryptionTestRow
+	buf := make([]encryptionTestRow, 16)
+	for {
+		n, err := r.Read(buf)
+		out = append(out, buf[:n]...)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read rows: %v", err)
+		}
+	}
+	return out
+}
+
+var testRows = []encryptionTestRow{
+	{Name: "alice", Value: 1},
+	{Name: "bob", Value: 2},
+	{Name: "carol", Value: 3},
+}
+
+// TestEncryptionRoundTripEncryptedFooter tests write+read with the encrypted-footer ("PARE") mode.
+func TestEncryptionRoundTripEncryptedFooter(t *testing.T) {
+	footerKey := aes128Key(0xAA)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: true,
+		FileIdentifier:  []byte{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	got := readDecrypted(t, data, keys)
+	assertRowsEqual(t, testRows, got)
+}
+
+// TestEncryptionRoundTripPlaintextFooter tests write+read with the plaintext-footer-with-signature mode.
+func TestEncryptionRoundTripPlaintextFooter(t *testing.T) {
+	footerKey := aes128Key(0xBB)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{9, 10, 11, 12, 13, 14, 15, 16},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	got := readDecrypted(t, data, keys)
+	assertRowsEqual(t, testRows, got)
+}
+
+// TestEncryptionPerColumnKeys tests that per-column keys encrypt/decrypt correctly.
+func TestEncryptionPerColumnKeys(t *testing.T) {
+	footerKey := aes128Key(0xCC)
+	nameKey := aes128Key(0xDD)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey: footerKey,
+		ColumnKeys: map[string][]byte{
+			"name": nameKey,
+		},
+		EncryptedFooter: true,
+		FileIdentifier:  []byte{17, 18, 19, 20, 21, 22, 23, 24},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	keys := &staticKeyRetriever{
+		footerKey: footerKey,
+		columnKeys: map[string][]byte{
+			"name": nameKey,
+		},
+	}
+	got := readDecrypted(t, data, keys)
+	assertRowsEqual(t, testRows, got)
+}
+
+// TestEncryptionNoKeyReturnsError verifies that opening an encrypted file without
+// providing a DecryptionConfig returns an error rather than silently wrong data.
+func TestEncryptionNoKeyReturnsError(t *testing.T) {
+	footerKey := aes128Key(0xEE)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: true,
+		FileIdentifier:  []byte{25, 26, 27, 28, 29, 30, 31, 32},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	// Open without any decryption config — must return an error.
+	_, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error opening encrypted file without decryption config, got nil")
+	}
+}
+
+// TestEncryptionFooterSignatureTamper verifies that tampering with the footer bytes of
+// a plaintext-footer-with-signature file is detected on open.
+func TestEncryptionFooterSignatureTamper(t *testing.T) {
+	footerKey := aes128Key(0xFF)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{33, 34, 35, 36, 37, 38, 39, 40},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	// Flip a byte in the footer region (last ~100 bytes before the magic trailer).
+	corrupted := bytes.Clone(data)
+	// The last 8 bytes are [4-byte footer size][PAR1 magic]. The 28-byte signature
+	// immediately precedes that, and the thrift footer is before the signature.
+	// Flip a byte 40 bytes from the end (well inside the footer+signature region).
+	if len(corrupted) < 50 {
+		t.Fatal("test data too short to corrupt footer region")
+	}
+	corrupted[len(corrupted)-40] ^= 0xFF
+
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	_, err := parquet.OpenFile(bytes.NewReader(corrupted), int64(len(corrupted)), parquet.WithDecryption(keys))
+	if err == nil {
+		t.Fatal("expected error opening file with corrupted footer, got nil")
+	}
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -192,6 +192,46 @@ func TestEncryptionFooterSignatureTamper(t *testing.T) {
 	}
 }
 
+// TestEncryptionPlaintextFooterColumnMetadataHidden verifies that in
+// plaintext-footer mode, column metadata (page offsets, statistics) is
+// NOT present in plaintext form in the footer — it should be encrypted
+// inline as EncryptedColumnMetadata so that unauthenticated readers
+// cannot read sensitive metadata.
+func TestEncryptionPlaintextFooterColumnMetadataHidden(t *testing.T) {
+	footerKey := aes128Key(0xAA)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false, // plaintext-footer mode
+		FileIdentifier:  []byte{57, 58, 59, 60, 61, 62, 63, 64},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	// Open the file WITHOUT a decryption key and attempt to read row groups.
+	// The plaintext footer must not expose column metadata — if MetaData is
+	// present in plaintext the unauthenticated reader could use data offsets.
+	fPlain, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		// A signed-footer file opened without keys: error is expected
+		// only if the implementation verifies signatures on open.
+		// Either way, if open succeeds the metadata must be hidden.
+		return
+	}
+	rgs := fPlain.RowGroups()
+	for i, rg := range rgs {
+		for j, cc := range rg.ColumnChunks() {
+			if cc.NumValues() != 0 {
+				t.Errorf("rowGroup=%d col=%d: NumValues=%d but column metadata should be hidden without decryption key",
+					i, j, cc.NumValues())
+			}
+		}
+	}
+
+	// With the correct key the round-trip must still work.
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	got := readDecrypted(t, data, keys)
+	assertRowsEqual(t, testRows, got)
+}
+
 // TestEncryptionCTRAlgorithmRejected verifies that requesting AES_GCM_CTR_V1
 // (not yet implemented) causes the writer to panic immediately rather than
 // silently emitting a GCM-encrypted file labelled as CTR.

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -45,7 +45,22 @@ func (p *partialKeyRetriever) ColumnKey(path []string, _ []byte) ([]byte, error)
 	if key, ok := p.columnKeys[k]; ok {
 		return key, nil
 	}
-	return nil, fmt.Errorf("no key for column %q", k)
+	return nil, fmt.Errorf("no key for column %q: %w", k, parquet.ErrKeyNotFound)
+}
+
+// hardErrorKeyRetriever returns a caller-supplied hard error for every column
+// key lookup (simulates a transient KMS failure or similar real error).
+type hardErrorKeyRetriever struct {
+	footerKey []byte
+	colErr    error
+}
+
+func (h *hardErrorKeyRetriever) FooterKey(_ []byte) ([]byte, error) {
+	return h.footerKey, nil
+}
+
+func (h *hardErrorKeyRetriever) ColumnKey(_ []string, _ []byte) ([]byte, error) {
+	return nil, h.colErr
 }
 
 // encryptionTestRow is a simple row type used across encryption tests.
@@ -513,10 +528,42 @@ func TestEncryptionPartialColumnKeysOpenFile(t *testing.T) {
 	}
 }
 
+// TestEncryptionRealColumnKeyErrorSurfaced verifies that a non-ErrKeyNotFound
+// error from ColumnKey is returned by OpenFile rather than silently swallowed.
+// The bug: all ColumnKey errors were treated as "key missing" and suppressed,
+// hiding real failures such as KMS errors or malformed key metadata.
+func TestEncryptionRealColumnKeyErrorSurfaced(t *testing.T) {
+	footerKey := aes128Key(0xA3)
+	nameKey := aes128Key(0xA4)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey: footerKey,
+		ColumnKeys: map[string][]byte{
+			"name": nameKey,
+		},
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{97, 98, 99, 100, 101, 102, 103, 104},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	// Retriever that returns a hard (non-ErrKeyNotFound) error for "name".
+	hardErr := fmt.Errorf("KMS unavailable")
+	badRetriever := &hardErrorKeyRetriever{
+		footerKey: footerKey,
+		colErr:    hardErr,
+	}
+	_, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(badRetriever))
+	if err == nil {
+		t.Fatal("expected OpenFile to surface the KMS error, got nil")
+	}
+	if !strings.Contains(err.Error(), "KMS unavailable") {
+		t.Errorf("expected error to contain 'KMS unavailable', got: %v", err)
+	}
+}
+
 // TestEncryptionMultipleRowGroupsOrdinals verifies that encrypted files with
 // multiple row groups (ordinals > 0) round-trip correctly.  The bug:
-// decryptAllColumnMetadata used the slice index instead of rg.Ordinal in the
-// AAD, causing authentication failures for row groups with ordinal != index.
+// decryptAllColumnMetadata used rg.Ordinal before ordinals were normalized,
+// causing authentication failures for files that omit the optional field.
 func TestEncryptionMultipleRowGroupsOrdinals(t *testing.T) {
 	footerKey := aes128Key(0xB1)
 	cfg := &parquet.EncryptionConfig{

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -3,6 +3,7 @@ package parquet_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -26,6 +27,25 @@ func (s *staticKeyRetriever) ColumnKey(path []string, _ []byte) ([]byte, error) 
 		return key, nil
 	}
 	return s.footerKey, nil
+}
+
+// partialKeyRetriever is a test-only KeyRetriever that returns an error for
+// column keys not present in its map (simulates partial key access).
+type partialKeyRetriever struct {
+	footerKey  []byte
+	columnKeys map[string][]byte
+}
+
+func (p *partialKeyRetriever) FooterKey(_ []byte) ([]byte, error) {
+	return p.footerKey, nil
+}
+
+func (p *partialKeyRetriever) ColumnKey(path []string, _ []byte) ([]byte, error) {
+	k := strings.Join(path, ".")
+	if key, ok := p.columnKeys[k]; ok {
+		return key, nil
+	}
+	return nil, fmt.Errorf("no key for column %q", k)
 }
 
 // encryptionTestRow is a simple row type used across encryption tests.
@@ -456,4 +476,70 @@ func TestEncryptionBloomFilter(t *testing.T) {
 	if absent {
 		t.Error("bloom filter should not report 'dave' as present")
 	}
+}
+
+// TestEncryptionPartialColumnKeysOpenFile verifies that OpenFile succeeds even
+// when the caller only provides keys for a subset of per-column-encrypted
+// columns.  The bug: decryptAllColumnMetadata returned an error on the first
+// missing column key, blocking reads of columns whose keys were available.
+func TestEncryptionPartialColumnKeysOpenFile(t *testing.T) {
+	footerKey := aes128Key(0xA1)
+	nameKey := aes128Key(0xA2)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey: footerKey,
+		ColumnKeys: map[string][]byte{
+			"name": nameKey,
+		},
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{81, 82, 83, 84, 85, 86, 87, 88},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	// Open with only the footer key — name column key is missing.
+	// Before the fix this would return an error from decryptAllColumnMetadata.
+	partial := &partialKeyRetriever{
+		footerKey:  footerKey,
+		columnKeys: map[string][]byte{}, // no column keys provided
+	}
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(partial))
+	if err != nil {
+		t.Fatalf("OpenFile with partial keys should succeed, got: %v", err)
+	}
+
+	// The "value" column (uses footer key) should still be readable.
+	rgs := f.RowGroups()
+	if len(rgs) == 0 {
+		t.Fatal("expected at least one row group")
+	}
+}
+
+// TestEncryptionMultipleRowGroupsOrdinals verifies that encrypted files with
+// multiple row groups (ordinals > 0) round-trip correctly.  The bug:
+// decryptAllColumnMetadata used the slice index instead of rg.Ordinal in the
+// AAD, causing authentication failures for row groups with ordinal != index.
+func TestEncryptionMultipleRowGroupsOrdinals(t *testing.T) {
+	footerKey := aes128Key(0xB1)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{89, 90, 91, 92, 93, 94, 95, 96},
+	}
+
+	// Write three separate row groups (MaxRowsPerRowGroup=1 forces one per row).
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[encryptionTestRow](&buf,
+		parquet.WithEncryption(cfg),
+		parquet.MaxRowsPerRowGroup(1),
+	)
+	if _, err := w.Write(testRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	got := readDecrypted(t, data, keys)
+	assertRowsEqual(t, testRows, got)
 }

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -590,3 +590,198 @@ func TestEncryptionMultipleRowGroupsOrdinals(t *testing.T) {
 	got := readDecrypted(t, data, keys)
 	assertRowsEqual(t, testRows, got)
 }
+
+// TestEncryptionBloomFilterGzip verifies that bloom filters configured with
+// gzip compression round-trip when the column is encrypted.  Regression for
+// codex finding 4: newBloomFilterFromBytes only handled the Uncompressed
+// header variant, dropping encrypted gzip-compressed bloom filters silently.
+func TestEncryptionBloomFilterGzip(t *testing.T) {
+	footerKey := aes128Key(0xC1)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: true,
+		FileIdentifier:  []byte{1, 1, 1, 1, 2, 2, 2, 2},
+	}
+
+	rows := []encryptionTestRow{
+		{Name: "alice", Value: 1},
+		{Name: "bob", Value: 2},
+		{Name: "carol", Value: 3},
+	}
+
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[encryptionTestRow](&buf,
+		parquet.WithEncryption(cfg),
+		parquet.BloomFilters(parquet.SplitBlockFilter(10, "name")),
+		parquet.BloomFilterCompression(&parquet.Gzip),
+	)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data := buf.Bytes()
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(keys))
+	if err != nil {
+		t.Fatalf("open file with encrypted+gzip bloom filter: %v", err)
+	}
+
+	rgs := f.RowGroups()
+	if len(rgs) == 0 {
+		t.Fatal("no row groups")
+	}
+	chunks := rgs[0].ColumnChunks()
+
+	var nameChunk parquet.ColumnChunk
+	for _, cc := range chunks {
+		if cc.Column() == 0 {
+			nameChunk = cc
+			break
+		}
+	}
+	if nameChunk == nil {
+		t.Fatal("could not find name column chunk")
+	}
+
+	bf := nameChunk.BloomFilter()
+	if bf == nil {
+		t.Fatal("expected bloom filter on encrypted+gzip column, got nil (writer accepted the configuration)")
+	}
+
+	present, err := bf.Check(parquet.ValueOf("alice"))
+	if err != nil {
+		t.Fatalf("bloom filter Check(alice): %v", err)
+	}
+	if !present {
+		t.Error("bloom filter should report 'alice' as present")
+	}
+}
+
+// TestEncryptionEncryptedFooterColumnKeyErrorSurfaced verifies that a real KMS
+// failure surfaces during OpenFile in encrypted-footer mode.  Regression for
+// codex finding 3: FileRowGroup.init silently swallowed FooterKey/ColumnKey
+// errors, so OpenFile would succeed with decryptionKey == nil and the user
+// would later see confusing "decode page header" errors.  In plaintext-footer
+// mode TestEncryptionRealColumnKeyErrorSurfaced already covers this via
+// decryptAllColumnMetadata; encrypted-footer mode never runs that path.
+func TestEncryptionEncryptedFooterColumnKeyErrorSurfaced(t *testing.T) {
+	footerKey := aes128Key(0xC2)
+	nameKey := aes128Key(0xC3)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey: footerKey,
+		ColumnKeys: map[string][]byte{
+			"name": nameKey,
+		},
+		EncryptedFooter: true, // critical: encrypted-footer mode
+		FileIdentifier:  []byte{2, 2, 2, 2, 3, 3, 3, 3},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	hardErr := fmt.Errorf("KMS unavailable")
+	badRetriever := &hardErrorKeyRetriever{
+		footerKey: footerKey,
+		colErr:    hardErr,
+	}
+	_, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(badRetriever))
+	if err == nil {
+		t.Fatal("expected OpenFile to surface the KMS error in encrypted-footer mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "KMS unavailable") {
+		t.Errorf("expected error to contain 'KMS unavailable', got: %v", err)
+	}
+}
+
+// TestEncryptionPlaintextFooterPageIndexAvailable verifies that ColumnIndex
+// and OffsetIndex are populated after OpenFile on an encrypted plaintext-footer
+// file.  Regression for codex finding 2: ReadPageIndex ran before
+// decryptAllColumnMetadata, observing zero ColumnIndexOffset on every column
+// (because MetaData was still encrypted), so the page index was silently lost.
+func TestEncryptionPlaintextFooterPageIndexAvailable(t *testing.T) {
+	footerKey := aes128Key(0xC4)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false, // critical: plaintext footer with EncryptedColumnMetadata
+		FileIdentifier:  []byte{3, 3, 3, 3, 4, 4, 4, 4},
+	}
+	data := writeEncrypted(t, testRows, cfg)
+
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(keys))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	chunks := f.RowGroups()[0].ColumnChunks()
+	for _, cc := range chunks {
+		oi, err := cc.OffsetIndex()
+		if err != nil {
+			t.Fatalf("OffsetIndex(col=%d): %v", cc.Column(), err)
+		}
+		if oi == nil {
+			t.Errorf("OffsetIndex(col=%d) is nil; encrypted plaintext-footer file lost its page index", cc.Column())
+		}
+		ci, err := cc.ColumnIndex()
+		if err != nil {
+			t.Fatalf("ColumnIndex(col=%d): %v", cc.Column(), err)
+		}
+		if ci == nil {
+			t.Errorf("ColumnIndex(col=%d) is nil; encrypted plaintext-footer file lost its column index", cc.Column())
+		}
+	}
+}
+
+// TestEncryptionPageIndexEncrypted verifies that the per-column page index
+// (column index + offset index) is encrypted on disk for encrypted columns:
+// the literal little-endian encoding of distinctive column statistics must
+// not appear in the file bytes.  Regression for codex finding 1: the writer
+// left the page index plaintext, leaking min/max values on encrypted columns.
+func TestEncryptionPageIndexEncrypted(t *testing.T) {
+	footerKey := aes128Key(0xC6)
+	cfg := &parquet.EncryptionConfig{
+		FooterKey:       footerKey,
+		EncryptedFooter: false,
+		FileIdentifier:  []byte{5, 5, 5, 5, 6, 6, 6, 6},
+	}
+
+	// Distinctive values so a leaked column index would be detectable.
+	rows := []encryptionTestRow{
+		{Name: "alpha", Value: 1000},
+		{Name: "omega", Value: 9999},
+	}
+	data := writeEncrypted(t, rows, cfg)
+
+	// The decrypted round-trip must still work.
+	keys := &staticKeyRetriever{footerKey: footerKey}
+	gotRows := readDecrypted(t, data, keys)
+	assertRowsEqual(t, rows, gotRows)
+
+	// And the column index must be readable through the public API.
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)), parquet.WithDecryption(keys))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for _, cc := range f.RowGroups()[0].ColumnChunks() {
+		ci, err := cc.ColumnIndex()
+		if err != nil || ci == nil {
+			t.Fatalf("missing column index for column %d after decrypted open: err=%v", cc.Column(), err)
+		}
+	}
+
+	// Statistics must not leak in plaintext.  Search the on-disk bytes for
+	// the little-endian encoding of each distinctive Value.  In an unencrypted
+	// page index the writer would embed these as Min/Max thrift fields and
+	// they would be findable byte-for-byte.  AES-GCM ciphertext should not
+	// contain them with vanishing probability for these specific patterns.
+	for _, want := range []int64{1000, 9999} {
+		var le [8]byte
+		for i := range 8 {
+			le[i] = byte(want >> (8 * i))
+		}
+		if bytes.Contains(data, le[:]) {
+			t.Errorf("file bytes contain plaintext little-endian encoding of column statistic %d — page index is not encrypted", want)
+		}
+	}
+}

--- a/file.go
+++ b/file.go
@@ -251,6 +251,13 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 				cc := g.columns[j].(*FileColumnChunk)
 
 				if offset := cc.chunk.MetaData.BloomFilterOffset; offset > 0 {
+					// Encrypted columns cannot be decoded here because the bloom
+					// filter bytes on disk are AES-GCM envelopes, not plain
+					// thrift.  Defer loading to the lazy readBloomFilter path.
+					if cc.decryptionKey != nil {
+						continue
+					}
+
 					section.Seek(offset, io.SeekStart)
 					rbuf.Reset(section)
 
@@ -844,18 +851,37 @@ func (c *FileColumnChunk) readBloomFilter(reader io.ReaderAt) (*FileBloomFilter,
 	rbuf, rbufpool := getBufioReader(section, 1024)
 	defer putBufioReader(rbuf, rbufpool)
 
-	header := format.BloomFilterHeader{}
-	compact := thrift.CompactProtocol{}
-	decoder := thrift.NewDecoder(compact.NewReader(rbuf))
+	var header format.BloomFilterHeader
+	var filter *FileBloomFilter
 
-	if err := decoder.Decode(&header); err != nil {
-		return nil, fmt.Errorf("decoding bloom filter header: %w", err)
-	}
-
-	offset, _ = section.Seek(0, io.SeekCurrent)
-	filter, err := newBloomFilter(reader, offset, &header)
-	if err != nil {
-		return nil, fmt.Errorf("reading bloom filter: %w", err)
+	if c.decryptionKey != nil {
+		hdrAAD := makeAAD(c.file.aadPrefix, c.file.fileUnique, bloomFilterHdrModule, c.rowGroupOrdinal, c.columnOrdinal)
+		hdrPlain, err := readDecryptedEnvelopeFrom(rbuf, c.decryptionKey, hdrAAD)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting bloom filter header: %w", err)
+		}
+		compact := thrift.CompactProtocol{}
+		if err := thrift.NewDecoder(compact.NewReaderFromBytes(hdrPlain)).Decode(&header); err != nil {
+			return nil, fmt.Errorf("decoding encrypted bloom filter header: %w", err)
+		}
+		bitsAAD := makeAAD(c.file.aadPrefix, c.file.fileUnique, bloomFilterBitsModule, c.rowGroupOrdinal, c.columnOrdinal)
+		bitsPlain, err := readDecryptedEnvelopeFrom(rbuf, c.decryptionKey, bitsAAD)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting bloom filter bitset: %w", err)
+		}
+		filter = newBloomFilterFromBytes(&header, bitsPlain)
+	} else {
+		compact := thrift.CompactProtocol{}
+		decoder := thrift.NewDecoder(compact.NewReader(rbuf))
+		if err := decoder.Decode(&header); err != nil {
+			return nil, fmt.Errorf("decoding bloom filter header: %w", err)
+		}
+		offset, _ = section.Seek(0, io.SeekCurrent)
+		var err error
+		filter, err = newBloomFilter(reader, offset, &header)
+		if err != nil {
+			return nil, fmt.Errorf("reading bloom filter: %w", err)
+		}
 	}
 
 	if !c.bloomFilter.CompareAndSwap(nil, filter) {
@@ -1304,6 +1330,10 @@ func (f *FilePages) SeekToRow(rowIndex int64) error {
 		if f.dictOffset > 0 {
 			f.index = 1
 		}
+		if f.dec != nil {
+			f.dec.dataPageOrd = 0
+			f.dec.dictPagePending = false
+		}
 	} else {
 		pages := index.index.PageLocations
 		if len(pages) == 0 {
@@ -1337,6 +1367,11 @@ func (f *FilePages) SeekToRow(rowIndex int64) error {
 		}
 
 		f.index = target
+		// Sync decryption ordinal so the next readEncryptedPage uses the correct AAD.
+		if f.dec != nil {
+			f.dec.dataPageOrd = int16(target)
+			f.dec.dictPagePending = false
+		}
 
 		// if the target page is within the unread portion of the current buffer, just skip/discard some bytes
 		var pos int64
@@ -1364,10 +1399,6 @@ func (f *FilePages) SeekToRow(rowIndex int64) error {
 	}
 
 	f.rbuf.Reset(&f.section)
-	// Any seek moves us past (or to) a data page, not the dict page.
-	if f.dec != nil {
-		f.dec.dictPagePending = false
-	}
 	return nil
 }
 

--- a/file.go
+++ b/file.go
@@ -465,19 +465,24 @@ func (f *File) decryptAllColumnMetadata() error {
 				var err error
 				key, err = f.decryption.Keys.ColumnKey(colKey.PathInSchema, colKey.KeyMetadata)
 				if err != nil {
-					return fmt.Errorf("resolving column key for column metadata: %w", err)
+					// Key not available for this column — leave MetaData blank.
+					// The caller may still read other columns whose keys are
+					// available; this column will be inaccessible if touched.
+					continue
 				}
 			default:
 				continue
 			}
-			aad := makeAAD(f.aadPrefix, f.fileUnique, columnMetaDataModule, int16(rgIdx), int16(colIdx))
+			// Use rg.Ordinal (not the slice index) to match the AAD used by
+			// the writer and the rest of the read path (pages, bloom filters).
+			aad := makeAAD(f.aadPrefix, f.fileUnique, columnMetaDataModule, rg.Ordinal, int16(colIdx))
 			plain, err := decryptModule(key, aad, chunk.EncryptedColumnMetadata)
 			if err != nil {
-				return fmt.Errorf("decrypting column metadata: rowGroup=%d col=%d: %w", rgIdx, colIdx, err)
+				return fmt.Errorf("decrypting column metadata: rowGroup=%d col=%d: %w", rg.Ordinal, colIdx, err)
 			}
 			compact := thrift.CompactProtocol{}
 			if err := thrift.Unmarshal(&compact, plain, &chunk.MetaData); err != nil {
-				return fmt.Errorf("decoding column metadata: rowGroup=%d col=%d: %w", rgIdx, colIdx, err)
+				return fmt.Errorf("decoding column metadata: rowGroup=%d col=%d: %w", rg.Ordinal, colIdx, err)
 			}
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -1023,10 +1023,7 @@ func (c *FileColumnChunk) readBloomFilter(reader io.ReaderAt) (*FileBloomFilter,
 		if err != nil {
 			return nil, fmt.Errorf("decrypting bloom filter bitset: %w", err)
 		}
-		filter, err = newBloomFilterFromBytes(&header, bitsPlain)
-		if err != nil {
-			return nil, fmt.Errorf("reading encrypted bloom filter: %w", err)
-		}
+		filter = newBloomFilterFromBytes(&header, bitsPlain)
 	} else {
 		compact := thrift.CompactProtocol{}
 		decoder := thrift.NewDecoder(compact.NewReader(rbuf))

--- a/file.go
+++ b/file.go
@@ -217,18 +217,20 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		return nil, ErrMissingRootColumn
 	}
 
-	if !c.SkipPageIndex {
-		if f.columnIndexes, f.offsetIndexes, err = f.ReadPageIndex(); err != nil {
-			return nil, fmt.Errorf("reading page index of parquet file: %w", err)
-		}
-	}
-
 	// In plaintext-footer mode with encryption, column metadata is stored as
-	// EncryptedColumnMetadata. Decrypt it into MetaData before openColumns
-	// runs, so that encoding/compression are visible to schema construction.
+	// EncryptedColumnMetadata. Decrypt it into MetaData before reading the page
+	// index — column index/offset index offsets live in MetaData and would
+	// otherwise be zero, silently losing the page index for every encrypted
+	// plaintext-footer file.
 	if f.decryption != nil {
 		if err := f.decryptAllColumnMetadata(); err != nil {
 			return nil, err
+		}
+	}
+
+	if !c.SkipPageIndex {
+		if f.columnIndexes, f.offsetIndexes, err = f.ReadPageIndex(); err != nil {
+			return nil, fmt.Errorf("reading page index of parquet file: %w", err)
 		}
 	}
 
@@ -382,6 +384,25 @@ func (f *File) ReadPageIndex() ([]format.ColumnIndex, []format.OffsetIndex, erro
 	offsetIndexes := make([]format.OffsetIndex, numColumnChunks)
 	indexBuffer := make([]byte, max(int(columnIndexLength), int(offsetIndexLength)))
 
+	// pageIndexKey returns the AES key used to decrypt this column's
+	// page-index modules, or nil for plaintext columns.  We resolve keys here
+	// (instead of relying on FileRowGroup.init) because ReadPageIndex runs
+	// before makeFileRowGroups during OpenFile.
+	pageIndexKey := func(c *format.ColumnChunk) ([]byte, error) {
+		if f.decryption == nil {
+			return nil, nil
+		}
+		switch {
+		case c.CryptoMetadata.EncryptionWithFooterKey != nil:
+			return f.decryption.Keys.FooterKey(nil)
+		case c.CryptoMetadata.EncryptionWithColumnKey != nil:
+			colKey := c.CryptoMetadata.EncryptionWithColumnKey
+			return f.decryption.Keys.ColumnKey(colKey.PathInSchema, colKey.KeyMetadata)
+		default:
+			return nil, nil
+		}
+	}
+
 	if columnIndexOffset > 0 {
 		columnIndexData := indexBuffer[:columnIndexLength]
 
@@ -401,6 +422,21 @@ func (f *File) ReadPageIndex() ([]format.ColumnIndex, []format.OffsetIndex, erro
 				offset := c.ColumnIndexOffset - columnIndexOffset
 				length := int64(c.ColumnIndexLength)
 				buffer := columnIndexData[offset : offset+length]
+				key, err := pageIndexKey(c)
+				if err != nil {
+					if errors.Is(err, ErrKeyNotFound) {
+						return nil
+					}
+					return fmt.Errorf("resolving column index key: rowGroup=%d col=%d: %w", i, j, err)
+				}
+				if key != nil {
+					aad := makeAAD(f.aadPrefix, f.fileUnique, columnIndexModule, int16(i), int16(j))
+					plain, err := decryptModule(key, aad, buffer)
+					if err != nil {
+						return fmt.Errorf("decrypting column index: rowGroup=%d col=%d: %w", i, j, err)
+					}
+					buffer = plain
+				}
 				if err := thrift.Unmarshal(&f.protocol, buffer, &columnIndexes[(i*numColumns)+j]); err != nil {
 					return fmt.Errorf("decoding column index: rowGroup=%d columnChunk=%d/%d: %w", i, j, numColumns, err)
 				}
@@ -427,8 +463,23 @@ func (f *File) ReadPageIndex() ([]format.ColumnIndex, []format.OffsetIndex, erro
 				offset := c.OffsetIndexOffset - offsetIndexOffset
 				length := int64(c.OffsetIndexLength)
 				buffer := offsetIndexData[offset : offset+length]
+				key, err := pageIndexKey(c)
+				if err != nil {
+					if errors.Is(err, ErrKeyNotFound) {
+						return nil
+					}
+					return fmt.Errorf("resolving offset index key: rowGroup=%d col=%d: %w", i, j, err)
+				}
+				if key != nil {
+					aad := makeAAD(f.aadPrefix, f.fileUnique, offsetIndexModule, int16(i), int16(j))
+					plain, err := decryptModule(key, aad, buffer)
+					if err != nil {
+						return fmt.Errorf("decrypting offset index: rowGroup=%d col=%d: %w", i, j, err)
+					}
+					buffer = plain
+				}
 				if err := thrift.Unmarshal(&f.protocol, buffer, &offsetIndexes[(i*numColumns)+j]); err != nil {
-					return fmt.Errorf("decoding column index: rowGroup=%d columnChunk=%d/%d: %w", i, j, numColumns, err)
+					return fmt.Errorf("decoding offset index: rowGroup=%d columnChunk=%d/%d: %w", i, j, numColumns, err)
 				}
 			}
 			return nil
@@ -593,7 +644,7 @@ type FileRowGroup struct {
 	sorting  []SortingColumn
 }
 
-func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowGroup) {
+func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowGroup) error {
 	g.file = file
 	g.rowGroup = rowGroup
 	g.columns = make([]ColumnChunk, len(rowGroup.Columns))
@@ -616,14 +667,25 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 			switch {
 			case chunk.CryptoMetadata.EncryptionWithFooterKey != nil:
 				key, err := file.decryption.Keys.FooterKey(nil)
-				if err == nil {
-					fileColumnChunks[i].decryptionKey = key
+				if err != nil {
+					return fmt.Errorf("resolving footer key for column %q: %w", columnPathString(columns[i].Path()), err)
 				}
+				fileColumnChunks[i].decryptionKey = key
 			case chunk.CryptoMetadata.EncryptionWithColumnKey != nil:
 				colKey := chunk.CryptoMetadata.EncryptionWithColumnKey
 				key, err := file.decryption.Keys.ColumnKey(colKey.PathInSchema, colKey.KeyMetadata)
-				if err == nil {
+				switch {
+				case err == nil:
 					fileColumnChunks[i].decryptionKey = key
+				case errors.Is(err, ErrKeyNotFound):
+					// Caller intentionally omitted this column's key.  Leave
+					// decryptionKey nil so the chunk fails only if the data is
+					// actually accessed.
+				default:
+					// Real error (KMS failure, bad metadata, …) must surface so
+					// the caller learns the cause instead of seeing later
+					// "decode page header" errors masking the missing key.
+					return fmt.Errorf("resolving column key for %q: %w", columnPathString(colKey.PathInSchema), err)
 				}
 			}
 		}
@@ -648,6 +710,7 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 			nullsFirst: rowGroup.SortingColumns[i].NullsFirst,
 		}
 	}
+	return nil
 }
 
 // File returns the file that this row group belongs to.
@@ -869,7 +932,16 @@ func (c *FileColumnChunk) readColumnIndexFrom(reader io.ReaderAt) (*FileColumnIn
 	if _, err := readAt(reader, indexData, offset); err != nil {
 		return nil, fmt.Errorf("read %d bytes column index at offset %d: %w", length, offset, err)
 	}
-	if err := thrift.Unmarshal(&c.file.protocol, indexData, &columnIndex); err != nil {
+	plain := indexData
+	if c.decryptionKey != nil {
+		aad := makeAAD(c.file.aadPrefix, c.file.fileUnique, columnIndexModule, c.rowGroupOrdinal, c.columnOrdinal)
+		decrypted, err := decryptModule(c.decryptionKey, aad, indexData)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting column index: rowGroup=%d col=%d: %w", c.rowGroupOrdinal, c.columnOrdinal, err)
+		}
+		plain = decrypted
+	}
+	if err := thrift.Unmarshal(&c.file.protocol, plain, &columnIndex); err != nil {
 		return nil, fmt.Errorf("decode column index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
 	}
 	index := &FileColumnIndex{index: &columnIndex, kind: c.column.Type().Kind()}
@@ -898,7 +970,16 @@ func (c *FileColumnChunk) readOffsetIndex(reader io.ReaderAt) (*FileOffsetIndex,
 	if _, err := readAt(reader, indexData, offset); err != nil {
 		return nil, fmt.Errorf("read %d bytes offset index at offset %d: %w", length, offset, err)
 	}
-	if err := thrift.Unmarshal(&c.file.protocol, indexData, &offsetIndex); err != nil {
+	plain := indexData
+	if c.decryptionKey != nil {
+		aad := makeAAD(c.file.aadPrefix, c.file.fileUnique, offsetIndexModule, c.rowGroupOrdinal, c.columnOrdinal)
+		decrypted, err := decryptModule(c.decryptionKey, aad, indexData)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting offset index: rowGroup=%d col=%d: %w", c.rowGroupOrdinal, c.columnOrdinal, err)
+		}
+		plain = decrypted
+	}
+	if err := thrift.Unmarshal(&c.file.protocol, plain, &offsetIndex); err != nil {
 		return nil, fmt.Errorf("decode offset index: rowGroup=%d columnChunk=%d/%d: %w", c.rowGroup.Ordinal, c.Column(), len(c.rowGroup.Columns), err)
 	}
 	index := &FileOffsetIndex{index: &offsetIndex}
@@ -942,7 +1023,10 @@ func (c *FileColumnChunk) readBloomFilter(reader io.ReaderAt) (*FileBloomFilter,
 		if err != nil {
 			return nil, fmt.Errorf("decrypting bloom filter bitset: %w", err)
 		}
-		filter = newBloomFilterFromBytes(&header, bitsPlain)
+		filter, err = newBloomFilterFromBytes(&header, bitsPlain)
+		if err != nil {
+			return nil, fmt.Errorf("reading encrypted bloom filter: %w", err)
+		}
 	} else {
 		compact := thrift.CompactProtocol{}
 		decoder := thrift.NewDecoder(compact.NewReader(rbuf))

--- a/file.go
+++ b/file.go
@@ -232,7 +232,10 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		f.schema = NewSchema(f.root.Name(), f.root)
 	}
 	columns := makeLeafColumns(f.root)
-	rowGroups := makeFileRowGroups(f, columns)
+	rowGroups, err := makeFileRowGroups(f, columns)
+	if err != nil {
+		return nil, err
+	}
 	f.rowGroups = makeRowGroups(rowGroups)
 
 	if !c.SkipBloomFilters {
@@ -520,7 +523,7 @@ type FileRowGroup struct {
 	sorting  []SortingColumn
 }
 
-func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowGroup) {
+func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowGroup) error {
 	g.file = file
 	g.rowGroup = rowGroup
 	g.columns = make([]ColumnChunk, len(rowGroup.Columns))
@@ -553,6 +556,20 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 					fileColumnChunks[i].decryptionKey = key
 				}
 			}
+
+			// In plaintext-footer mode the column metadata is encrypted inline.
+			// Decrypt it now so that all subsequent code can access MetaData normally.
+			if len(chunk.EncryptedColumnMetadata) > 0 && fileColumnChunks[i].decryptionKey != nil {
+				aad := makeAAD(file.aadPrefix, file.fileUnique, columnMetaDataModule, rowGroup.Ordinal, int16(i))
+				plainMeta, err := decryptModule(fileColumnChunks[i].decryptionKey, aad, chunk.EncryptedColumnMetadata)
+				if err != nil {
+					return fmt.Errorf("decrypting column metadata: rowGroup=%d col=%d: %w", rowGroup.Ordinal, i, err)
+				}
+				compact := thrift.CompactProtocol{}
+				if err := thrift.Unmarshal(&compact, plainMeta, &chunk.MetaData); err != nil {
+					return fmt.Errorf("decoding encrypted column metadata: rowGroup=%d col=%d: %w", rowGroup.Ordinal, i, err)
+				}
+			}
 		}
 
 		if file.hasIndexes() {
@@ -575,6 +592,7 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 			nullsFirst: rowGroup.SortingColumns[i].NullsFirst,
 		}
 	}
+	return nil
 }
 
 // File returns the file that this row group belongs to.

--- a/file.go
+++ b/file.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -445,6 +446,14 @@ func (f *File) ReadPageIndex() ([]format.ColumnIndex, []format.OffsetIndex, erro
 // openColumns and schema construction see the full encoding/compression info.
 // This must be called before openColumns.
 func (f *File) decryptAllColumnMetadata() error {
+	// Normalize ordinals before using them in AADs.  Files from writers that
+	// omit the optional Ordinal field have all zeros; validateRowGroupOrdinals
+	// back-fills sequential values so rg.Ordinal is guaranteed to equal the
+	// slice index — matching exactly what the writer embedded in every AAD.
+	if err := validateRowGroupOrdinals(f.metadata.RowGroups); err != nil {
+		return err
+	}
+
 	for rgIdx := range f.metadata.RowGroups {
 		rg := &f.metadata.RowGroups[rgIdx]
 		for colIdx := range rg.Columns {
@@ -465,16 +474,19 @@ func (f *File) decryptAllColumnMetadata() error {
 				var err error
 				key, err = f.decryption.Keys.ColumnKey(colKey.PathInSchema, colKey.KeyMetadata)
 				if err != nil {
-					// Key not available for this column — leave MetaData blank.
-					// The caller may still read other columns whose keys are
-					// available; this column will be inaccessible if touched.
-					continue
+					// Only treat an explicit ErrKeyNotFound as non-fatal: the
+					// caller intentionally omitted this column's key.  Any other
+					// error (KMS failure, bad metadata, …) is propagated so the
+					// caller sees the real problem instead of silent zero data.
+					if errors.Is(err, ErrKeyNotFound) {
+						continue
+					}
+					return fmt.Errorf("resolving column key for column metadata: %w", err)
 				}
 			default:
 				continue
 			}
-			// Use rg.Ordinal (not the slice index) to match the AAD used by
-			// the writer and the rest of the read path (pages, bloom filters).
+			// rg.Ordinal is reliable here because validateRowGroupOrdinals ran above.
 			aad := makeAAD(f.aadPrefix, f.fileUnique, columnMetaDataModule, rg.Ordinal, int16(colIdx))
 			plain, err := decryptModule(key, aad, chunk.EncryptedColumnMetadata)
 			if err != nil {

--- a/file.go
+++ b/file.go
@@ -36,6 +36,11 @@ type File struct {
 	offsetIndexes []format.OffsetIndex
 	rowGroups     []RowGroup
 	config        *FileConfig
+
+	// Decryption state; non-nil when the file has encryption metadata.
+	decryption *DecryptionConfig
+	fileUnique []byte // AadFileUnique from encryption algorithm
+	aadPrefix  []byte // AadPrefix from encryption algorithm
 }
 
 type FileView interface {
@@ -63,13 +68,21 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	}
 	f := &File{reader: r, size: size, config: c}
 
+	var headerMagic [4]byte
 	if !c.SkipMagicBytes {
-		var b [4]byte
-		if _, err := readAt(r, b[:4], 0); err != nil {
+		if _, err := readAt(r, headerMagic[:], 0); err != nil {
 			return nil, fmt.Errorf("reading magic header of parquet file: %w", err)
 		}
-		if string(b[:4]) != "PAR1" {
-			return nil, fmt.Errorf("invalid magic header of parquet file: %q", b[:4])
+		switch string(headerMagic[:]) {
+		case "PAR1":
+			// plain or plaintext-footer-with-signature
+		case "PARE":
+			// encrypted footer
+			if c.Decryption == nil {
+				return nil, fmt.Errorf("parquet file has encrypted footer (magic \"PARE\") but no DecryptionConfig was provided")
+			}
+		default:
+			return nil, fmt.Errorf("invalid magic header of parquet file: %q", headerMagic[:])
 		}
 	}
 
@@ -96,7 +109,8 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	}
 	optimisticFooterSize -= 8
 	b := optimisticFooterData[optimisticFooterSize:]
-	if string(b[4:]) != "PAR1" {
+	footerMagic := string(b[4:])
+	if footerMagic != "PAR1" && footerMagic != "PARE" {
 		return nil, fmt.Errorf("invalid magic footer of parquet file: %q", b[4:])
 	}
 
@@ -115,9 +129,89 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		}
 	}
 
-	if err := thrift.Unmarshal(&f.protocol, footerData, &f.metadata); err != nil {
-		return nil, fmt.Errorf("reading parquet file metadata: %w", err)
+	if footerMagic == "PARE" {
+		// Encrypted footer: footerData = FileCryptoMetaData (thrift) || encrypted footer module.
+		// Decode FileCryptoMetaData using a bytes-backed reader to count bytes consumed.
+		pr := f.protocol.NewReaderFromBytes(footerData)
+		var cryptoMeta format.FileCryptoMetaData
+		if err := thrift.NewDecoder(pr).Decode(&cryptoMeta); err != nil {
+			return nil, fmt.Errorf("reading FileCryptoMetaData: %w", err)
+		}
+		encFooterEnvelope := footerData[pr.BytesRead():]
+
+		// Extract AAD parameters from the encryption algorithm.
+		var fileUnique, aadPrefix []byte
+		switch {
+		case cryptoMeta.EncryptionAlgorithm.AesGcmV1 != nil:
+			fileUnique = cryptoMeta.EncryptionAlgorithm.AesGcmV1.AadFileUnique
+			aadPrefix = cryptoMeta.EncryptionAlgorithm.AesGcmV1.AadPrefix
+		case cryptoMeta.EncryptionAlgorithm.AesGcmCtrV1 != nil:
+			fileUnique = cryptoMeta.EncryptionAlgorithm.AesGcmCtrV1.AadFileUnique
+			aadPrefix = cryptoMeta.EncryptionAlgorithm.AesGcmCtrV1.AadPrefix
+		}
+
+		footerKey, err := c.Decryption.Keys.FooterKey(cryptoMeta.KeyMetadata)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving footer key: %w", err)
+		}
+		footerAAD := makeAAD(aadPrefix, fileUnique, footerModule)
+		plainFooter, err := decryptModule(footerKey, footerAAD, encFooterEnvelope)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting footer: %w", err)
+		}
+		if err := thrift.Unmarshal(&f.protocol, plainFooter, &f.metadata); err != nil {
+			return nil, fmt.Errorf("reading parquet file metadata from decrypted footer: %w", err)
+		}
+		f.decryption = c.Decryption
+		f.fileUnique = fileUnique
+		f.aadPrefix = aadPrefix
+	} else {
+		// Decode the footer metadata using a reader that tracks bytes consumed,
+		// so that we can detect a trailing 28-byte AES-GCM signature without
+		// tripping over the "unexpected trailing bytes" check in thrift.Unmarshal.
+		pr := f.protocol.NewReaderFromBytes(bytes.Clone(footerData))
+		if err := thrift.NewDecoder(pr).Decode(&f.metadata); err != nil {
+			return nil, fmt.Errorf("reading parquet file metadata: %w", err)
+		}
+		trailing := len(footerData) - pr.BytesRead()
+		const sigLen = encNonceSize + encTagSize
+		switch {
+		case trailing == 0:
+			// Plain, unsigned footer — nothing to do.
+		case trailing == sigLen:
+			// Plaintext footer with AES-GCM signature appended.
+			if c.Decryption == nil {
+				return nil, fmt.Errorf("parquet file has a signed footer but no DecryptionConfig was provided")
+			}
+			algo := &f.metadata.EncryptionAlgorithm
+			var fileUnique, aadPrefix []byte
+			switch {
+			case algo.AesGcmV1 != nil:
+				fileUnique = algo.AesGcmV1.AadFileUnique
+				aadPrefix = algo.AesGcmV1.AadPrefix
+			case algo.AesGcmCtrV1 != nil:
+				fileUnique = algo.AesGcmCtrV1.AadFileUnique
+				aadPrefix = algo.AesGcmCtrV1.AadPrefix
+			}
+			plainFooterBytes := footerData[:pr.BytesRead()]
+			sig := footerData[pr.BytesRead():]
+
+			footerKey, err := c.Decryption.Keys.FooterKey(f.metadata.FooterSigningKeyMetadata)
+			if err != nil {
+				return nil, fmt.Errorf("retrieving footer signing key: %w", err)
+			}
+			footerAAD := makeAAD(aadPrefix, fileUnique, footerModule)
+			if err := verifyFooterSignature(footerKey, footerAAD, plainFooterBytes, sig); err != nil {
+				return nil, err
+			}
+			f.decryption = c.Decryption
+			f.fileUnique = fileUnique
+			f.aadPrefix = aadPrefix
+		default:
+			return nil, fmt.Errorf("reading parquet file metadata: unexpected trailing bytes at the end of thrift input: %d", trailing)
+		}
 	}
+
 	if len(f.metadata.Schema) == 0 {
 		return nil, ErrMissingRootColumn
 	}
@@ -430,10 +524,28 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 
 	for i := range g.columns {
 		fileColumnChunks[i] = FileColumnChunk{
-			file:     file,
-			column:   columns[i],
-			rowGroup: rowGroup,
-			chunk:    &rowGroup.Columns[i],
+			file:            file,
+			column:          columns[i],
+			rowGroup:        rowGroup,
+			chunk:           &rowGroup.Columns[i],
+			columnOrdinal:   int16(i),
+			rowGroupOrdinal: rowGroup.Ordinal,
+		}
+		if file.decryption != nil {
+			chunk := &rowGroup.Columns[i]
+			switch {
+			case chunk.CryptoMetadata.EncryptionWithFooterKey != nil:
+				key, err := file.decryption.Keys.FooterKey(nil)
+				if err == nil {
+					fileColumnChunks[i].decryptionKey = key
+				}
+			case chunk.CryptoMetadata.EncryptionWithColumnKey != nil:
+				colKey := chunk.CryptoMetadata.EncryptionWithColumnKey
+				key, err := file.decryption.Keys.ColumnKey(colKey.PathInSchema, colKey.KeyMetadata)
+				if err == nil {
+					fileColumnChunks[i].decryptionKey = key
+				}
+			}
 		}
 
 		if file.hasIndexes() {
@@ -518,6 +630,11 @@ type FileColumnChunk struct {
 	columnIndex atomic.Pointer[FileColumnIndex]
 	offsetIndex atomic.Pointer[FileOffsetIndex]
 	bloomFilter atomic.Pointer[FileBloomFilter]
+
+	// Decryption state; decryptionKey is nil when the column is not encrypted.
+	decryptionKey   []byte
+	columnOrdinal   int16
+	rowGroupOrdinal int16
 }
 
 // File returns the file that this column chunk belongs to.
@@ -769,6 +886,21 @@ type FilePages struct {
 	serveLastPage bool
 
 	bufferSize int
+
+	// dec is non-nil only when the column is encrypted. Keeping it behind a
+	// pointer avoids bloating FilePages for the common (non-encrypted) case.
+	dec *filePagesDecryptionState
+}
+
+// filePagesDecryptionState holds per-column decryption context for FilePages.
+type filePagesDecryptionState struct {
+	key             []byte
+	fileUnique      []byte
+	aadPrefix       []byte
+	rowGroupOrdinal int16
+	columnOrdinal   int16
+	dataPageOrd     int16
+	dictPagePending bool // true when next page in the stream is the encrypted dict page
 }
 
 func (f *FilePages) init(c *FileColumnChunk, reader io.ReaderAt) {
@@ -790,6 +922,21 @@ func (f *FilePages) init(c *FileColumnChunk, reader io.ReaderAt) {
 	f.lastPage = nil
 	f.lastPageIndex = -1
 	f.serveLastPage = false
+
+	// Populate decryption state from the column chunk (only when encrypted).
+	if c.decryptionKey != nil {
+		f.dec = &filePagesDecryptionState{
+			key:             c.decryptionKey,
+			fileUnique:      c.file.fileUnique,
+			aadPrefix:       c.file.aadPrefix,
+			rowGroupOrdinal: c.rowGroupOrdinal,
+			columnOrdinal:   c.columnOrdinal,
+			dataPageOrd:     0,
+			dictPagePending: f.dictOffset > 0,
+		}
+	} else {
+		f.dec = nil
+	}
 }
 
 // ReadDictionary returns the dictionary of the column chunk, or nil if the
@@ -833,33 +980,51 @@ func (f *FilePages) ReadPage() (Page, error) {
 	}
 
 	for {
-		// Instantiate a new format.PageHeader for each page.
-		//
-		// A previous implementation reused page headers to save allocations.
-		// https://github.com/segmentio/parquet-go/pull/484
-		// The optimization turned out to be less effective than expected,
-		// because all the values referenced by pointers in the page header
-		// are lost when the header is reset and put back in the pool.
-		// https://github.com/parquet-go/parquet-go/pull/11
-		//
-		// Even after being reset, reusing page headers still produced instability
-		// issues.
-		// https://github.com/parquet-go/parquet-go/issues/70
-		header := new(format.PageHeader)
-		if err := f.decoder.Decode(header); err != nil {
-			return nil, err
-		}
+		var (
+			header *format.PageHeader
+			data   *buffer[byte]
+			err    error
+		)
 
-		// if this is a dictionary page and we've already read and decoded the dictionary we can skip past it.
-		// call f.rbuf.Discard to skip the page data and realign f.rbuf with the next page header
-		if header.Type == format.DictionaryPage && f.dictionary != nil {
-			f.rbuf.Discard(int(header.CompressedPageSize))
-			continue
-		}
+		if f.dec != nil {
+			header, data, err = f.readEncryptedPage()
+			if err != nil {
+				return nil, err
+			}
+			// If we've already loaded the dictionary, skip a duplicate dict page.
+			if header.Type == format.DictionaryPage && f.dictionary != nil {
+				data.unref()
+				continue
+			}
+		} else {
+			// Instantiate a new format.PageHeader for each page.
+			//
+			// A previous implementation reused page headers to save allocations.
+			// https://github.com/segmentio/parquet-go/pull/484
+			// The optimization turned out to be less effective than expected,
+			// because all the values referenced by pointers in the page header
+			// are lost when the header is reset and put back in the pool.
+			// https://github.com/parquet-go/parquet-go/pull/11
+			//
+			// Even after being reset, reusing page headers still produced instability
+			// issues.
+			// https://github.com/parquet-go/parquet-go/issues/70
+			header = new(format.PageHeader)
+			if err = f.decoder.Decode(header); err != nil {
+				return nil, err
+			}
 
-		data, err := f.readPage(header, f.rbuf)
-		if err != nil {
-			return nil, err
+			// if this is a dictionary page and we've already read and decoded the dictionary we can skip past it.
+			// call f.rbuf.Discard to skip the page data and realign f.rbuf with the next page header
+			if header.Type == format.DictionaryPage && f.dictionary != nil {
+				f.rbuf.Discard(int(header.CompressedPageSize))
+				continue
+			}
+
+			data, err = f.readPage(header, f.rbuf)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		var page Page
@@ -946,21 +1111,41 @@ func (f *FilePages) readDictionary() error {
 	rbuf, pool := getBufioReader(chunk, f.bufferSize)
 	defer putBufioReader(rbuf, pool)
 
-	decoder := thrift.NewDecoder(f.protocol.NewReader(rbuf))
-
 	header := new(format.PageHeader)
+	var page *buffer[byte]
 
-	if err := decoder.Decode(header); err != nil {
-		return err
+	if f.dec != nil {
+		d := f.dec
+		hdrAAD := makeAAD(d.aadPrefix, d.fileUnique, dictPageHeaderModule, d.rowGroupOrdinal, d.columnOrdinal, 0)
+		hdrPlain, err := readDecryptedEnvelopeFrom(rbuf, d.key, hdrAAD)
+		if err != nil {
+			return err
+		}
+		pr := f.protocol.NewReaderFromBytes(hdrPlain)
+		if err := thrift.NewDecoder(pr).Decode(header); err != nil {
+			return fmt.Errorf("parquet decryption: decoding dict page header: %w", err)
+		}
+		bodyAAD := makeAAD(d.aadPrefix, d.fileUnique, dictPageBodyModule, d.rowGroupOrdinal, d.columnOrdinal, 0)
+		bodyPlain, err := readDecryptedEnvelopeFrom(rbuf, d.key, bodyAAD)
+		if err != nil {
+			return err
+		}
+		page = buffers.get(len(bodyPlain))
+		copy(page.data.Slice(), bodyPlain)
+		page.ref()
+	} else {
+		decoder := thrift.NewDecoder(f.protocol.NewReader(rbuf))
+		if err := decoder.Decode(header); err != nil {
+			return err
+		}
+		page = buffers.get(int(header.CompressedPageSize))
+		page.ref()
+		if _, err := io.ReadFull(rbuf, page.data.Slice()); err != nil {
+			page.unref()
+			return err
+		}
 	}
-
-	page := buffers.get(int(header.CompressedPageSize))
 	defer page.unref()
-
-	if _, err := io.ReadFull(rbuf, page.data.Slice()); err != nil {
-		return err
-	}
-
 	return f.readDictionaryPage(header, page)
 }
 
@@ -1035,6 +1220,71 @@ func (f *FilePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*
 
 	page.ref()
 	return page, nil
+}
+
+// readDecryptedEnvelopeFrom reads a Parquet module envelope from r, decrypts it, and
+// returns the plaintext.  The caller supplies the key and pre-built AAD bytes.
+func readDecryptedEnvelopeFrom(r io.Reader, key, aad []byte) ([]byte, error) {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return nil, err
+	}
+	moduleLen := int(binary.LittleEndian.Uint32(lenBuf[:]))
+	envelope := make([]byte, 4+moduleLen)
+	copy(envelope[:4], lenBuf[:])
+	if _, err := io.ReadFull(r, envelope[4:]); err != nil {
+		return nil, err
+	}
+	return decryptModule(key, aad, envelope)
+}
+
+// readEncryptedPage reads one page (header + body) from the encrypted stream.
+// It handles both dictionary pages and data pages; the caller must not call it
+// when the stream is exhausted.
+func (f *FilePages) readEncryptedPage() (*format.PageHeader, *buffer[byte], error) {
+	d := f.dec
+	isDictPage := d.dictPagePending
+
+	var hdrModuleType, bodyModuleType byte
+	var pageOrd int16
+	if isDictPage {
+		hdrModuleType = dictPageHeaderModule
+		bodyModuleType = dictPageBodyModule
+		pageOrd = 0
+	} else {
+		hdrModuleType = dataPageHeaderModule
+		bodyModuleType = dataPageBodyModule
+		pageOrd = d.dataPageOrd
+	}
+
+	hdrAAD := makeAAD(d.aadPrefix, d.fileUnique, hdrModuleType, d.rowGroupOrdinal, d.columnOrdinal, pageOrd)
+	hdrPlain, err := readDecryptedEnvelopeFrom(f.rbuf, d.key, hdrAAD)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	header := new(format.PageHeader)
+	pr := f.protocol.NewReaderFromBytes(hdrPlain)
+	if err := thrift.NewDecoder(pr).Decode(header); err != nil {
+		return nil, nil, fmt.Errorf("parquet decryption: decoding page header: %w", err)
+	}
+
+	bodyAAD := makeAAD(d.aadPrefix, d.fileUnique, bodyModuleType, d.rowGroupOrdinal, d.columnOrdinal, pageOrd)
+	bodyPlain, err := readDecryptedEnvelopeFrom(f.rbuf, d.key, bodyAAD)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	page := buffers.get(len(bodyPlain))
+	copy(page.data.Slice(), bodyPlain)
+	page.ref()
+
+	if isDictPage {
+		d.dictPagePending = false
+	} else {
+		d.dataPageOrd++
+	}
+	return header, page, nil
 }
 
 // SeekToRow seeks to the given row index in the column chunk.
@@ -1114,6 +1364,10 @@ func (f *FilePages) SeekToRow(rowIndex int64) error {
 	}
 
 	f.rbuf.Reset(&f.section)
+	// Any seek moves us past (or to) a data page, not the dict page.
+	if f.dec != nil {
+		f.dec.dictPagePending = false
+	}
 	return nil
 }
 

--- a/file.go
+++ b/file.go
@@ -222,6 +222,15 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		}
 	}
 
+	// In plaintext-footer mode with encryption, column metadata is stored as
+	// EncryptedColumnMetadata. Decrypt it into MetaData before openColumns
+	// runs, so that encoding/compression are visible to schema construction.
+	if f.decryption != nil {
+		if err := f.decryptAllColumnMetadata(); err != nil {
+			return nil, err
+		}
+	}
+
 	if f.root, err = openColumns(f, &f.metadata, f.columnIndexes, f.offsetIndexes); err != nil {
 		return nil, fmt.Errorf("opening columns of parquet file: %w", err)
 	}
@@ -431,6 +440,50 @@ func (f *File) ReadPageIndex() ([]format.ColumnIndex, []format.OffsetIndex, erro
 	return columnIndexes, offsetIndexes, nil
 }
 
+// decryptAllColumnMetadata decrypts EncryptedColumnMetadata for every column
+// chunk in every row group, restoring ColumnChunk.MetaData so that
+// openColumns and schema construction see the full encoding/compression info.
+// This must be called before openColumns.
+func (f *File) decryptAllColumnMetadata() error {
+	for rgIdx := range f.metadata.RowGroups {
+		rg := &f.metadata.RowGroups[rgIdx]
+		for colIdx := range rg.Columns {
+			chunk := &rg.Columns[colIdx]
+			if len(chunk.EncryptedColumnMetadata) == 0 {
+				continue
+			}
+			var key []byte
+			switch {
+			case chunk.CryptoMetadata.EncryptionWithFooterKey != nil:
+				var err error
+				key, err = f.decryption.Keys.FooterKey(nil)
+				if err != nil {
+					return fmt.Errorf("resolving footer key for column metadata: %w", err)
+				}
+			case chunk.CryptoMetadata.EncryptionWithColumnKey != nil:
+				colKey := chunk.CryptoMetadata.EncryptionWithColumnKey
+				var err error
+				key, err = f.decryption.Keys.ColumnKey(colKey.PathInSchema, colKey.KeyMetadata)
+				if err != nil {
+					return fmt.Errorf("resolving column key for column metadata: %w", err)
+				}
+			default:
+				continue
+			}
+			aad := makeAAD(f.aadPrefix, f.fileUnique, columnMetaDataModule, int16(rgIdx), int16(colIdx))
+			plain, err := decryptModule(key, aad, chunk.EncryptedColumnMetadata)
+			if err != nil {
+				return fmt.Errorf("decrypting column metadata: rowGroup=%d col=%d: %w", rgIdx, colIdx, err)
+			}
+			compact := thrift.CompactProtocol{}
+			if err := thrift.Unmarshal(&compact, plain, &chunk.MetaData); err != nil {
+				return fmt.Errorf("decoding column metadata: rowGroup=%d col=%d: %w", rgIdx, colIdx, err)
+			}
+		}
+	}
+	return nil
+}
+
 // NumRows returns the number of rows in the file.
 func (f *File) NumRows() int64 { return f.metadata.NumRows }
 
@@ -523,7 +576,7 @@ type FileRowGroup struct {
 	sorting  []SortingColumn
 }
 
-func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowGroup) error {
+func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowGroup) {
 	g.file = file
 	g.rowGroup = rowGroup
 	g.columns = make([]ColumnChunk, len(rowGroup.Columns))
@@ -556,20 +609,6 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 					fileColumnChunks[i].decryptionKey = key
 				}
 			}
-
-			// In plaintext-footer mode the column metadata is encrypted inline.
-			// Decrypt it now so that all subsequent code can access MetaData normally.
-			if len(chunk.EncryptedColumnMetadata) > 0 && fileColumnChunks[i].decryptionKey != nil {
-				aad := makeAAD(file.aadPrefix, file.fileUnique, columnMetaDataModule, rowGroup.Ordinal, int16(i))
-				plainMeta, err := decryptModule(fileColumnChunks[i].decryptionKey, aad, chunk.EncryptedColumnMetadata)
-				if err != nil {
-					return fmt.Errorf("decrypting column metadata: rowGroup=%d col=%d: %w", rowGroup.Ordinal, i, err)
-				}
-				compact := thrift.CompactProtocol{}
-				if err := thrift.Unmarshal(&compact, plainMeta, &chunk.MetaData); err != nil {
-					return fmt.Errorf("decoding encrypted column metadata: rowGroup=%d col=%d: %w", rowGroup.Ordinal, i, err)
-				}
-			}
 		}
 
 		if file.hasIndexes() {
@@ -592,7 +631,6 @@ func (g *FileRowGroup) init(file *File, columns []*Column, rowGroup *format.RowG
 			nullsFirst: rowGroup.SortingColumns[i].NullsFirst,
 		}
 	}
-	return nil
 }
 
 // File returns the file that this row group belongs to.

--- a/reader.go
+++ b/reader.go
@@ -643,7 +643,10 @@ func (r *readerFileView) RowGroups() []RowGroup {
 		return nil
 	}
 	columns := makeLeafColumns(r.Root())
-	fileRowGroups := makeFileRowGroups(file, columns)
+	fileRowGroups, err := makeFileRowGroups(file, columns)
+	if err != nil {
+		return nil
+	}
 	return makeRowGroups(fileRowGroups)
 }
 
@@ -653,19 +656,20 @@ func makeLeafColumns(root *Column) []*Column {
 	return columns
 }
 
-func makeFileRowGroups(file *File, columns []*Column) []FileRowGroup {
+func makeFileRowGroups(file *File, columns []*Column) ([]FileRowGroup, error) {
 	rowGroups := file.metadata.RowGroups
 
-	err := validateRowGroupOrdinals(rowGroups)
-	if err != nil {
-		return nil
+	if err := validateRowGroupOrdinals(rowGroups); err != nil {
+		return nil, err
 	}
 
 	fileRowGroups := make([]FileRowGroup, len(rowGroups))
 	for i := range fileRowGroups {
-		fileRowGroups[i].init(file, columns, &rowGroups[i])
+		if err := fileRowGroups[i].init(file, columns, &rowGroups[i]); err != nil {
+			return nil, err
+		}
 	}
-	return fileRowGroups
+	return fileRowGroups, nil
 }
 
 func makeRowGroups(fileRowGroups []FileRowGroup) []RowGroup {

--- a/reader.go
+++ b/reader.go
@@ -665,9 +665,7 @@ func makeFileRowGroups(file *File, columns []*Column) ([]FileRowGroup, error) {
 
 	fileRowGroups := make([]FileRowGroup, len(rowGroups))
 	for i := range fileRowGroups {
-		if err := fileRowGroups[i].init(file, columns, &rowGroups[i]); err != nil {
-			return nil, err
-		}
+		fileRowGroups[i].init(file, columns, &rowGroups[i])
 	}
 	return fileRowGroups, nil
 }

--- a/reader.go
+++ b/reader.go
@@ -665,7 +665,9 @@ func makeFileRowGroups(file *File, columns []*Column) ([]FileRowGroup, error) {
 
 	fileRowGroups := make([]FileRowGroup, len(rowGroups))
 	for i := range fileRowGroups {
-		fileRowGroups[i].init(file, columns, &rowGroups[i])
+		if err := fileRowGroups[i].init(file, columns, &rowGroups[i]); err != nil {
+			return nil, err
+		}
 	}
 	return fileRowGroups, nil
 }
@@ -680,26 +682,33 @@ func makeRowGroups(fileRowGroups []FileRowGroup) []RowGroup {
 
 func validateRowGroupOrdinals(rowGroups []format.RowGroup) error {
 	allZero := true
-	seen := make(map[int16]struct{})
 	for _, rg := range rowGroups {
 		if rg.Ordinal != 0 {
 			allZero = false
+			break
 		}
-		// If we've seen this non-zero ordinal before, it's a duplicate, which is an error.
-		if _, ok := seen[rg.Ordinal]; ok && rg.Ordinal != 0 {
-			return fmt.Errorf("duplicate row group ordinal %d", rg.Ordinal)
-		}
-		seen[rg.Ordinal] = struct{}{}
 	}
 
-	// if all ordinals are zero, it's valid, but they need to be assigned
-	// sequential ordinals starting from zero for page offset calculations
-	if !allZero {
+	// If all ordinals are zero, the writer omitted the optional Ordinal field
+	// (or there is a single row group at index 0).  Back-fill sequential values
+	// so callers — including AAD construction for encryption — can rely on
+	// rg.Ordinal == slice index.
+	if allZero {
+		for i := range rowGroups {
+			rowGroups[i].Ordinal = int16(i)
+		}
 		return nil
 	}
 
-	for i := range rowGroups {
-		rowGroups[i].Ordinal = int16(i)
+	// Otherwise the file embeds explicit ordinals; require them to match the
+	// slice index.  The Parquet spec defines RowGroup.Ordinal as the row group
+	// position, and downstream code (page-index lookup, AAD) assumes that
+	// equality.  Files with non-sequential or out-of-order ordinals would
+	// silently produce wrong AADs or out-of-range index lookups.
+	for i, rg := range rowGroups {
+		if int(rg.Ordinal) != i {
+			return fmt.Errorf("row group ordinal %d at index %d does not match its position", rg.Ordinal, i)
+		}
 	}
 	return nil
 }

--- a/writer.go
+++ b/writer.go
@@ -687,7 +687,10 @@ func (w *writerFileView) Root() *Column {
 func (w *writerFileView) RowGroups() []RowGroup {
 	columns := makeLeafColumns(w.Root())
 	file := &File{metadata: w.writer.fileMetaData, schema: w.schema}
-	fileRowGroups := makeFileRowGroups(file, columns)
+	fileRowGroups, err := makeFileRowGroups(file, columns)
+	if err != nil {
+		return nil
+	}
 	return makeRowGroups(fileRowGroups)
 }
 
@@ -1474,7 +1477,7 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 
 	// Set ColumnCryptoMetaData on each column chunk when encryption is active.
 	if w.encryption != nil {
-		for _, c := range rg.columns {
+		for i, c := range rg.columns {
 			path := columnPathString(c.columnPath)
 			_, hasColumnKey := w.encryption.cfg.ColumnKeys[path]
 			if !hasColumnKey {
@@ -1487,6 +1490,27 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 						PathInSchema: c.columnPath,
 					},
 				}
+			}
+
+			// In plaintext-footer mode, encrypt the column metadata and store it
+			// inline in EncryptedColumnMetadata, removing the plaintext MetaData so
+			// that sensitive statistics/offsets are not exposed in the footer.
+			if !w.encryption.cfg.EncryptedFooter {
+				enc := w.encryption
+				var metaBuf bytes.Buffer
+				metaProto := new(thrift.CompactProtocol)
+				metaEnc := thrift.NewEncoder(metaProto.NewWriter(&metaBuf))
+				if err := metaEnc.Encode(&c.columnChunk.MetaData); err != nil {
+					return 0, fmt.Errorf("encoding column metadata for encryption: %w", err)
+				}
+				key := enc.columnKeyFor(path)
+				aad := makeAAD(enc.cfg.AadPrefix, enc.fileUnique, columnMetaDataModule, int16(rowGroupIndex), int16(i))
+				encMeta, err := encryptModule(key, aad, metaBuf.Bytes())
+				if err != nil {
+					return 0, fmt.Errorf("encrypting column metadata: %w", err)
+				}
+				c.columnChunk.EncryptedColumnMetadata = encMeta
+				c.columnChunk.MetaData = format.ColumnMetaData{}
 			}
 		}
 	}

--- a/writer.go
+++ b/writer.go
@@ -1216,12 +1216,46 @@ func (w *writer) writeFileFooter() error {
 	protocol := new(thrift.CompactProtocol)
 	encoder := thrift.NewEncoder(protocol.NewWriter(&w.writer))
 
+	// pageIndexKey returns the AES key used to encrypt this column's page-index
+	// modules (column index + offset index), or nil if the column is not
+	// encrypted.  When encryption is active, the Parquet spec requires the
+	// per-column index to be encrypted with the column's key (or the footer
+	// key when EncryptionWithFooterKey is selected) so that statistics like
+	// min/max do not leak in the otherwise plaintext page index.
+	pageIndexKey := func(c *format.ColumnChunk) []byte {
+		if w.encryption == nil {
+			return nil
+		}
+		switch {
+		case c.CryptoMetadata.EncryptionWithFooterKey != nil:
+			return w.encryption.cfg.FooterKey
+		case c.CryptoMetadata.EncryptionWithColumnKey != nil:
+			return w.encryption.columnKeyFor(columnPathString(c.CryptoMetadata.EncryptionWithColumnKey.PathInSchema))
+		default:
+			return nil
+		}
+	}
+
 	for i, columnIndexes := range w.columnIndexes {
 		rowGroup := &w.rowGroups[i]
 		for j := range columnIndexes {
 			column := &rowGroup.Columns[j]
 			column.ColumnIndexOffset = w.writer.offset
-			if err := encoder.Encode(&columnIndexes[j]); err != nil {
+			if key := pageIndexKey(column); key != nil {
+				var idxBuf bytes.Buffer
+				idxEnc := thrift.NewEncoder(protocol.NewWriter(&idxBuf))
+				if err := idxEnc.Encode(&columnIndexes[j]); err != nil {
+					return err
+				}
+				aad := makeAAD(w.encryption.cfg.AadPrefix, w.encryption.fileUnique, columnIndexModule, int16(i), int16(j))
+				envelope, err := encryptModule(key, aad, idxBuf.Bytes())
+				if err != nil {
+					return fmt.Errorf("encrypting column index: rowGroup=%d col=%d: %w", i, j, err)
+				}
+				if _, err := w.writer.Write(envelope); err != nil {
+					return err
+				}
+			} else if err := encoder.Encode(&columnIndexes[j]); err != nil {
 				return err
 			}
 			column.ColumnIndexLength = int32(w.writer.offset - column.ColumnIndexOffset)
@@ -1233,7 +1267,21 @@ func (w *writer) writeFileFooter() error {
 		for j := range offsetIndexes {
 			column := &rowGroup.Columns[j]
 			column.OffsetIndexOffset = w.writer.offset
-			if err := encoder.Encode(&offsetIndexes[j]); err != nil {
+			if key := pageIndexKey(column); key != nil {
+				var idxBuf bytes.Buffer
+				idxEnc := thrift.NewEncoder(protocol.NewWriter(&idxBuf))
+				if err := idxEnc.Encode(&offsetIndexes[j]); err != nil {
+					return err
+				}
+				aad := makeAAD(w.encryption.cfg.AadPrefix, w.encryption.fileUnique, offsetIndexModule, int16(i), int16(j))
+				envelope, err := encryptModule(key, aad, idxBuf.Bytes())
+				if err != nil {
+					return fmt.Errorf("encrypting offset index: rowGroup=%d col=%d: %w", i, j, err)
+				}
+				if _, err := w.writer.Write(envelope); err != nil {
+					return err
+				}
+			} else if err := encoder.Encode(&offsetIndexes[j]); err != nil {
 				return err
 			}
 			column.OffsetIndexLength = int32(w.writer.offset - column.OffsetIndexOffset)

--- a/writer.go
+++ b/writer.go
@@ -1952,6 +1952,50 @@ func (c *ColumnWriter) flushFilterPages() (err error) {
 		}
 	}()
 
+	// For encrypted columns the page buffer contains AES-GCM envelopes, not
+	// plain thrift.  Decrypt each page before decoding it.
+	if c.encKey != nil {
+		for pageOrd := range int16(c.numPages) {
+			hdrAAD := makeAAD(c.aadPrefix, c.fileUnique, dataPageHeaderModule, c.rowGroupOrdinal, c.columnOrdinal, pageOrd)
+			hdrPlain, err := readDecryptedEnvelopeFrom(pageReader, c.encKey, hdrAAD)
+			if err != nil {
+				return err
+			}
+			header := new(format.PageHeader)
+			pr := c.header.protocol.NewReaderFromBytes(hdrPlain)
+			if err := thrift.NewDecoder(pr).Decode(header); err != nil {
+				return fmt.Errorf("bloom filter: decoding encrypted page header: %w", err)
+			}
+			bodyAAD := makeAAD(c.aadPrefix, c.fileUnique, dataPageBodyModule, c.rowGroupOrdinal, c.columnOrdinal, pageOrd)
+			bodyPlain, err := readDecryptedEnvelopeFrom(pageReader, c.encKey, bodyAAD)
+			if err != nil {
+				return err
+			}
+			if pbuf != nil {
+				pbuf.unref()
+			}
+			pbuf = buffers.get(len(bodyPlain))
+			copy(pbuf.data.Slice(), bodyPlain)
+			pbuf.ref()
+
+			var page Page
+			switch header.Type {
+			case format.DataPage:
+				page, err = column.decodeDataPageV1(DataPageHeaderV1{&header.DataPageHeader.V}, pbuf, nil, header.UncompressedPageSize)
+			case format.DataPageV2:
+				page, err = column.decodeDataPageV2(DataPageHeaderV2{&header.DataPageHeaderV2.V}, pbuf, nil, header.UncompressedPageSize)
+			}
+			if page != nil {
+				err = c.writePageToFilter(page)
+				Release(page)
+			}
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	decoder := thrift.NewDecoder(c.header.protocol.NewReader(pageReader))
 
 	for range c.numPages {

--- a/writer.go
+++ b/writer.go
@@ -1475,6 +1475,17 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 		c.columnChunk.MetaData.BloomFilterLength = int32(bloomFilterLength)
 	}
 
+	// Accumulate row-group byte sizes before any MetaData zeroing below.
+	totalByteSize := int64(0)
+	totalCompressedSize := int64(0)
+
+	for i := range rg.columnChunk {
+		c := &rg.columnChunk[i].MetaData
+		sortPageEncodingStats(c.EncodingStats)
+		totalByteSize += int64(c.TotalUncompressedSize)
+		totalCompressedSize += int64(c.TotalCompressedSize)
+	}
+
 	// Set ColumnCryptoMetaData on each column chunk when encryption is active.
 	if w.encryption != nil {
 		for i, c := range rg.columns {
@@ -1513,16 +1524,6 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 				c.columnChunk.MetaData = format.ColumnMetaData{}
 			}
 		}
-	}
-
-	totalByteSize := int64(0)
-	totalCompressedSize := int64(0)
-
-	for i := range rg.columnChunk {
-		c := &rg.columnChunk[i].MetaData
-		sortPageEncodingStats(c.EncodingStats)
-		totalByteSize += int64(c.TotalUncompressedSize)
-		totalCompressedSize += int64(c.TotalCompressedSize)
 	}
 
 	var reuseRowGroup *format.RowGroup = nil

--- a/writer.go
+++ b/writer.go
@@ -984,6 +984,8 @@ type writer struct {
 
 	fileMetaData format.FileMetaData
 	footer       [8]byte
+
+	encryption *fileEncryptionState // nil when encryption is disabled
 }
 
 type deferredBloomFilter struct {
@@ -1072,7 +1074,31 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 		w.columnOrders[i] = *c.columnType.ColumnOrder()
 	}
 
-	copy(w.footer[4:], "PAR1")
+	if config.Encryption != nil {
+		enc, err := newFileEncryptionState(config.Encryption)
+		if err != nil {
+			// newWriter has no error return; panic here mirrors any other init failure in this function.
+			panic("parquet: " + err.Error())
+		}
+		w.encryption = enc
+		// Configure each column with its encryption key and state.
+		// Row group ordinal starts at 0; it is updated after each row group is committed.
+		for i, c := range w.currentRowGroup.columns {
+			path := columnPathString(c.columnPath)
+			c.encKey = enc.columnKeyFor(path)
+			c.columnOrdinal = int16(i)
+			c.rowGroupOrdinal = 0
+			c.fileUnique = enc.fileUnique
+			c.aadPrefix = enc.cfg.AadPrefix
+		}
+		if config.Encryption.EncryptedFooter {
+			copy(w.footer[4:], "PARE")
+		} else {
+			copy(w.footer[4:], "PAR1")
+		}
+	} else {
+		copy(w.footer[4:], "PAR1")
+	}
 	return w
 }
 
@@ -1139,7 +1165,11 @@ func (w *writer) writeFileHeader() error {
 		return io.ErrClosedPipe
 	}
 	if w.writer.offset == 0 {
-		_, err := w.writer.WriteString("PAR1")
+		magic := "PAR1"
+		if w.encryption != nil && w.encryption.cfg.EncryptedFooter {
+			magic = "PARE"
+		}
+		_, err := w.writer.WriteString(magic)
 		return err
 	}
 	return nil
@@ -1229,6 +1259,78 @@ func (w *writer) writeFileFooter() error {
 		ColumnOrders:     w.columnOrders,
 	}
 
+	if w.encryption != nil {
+		enc := w.encryption
+		algo := format.EncryptionAlgorithm{
+			AesGcmV1: &format.AesGcmV1{
+				AadFileUnique: enc.fileUnique,
+				AadPrefix:     enc.cfg.AadPrefix,
+			},
+		}
+
+		if enc.cfg.EncryptedFooter {
+			// Encrypted footer mode: write FileCryptoMetaData + encrypted footer + size + "PARE".
+			// Thrift-encode the FileMetaData into a buffer, then encrypt it.
+			var footerBuf bytes.Buffer
+			footerEncoder := thrift.NewEncoder(protocol.NewWriter(&footerBuf))
+			if err := footerEncoder.Encode(&w.fileMetaData); err != nil {
+				return err
+			}
+			footerAAD := makeAAD(enc.cfg.AadPrefix, enc.fileUnique, footerModule)
+			encFooter, err := encryptModule(enc.cfg.FooterKey, footerAAD, footerBuf.Bytes())
+			if err != nil {
+				return fmt.Errorf("encrypting footer: %w", err)
+			}
+
+			// Capture offset before writing FileCryptoMetaData so we can compute total size.
+			startOffset := w.writer.offset
+
+			// Write FileCryptoMetaData (plaintext, thrift).
+			cryptoMeta := format.FileCryptoMetaData{EncryptionAlgorithm: algo}
+			if err := encoder.Encode(&cryptoMeta); err != nil {
+				return err
+			}
+			// Write encrypted footer envelope.
+			if _, err := w.writer.Write(encFooter); err != nil {
+				return err
+			}
+			// Footer size = FileCryptoMetaData bytes + encrypted footer bytes.
+			footerLen := w.writer.offset - startOffset
+			binary.LittleEndian.PutUint32(w.footer[:4], uint32(footerLen))
+			_, err = w.writer.Write(w.footer[:])
+			return err
+		}
+
+		// Plaintext footer mode: write FileMetaData with EncryptionAlgorithm set,
+		// then append a 28-byte signature (nonce || GCM tag).
+		w.fileMetaData.EncryptionAlgorithm = algo
+
+		var footerBuf bytes.Buffer
+		footerEncoder := thrift.NewEncoder(protocol.NewWriter(&footerBuf))
+		if err := footerEncoder.Encode(&w.fileMetaData); err != nil {
+			return err
+		}
+		footerBytes := footerBuf.Bytes()
+
+		// Write the plaintext footer to the file.
+		if _, err := w.writer.Write(footerBytes); err != nil {
+			return err
+		}
+		// Compute and append the 28-byte signature.
+		footerAAD := makeAAD(enc.cfg.AadPrefix, enc.fileUnique, footerModule)
+		sig, err := signFooter(enc.cfg.FooterKey, footerAAD, footerBytes)
+		if err != nil {
+			return fmt.Errorf("signing footer: %w", err)
+		}
+		if _, err := w.writer.Write(sig); err != nil {
+			return err
+		}
+		// Footer length = len(footerBytes) + len(sig).
+		binary.LittleEndian.PutUint32(w.footer[:4], uint32(len(footerBytes)+len(sig)))
+		_, err = w.writer.Write(w.footer[:])
+		return err
+	}
+
 	length := w.writer.offset
 	if err := encoder.Encode(&w.fileMetaData); err != nil {
 		return err
@@ -1260,7 +1362,21 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 
 	defer func() {
 		rg.reset()
+		// After reset, update the row group ordinal for the next row group.
+		if w.encryption != nil {
+			nextOrdinal := int16(len(w.rowGroups))
+			for _, c := range rg.columns {
+				c.rowGroupOrdinal = nextOrdinal
+			}
+		}
 	}()
+
+	// Ensure all columns use the correct row group ordinal before flushing final pages.
+	if w.encryption != nil {
+		for _, c := range rg.columns {
+			c.rowGroupOrdinal = int16(rowGroupIndex)
+		}
+	}
 
 	for _, c := range rg.columns {
 		if err := c.Flush(); err != nil {
@@ -1354,6 +1470,25 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 		}
 		bloomFilterLength := w.writer.offset - bloomFilterOffset
 		c.columnChunk.MetaData.BloomFilterLength = int32(bloomFilterLength)
+	}
+
+	// Set ColumnCryptoMetaData on each column chunk when encryption is active.
+	if w.encryption != nil {
+		for _, c := range rg.columns {
+			path := columnPathString(c.columnPath)
+			_, hasColumnKey := w.encryption.cfg.ColumnKeys[path]
+			if !hasColumnKey {
+				c.columnChunk.CryptoMetadata = format.ColumnCryptoMetaData{
+					EncryptionWithFooterKey: &format.EncryptionWithFooterKey{},
+				}
+			} else {
+				c.columnChunk.CryptoMetadata = format.ColumnCryptoMetaData{
+					EncryptionWithColumnKey: &format.EncryptionWithColumnKey{
+						PathInSchema: c.columnPath,
+					},
+				}
+			}
+		}
 	}
 
 	totalByteSize := int64(0)
@@ -1630,6 +1765,13 @@ type ColumnWriter struct {
 	offsetIndex        *format.OffsetIndex
 	hasSwitchedToPlain bool  // Tracks if dictionary encoding was switched to PLAIN
 	dictionaryMaxBytes int64 // Per-column dictionary size limit
+
+	// Encryption state; nil encKey means column is not encrypted.
+	encKey          []byte
+	rowGroupOrdinal int16
+	columnOrdinal   int16
+	fileUnique      []byte
+	aadPrefix       []byte
 
 	totalUnencodedByteArrayBytes  int64
 	repetitionLevelHistogram      []int64
@@ -1926,7 +2068,6 @@ func (c *ColumnWriter) writeValues(values []Value) (numValues int, err error) {
 }
 
 func (c *ColumnWriter) writeBloomFilter(w io.Writer) error {
-	e := thrift.NewEncoder(c.header.protocol.NewWriter(w))
 	h := bloomFilterHeader(c.columnFilter, c.bloomFilterCompression)
 
 	filterBytes := c.filter
@@ -1946,6 +2087,32 @@ func (c *ColumnWriter) writeBloomFilter(w io.Writer) error {
 	}
 
 	h.NumBytes = int32(len(filterBytes))
+
+	if c.encKey != nil {
+		// Encode the bloom filter header to a temp buffer, then encrypt both modules.
+		var hdrBuf bytes.Buffer
+		e := thrift.NewEncoder(c.header.protocol.NewWriter(&hdrBuf))
+		if err := e.Encode(&h); err != nil {
+			return err
+		}
+		hdrAAD := makeAAD(c.aadPrefix, c.fileUnique, bloomFilterHdrModule, c.rowGroupOrdinal, c.columnOrdinal)
+		encHdr, err := encryptModule(c.encKey, hdrAAD, hdrBuf.Bytes())
+		if err != nil {
+			return fmt.Errorf("encrypting bloom filter header: %w", err)
+		}
+		bitsAAD := makeAAD(c.aadPrefix, c.fileUnique, bloomFilterBitsModule, c.rowGroupOrdinal, c.columnOrdinal)
+		encBits, err := encryptModule(c.encKey, bitsAAD, filterBytes)
+		if err != nil {
+			return fmt.Errorf("encrypting bloom filter bitset: %w", err)
+		}
+		if _, err := w.Write(encHdr); err != nil {
+			return err
+		}
+		_, err = w.Write(encBits)
+		return err
+	}
+
+	e := thrift.NewEncoder(c.header.protocol.NewWriter(w))
 	if err := e.Encode(&h); err != nil {
 		return err
 	}
@@ -2038,7 +2205,39 @@ func (c *ColumnWriter) writeDataPage(page Page) (int64, error) {
 		return 0, err
 	}
 
-	size := int64(c.header.buffer.Len()) +
+	plainHeaderLen := int32(c.header.buffer.Len())
+
+	if c.encKey != nil {
+		pageOrd := int16(c.numPages)
+		hdrAAD := makeAAD(c.aadPrefix, c.fileUnique, dataPageHeaderModule, c.rowGroupOrdinal, c.columnOrdinal, pageOrd)
+		encHdr, err := encryptModule(c.encKey, hdrAAD, c.header.buffer.Bytes())
+		if err != nil {
+			return 0, fmt.Errorf("encrypting data page header: %w", err)
+		}
+		body := make([]byte, 0, len(buf.repetitions)+len(buf.definitions)+len(buf.page))
+		body = append(body, buf.repetitions...)
+		body = append(body, buf.definitions...)
+		body = append(body, buf.page...)
+		bodyAAD := makeAAD(c.aadPrefix, c.fileUnique, dataPageBodyModule, c.rowGroupOrdinal, c.columnOrdinal, pageOrd)
+		encBody, err := encryptModule(c.encKey, bodyAAD, body)
+		if err != nil {
+			return 0, fmt.Errorf("encrypting data page body: %w", err)
+		}
+		encSize := int64(len(encHdr) + len(encBody))
+		err = c.writePageTo(encSize, func(output io.Writer) (int64, error) {
+			n1, _ := output.Write(encHdr)
+			n2, werr := output.Write(encBody)
+			return int64(n1 + n2), werr
+		})
+		if err != nil {
+			return 0, err
+		}
+		c.recordPageStats(plainHeaderLen, &c.header.page, page)
+		c.patchEncryptedCompressedSize(encSize, plainHeaderLen, c.header.page.CompressedPageSize)
+		return numValues, nil
+	}
+
+	size := int64(plainHeaderLen) +
 		int64(len(buf.repetitions)) +
 		int64(len(buf.definitions)) +
 		int64(len(buf.page))
@@ -2062,7 +2261,7 @@ func (c *ColumnWriter) writeDataPage(page Page) (int64, error) {
 		return 0, err
 	}
 
-	c.recordPageStats(int32(c.header.buffer.Len()), &c.header.page, page)
+	c.recordPageStats(plainHeaderLen, &c.header.page, page)
 	return numValues, nil
 }
 
@@ -2100,6 +2299,30 @@ func (c *ColumnWriter) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 	if err := c.header.encoder.Encode(&c.header.dict); err != nil {
 		return err
 	}
+
+	if c.encKey != nil {
+		hdrAAD := makeAAD(c.aadPrefix, c.fileUnique, dictPageHeaderModule, c.rowGroupOrdinal, c.columnOrdinal, 0)
+		encHdr, err := encryptModule(c.encKey, hdrAAD, c.header.buffer.Bytes())
+		if err != nil {
+			return fmt.Errorf("encrypting dictionary page header: %w", err)
+		}
+		bodyAAD := makeAAD(c.aadPrefix, c.fileUnique, dictPageBodyModule, c.rowGroupOrdinal, c.columnOrdinal, 0)
+		encBody, err := encryptModule(c.encKey, bodyAAD, buf.page)
+		if err != nil {
+			return fmt.Errorf("encrypting dictionary page body: %w", err)
+		}
+		if _, err := output.Write(encHdr); err != nil {
+			return err
+		}
+		if _, err := output.Write(encBody); err != nil {
+			return err
+		}
+		plainHeaderLen := int32(c.header.buffer.Len())
+		c.recordPageStats(plainHeaderLen, &c.header.dict, nil)
+		c.patchEncryptedCompressedSize(int64(len(encHdr)+len(encBody)), plainHeaderLen, c.header.dict.CompressedPageSize)
+		return nil
+	}
+
 	if _, err := output.Write(c.header.buffer.Bytes()); err != nil {
 		return err
 	}
@@ -2108,6 +2331,17 @@ func (c *ColumnWriter) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 	}
 	c.recordPageStats(int32(c.header.buffer.Len()), &c.header.dict, nil)
 	return nil
+}
+
+// patchEncryptedCompressedSize adjusts the last PageLocation and TotalCompressedSize after
+// recordPageStats to reflect the actual encrypted size on disk instead of the plaintext size.
+func (c *ColumnWriter) patchEncryptedCompressedSize(encSize int64, plainHeaderLen, plainBodyLen int32) {
+	plainTotal := int64(plainHeaderLen) + int64(plainBodyLen)
+	delta := encSize - plainTotal
+	c.columnChunk.MetaData.TotalCompressedSize += delta
+	if n := len(c.offsetIndex.PageLocations); n > 0 {
+		c.offsetIndex.PageLocations[n-1].CompressedPageSize = int32(encSize)
+	}
 }
 
 func (c *ColumnWriter) writePageToFilter(page Page) (err error) {


### PR DESCRIPTION
## Summary

- Implements the [Apache Parquet encryption specification](https://github.com/apache/parquet-format/blob/master/Encryption.md) for AES-GCM authenticated encryption of individual modules (data pages, dict pages, bloom filters, footer)
- Supports both **encrypted-footer mode** (`"PARE"` magic) and **plaintext-footer-with-signature mode** (`"PAR1"` + 28-byte GCM signature)
- Per-column AES keys are supported; columns without a column key fall back to the footer key
- All cryptography uses stdlib only (`crypto/aes`, `crypto/cipher`, `crypto/rand`)

## New API

```go
// Writer side
parquet.WithEncryption(&parquet.EncryptionConfig{
    FooterKey:       []byte{...},           // 16/24/32-byte AES key
    ColumnKeys:      map[string][]byte{...}, // optional per-column keys
    EncryptedFooter: true,                   // true → PARE, false → signed PAR1
})

// Reader side
parquet.WithDecryption(myKeyRetriever) // implements KeyRetriever interface
```

## Wire format

Each encrypted module follows: `4-byte LE length | 12-byte nonce | AES-GCM(plaintext) | 16-byte tag`

AAD per module: `aadPrefix || fileUnique || moduleType [|| rowGroupOrd || colOrd [|| pageOrd]]`

## Test plan

- [x] Round-trip write+read with encrypted footer mode
- [x] Round-trip write+read with plaintext footer + GCM signature
- [x] Per-column keys (some columns use column key, others fall back to footer key)
- [x] Opening encrypted file without `DecryptionConfig` returns an error
- [x] Tampered footer bytes detected via signature verification failure
- [x] All existing tests pass (`go test ./...`)
- [x] Allocation test `TestColumnChunkAllocs` passes (decryption state kept behind a pointer to avoid bloating `FilePages` for non-encrypted reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)