### PR TITLE
feat: add EnablePageStatistics writer option for selective per-column stats

### DIFF
--- a/config.go
+++ b/config.go
@@ -236,6 +236,7 @@ type WriterConfig struct {
 	Sorting                      SortingConfig
 	SkipPageBounds               [][]string
 	SkipPageStatistics           [][]string
+	EnablePageStatistics         [][]string
 	Encodings                    map[Kind]encoding.Encoding
 	DictionaryMaxBytes           int64
 	SchemaConfig                 *SchemaConfig
@@ -315,6 +316,7 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 		Sorting:                      coalesceSortingConfig(c.Sorting, config.Sorting),
 		SkipPageBounds:               coalesceSlices(c.SkipPageBounds, config.SkipPageBounds),
 		SkipPageStatistics:           coalesceSlices(c.SkipPageStatistics, config.SkipPageStatistics),
+		EnablePageStatistics:         coalesceSlices(c.EnablePageStatistics, config.EnablePageStatistics),
 		Encodings:                    encodings,
 		SchemaConfig:                 cmp.Or(c.SchemaConfig, config.SchemaConfig),
 	}
@@ -763,6 +765,14 @@ func SkipPageBounds(path ...string) WriterOption {
 // This option is additive, it may be used multiple times to skip multiple columns.
 func SkipPageStatistics(path ...string) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.SkipPageStatistics = append(config.SkipPageStatistics, path) })
+}
+
+// EnablePageStatistics creates a configuration option which enables page
+// statistics on the column at the given path. This is useful when
+// DataPageStatistics has been set to false globally, but statistics are still
+// desired for specific columns.
+func EnablePageStatistics(path ...string) WriterOption {
+	return writerOption(func(config *WriterConfig) { config.EnablePageStatistics = append(config.EnablePageStatistics, path) })
 }
 
 // DefaultEncodingFor creates a configuration option which sets the default encoding

--- a/writer.go
+++ b/writer.go
@@ -739,9 +739,11 @@ func newConcurrentRowGroupWriter(w *writer, config *WriterConfig) *ConcurrentRow
 			maxDefinitionLevel:     leaf.maxDefinitionLevel,
 			bufferIndex:            int32(leaf.columnIndex),
 			bufferSize:             int32(float64(config.PageBufferSize) * 0.98),
-			writePageStats: config.DataPageStatistics && !slices.ContainsFunc(config.SkipPageStatistics, func(skip []string) bool {
+			writePageStats: (config.DataPageStatistics && !slices.ContainsFunc(config.SkipPageStatistics, func(skip []string) bool {
 				return columnPath(skip).equal(leaf.path)
-			}),
+			})) || (!config.DataPageStatistics && slices.ContainsFunc(config.EnablePageStatistics, func(enable []string) bool {
+				return columnPath(enable).equal(leaf.path)
+			})),
 			writePageBounds: !slices.ContainsFunc(config.SkipPageBounds, func(skip []string) bool {
 				return columnPath(skip).equal(leaf.path)
 			}),

--- a/writer_statistics_test.go
+++ b/writer_statistics_test.go
@@ -555,6 +555,23 @@ func TestSkipPageStatistics(t *testing.T) {
 		}
 	})
 
+	t.Run("enable specific columns when stats globally disabled", func(t *testing.T) {
+		f := writeAndOpen(t,
+			DataPageStatistics(false),
+			EnablePageStatistics("id"),
+		)
+
+		if !hasPageStats(columnStats(t, f, "id")) {
+			t.Error("expected page statistics on column \"id\" (was in EnablePageStatistics)")
+		}
+		if hasPageStats(columnStats(t, f, "name")) {
+			t.Error("expected no page statistics on column \"name\"")
+		}
+		if hasPageStats(columnStats(t, f, "blob")) {
+			t.Error("expected no page statistics on column \"blob\"")
+		}
+	})
+
 	t.Run("verify uncompressed JSON in file", func(t *testing.T) {
 		for _, tt := range []struct {
 			name   string


### PR DESCRIPTION
## Summary

- Adds `EnablePageStatistics(path ...string)` writer option, the complement to the existing `SkipPageStatistics`. Users can now disable stats globally with `DataPageStatistics(false)` and selectively re-enable them for specific columns — useful for large schemas where only a few columns benefit from page-level statistics.
- Adds `EnablePageStatistics` field to `WriterConfig` with proper coalescence in `Merge()`.
- Extends the `writePageStats` logic in `writer.go` to check the enable list when stats are globally disabled.

## Usage

```go
w := parquet.NewWriter(output, schema,
    parquet.DataPageStatistics(false),        // disable all
    parquet.EnablePageStatistics("timestamp"), // re-enable for these
    parquet.EnablePageStatistics("user_id"),
)
```

## Test plan

- Added test case in `TestSkipPageStatistics`: `DataPageStatistics(false)` + `EnablePageStatistics("id")` verifies only `"id"` has stats, other columns do not.
- Existing `TestSkipPageStatistics` subtests continue to pass (no regressions).
