### PR TITLE
Fix optional list element decoding

### DIFF
--- a/parquet_test.go
+++ b/parquet_test.go
@@ -1675,3 +1675,44 @@ func TestIssue40MapValueNestedStruct(t *testing.T) {
 		t.Errorf("data mismatch:\nwant: %+v\ngot:  %+v", input, output)
 	}
 }
+
+func TestReconstructOptionalListElementsAndMapValues(t *testing.T) {
+	type Data struct {
+		RequiredListElements        []int32             `parquet:"required_elements,list"`
+		OptionalListElements        []*int32            `parquet:"optional_elements,list"`
+		RequiredMapValues           map[string]int32    `parquet:"required_map"`
+		OptionalMapValues           map[string]*int32   `parquet:"optional_map"`
+		MapWithOptionalListElements map[string][]*int32 `parquet:"map_with_optional_list_elements" parquet-value:",list"`
+	}
+
+	int1 := int32(1)
+	input := []Data{
+		{
+			RequiredListElements: []int32{1, 2, 3},
+			OptionalListElements: []*int32{&int1, nil, nil},
+			RequiredMapValues:    map[string]int32{"a": 1, "b": 2, "c": 3},
+			OptionalMapValues:    map[string]*int32{"a": &int1, "b": nil, "c": nil},
+			MapWithOptionalListElements: map[string][]*int32{
+				"a": {&int1, nil, nil},
+				"b": {nil, &int1, nil},
+				"c": {nil, nil, &int1},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := parquet.Write(&buf, input); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	data, size := bytes.NewReader(buf.Bytes()), int64(buf.Len())
+
+	output, err := parquet.Read[Data](data, size)
+	if err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
+
+	if !reflect.DeepEqual(input, output) {
+		t.Errorf("data mismatch:\nwant: %+v\ngot:  %+v", input, output)
+	}
+}

--- a/row.go
+++ b/row.go
@@ -583,7 +583,7 @@ func reconstructFuncOf(columnIndex uint16, node Node) (uint16, reconstructFunc) 
 	case node.Optional():
 		return reconstructFuncOfOptional(columnIndex, node)
 	case node.Repeated():
-		return reconstructFuncOfRepeated(columnIndex, node)
+		return reconstructFuncOfRepeated(columnIndex, Required(node))
 	case isList(node):
 		return reconstructFuncOfList(columnIndex, node)
 	case isMap(node):
@@ -648,7 +648,7 @@ func setNullSlice(v reflect.Value) reflect.Value {
 
 //go:noinline
 func reconstructFuncOfRepeated(columnIndex uint16, node Node) (uint16, reconstructFunc) {
-	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node))
+	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, node)
 	return nextColumnIndex, func(value reflect.Value, levels columnLevels, columns [][]Value) error {
 		levels.repetitionDepth++
 		levels.definitionLevel++
@@ -729,93 +729,9 @@ func reconstructFuncOfList(columnIndex uint16, node Node) (uint16, reconstructFu
 	// reconstructFuncOfRepeated would wrap the node with Required() which
 	// hides the Optional property.
 	if elem.Optional() {
-		return reconstructFuncOfRepeatedOptional(columnIndex, elem)
+		return reconstructFuncOfRepeated(columnIndex, elem)
 	}
 	return reconstructFuncOf(columnIndex, Repeated(elem))
-}
-
-// reconstructFuncOfRepeatedOptional handles the case where list elements are optional.
-// This is needed because reconstructFuncOfRepeated uses Required() which hides
-// the Optional property of the inner node.
-//
-//go:noinline
-func reconstructFuncOfRepeatedOptional(columnIndex uint16, node Node) (uint16, reconstructFunc) {
-	// node is Optional(X), get the inner reconstruction for the required version
-	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node))
-
-	return nextColumnIndex, func(value reflect.Value, levels columnLevels, columns [][]Value) error {
-		// Increment both for the repeated and optional levels
-		levels.repetitionDepth++
-		levels.definitionLevel += 2 // +1 for repeated, +1 for optional
-
-		// Handle empty groups (no columns)
-		if len(columns) == 0 || len(columns[0]) == 0 {
-			setMakeSlice(value, 0)
-			return nil
-		}
-
-		// Check if the list itself is null (definition level less than the repeated level)
-		// We need to check against (levels.definitionLevel - 1) because that's the repeated level
-		if columns[0][0].definitionLevel < levels.definitionLevel-1 {
-			setMakeSlice(value, 0)
-			return nil
-		}
-
-		values := make([][]Value, len(columns))
-		column := columns[0]
-		n := 0
-
-		for i, column := range columns {
-			values[i] = column[0:0:len(column)]
-		}
-
-		for i := 0; i < len(column); {
-			i++
-			n++
-
-			for i < len(column) && column[i].repetitionLevel > levels.repetitionDepth {
-				i++
-			}
-		}
-
-		value = setMakeSlice(value, n)
-
-		for i := range n {
-			for j, column := range values {
-				column = column[:cap(column)]
-				if len(column) == 0 {
-					continue
-				}
-
-				k := 1
-				for k < len(column) && column[k].repetitionLevel > levels.repetitionDepth {
-					k++
-				}
-
-				values[j] = column[:k]
-			}
-
-			// Check if this element is null (definition level indicates null)
-			// An element is null if its definition level is less than the max (which includes optional)
-			elemValue := value.Index(i)
-			if len(values) > 0 && len(values[0]) > 0 && values[0][0].definitionLevel < levels.definitionLevel {
-				// Element is null, leave as zero value
-				elemValue.SetZero()
-			} else {
-				if err := reconstruct(elemValue, levels, values); err != nil {
-					return err
-				}
-			}
-
-			for j, column := range values {
-				values[j] = column[len(column):len(column):cap(column)]
-			}
-
-			levels.repetitionLevel = levels.repetitionDepth
-		}
-
-		return nil
-	}
 }
 
 //go:noinline


### PR DESCRIPTION
Previously the `TestReconstructOptionalListElementsAndMapValues` test would fail for the `OptionalListElements []*int32` field due to 

```
panic: reflect.Set: value of type int32 is not assignable to type *int32
```

because this line
```
nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node))
```
drops the optionality of the element node.

This PR fix the above by preserving the optional node wrapper for list elements during reconstruction. As part of this I've also unified the handling of repeated fields and list field to both use `reconstructFuncOfRepeated` and moved the required node wrapping to the call site, but let me know if this is confusing.