### PR TITLE
Fix optional list element writing for generic writer reflection path

### DIFF
--- a/column_buffer_reflect.go
+++ b/column_buffer_reflect.go
@@ -489,8 +489,7 @@ func writeValueFuncOfRequired(columnIndex uint16, node Node) (uint16, writeValue
 
 func writeValueFuncOfList(columnIndex uint16, node Node) (uint16, writeValueFunc) {
 	elem := listElementOf(node)
-	// Preserve optionality of list elements when writing via reflect paths
-	// (e.g. GenericWriter[any] with []*T list elements).
+	// Preserve optionality of list elements when writing via reflection paths.
 	if elem.Optional() {
 		return writeValueFuncOfRepeated(columnIndex, elem)
 	}

--- a/column_buffer_reflect.go
+++ b/column_buffer_reflect.go
@@ -325,7 +325,7 @@ func writeValueFuncOf(columnIndex uint16, node Node) (uint16, writeValueFunc) {
 	case node.Optional():
 		return writeValueFuncOfOptional(columnIndex, node)
 	case node.Repeated():
-		return writeValueFuncOfRepeated(columnIndex, node)
+		return writeValueFuncOfRepeated(columnIndex, Required(node))
 	case isList(node):
 		return writeValueFuncOfList(columnIndex, node)
 	case isMap(node):
@@ -350,7 +350,7 @@ func writeValueFuncOfOptional(columnIndex uint16, node Node) (uint16, writeValue
 }
 
 func writeValueFuncOfRepeated(columnIndex uint16, node Node) (uint16, writeValueFunc) {
-	nextColumnIndex, writeValue := writeValueFuncOf(columnIndex, Required(node))
+	nextColumnIndex, writeValue := writeValueFuncOf(columnIndex, node)
 	return nextColumnIndex, func(columns []ColumnBuffer, levels columnLevels, value reflect.Value) {
 	writeRepatedValue:
 		if !value.IsValid() {
@@ -488,7 +488,13 @@ func writeValueFuncOfRequired(columnIndex uint16, node Node) (uint16, writeValue
 }
 
 func writeValueFuncOfList(columnIndex uint16, node Node) (uint16, writeValueFunc) {
-	return writeValueFuncOf(columnIndex, Repeated(listElementOf(node)))
+	elem := listElementOf(node)
+	// Preserve optionality of list elements when writing via reflect paths
+	// (e.g. GenericWriter[any] with []*T list elements).
+	if elem.Optional() {
+		return writeValueFuncOfRepeated(columnIndex, elem)
+	}
+	return writeValueFuncOf(columnIndex, Repeated(elem))
 }
 
 func writeValueFuncOfMap(columnIndex uint16, node Node) (uint16, writeValueFunc) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -4144,3 +4144,46 @@ func TestIssue472DataPageV2DictCompression(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteOptionalListWithGenericWriterReflectionPath(t *testing.T) {
+	type Row struct {
+		OptionalList []*string `parquet:"optional_list,list"`
+	}
+
+	var (
+		numRows      = 50
+		expectedRows = make([]Row, 0, numRows)
+		inputs       = make([]any, 0, numRows)
+	)
+
+	for i := range numRows {
+		var row Row
+		if i%2 == 0 {
+			row = Row{OptionalList: []*string{nil}}
+		} else {
+			value := fmt.Sprintf("value_%d", i)
+			row = Row{OptionalList: []*string{&value}}
+		}
+		expectedRows = append(expectedRows, row)
+		inputs = append(inputs, row)
+	}
+
+	var buf bytes.Buffer
+	writer := parquet.NewGenericWriter[any](&buf, parquet.SchemaOf(Row{}))
+	if _, err := writer.Write(inputs); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close writer: %v", err)
+	}
+	data, size := bytes.NewReader(buf.Bytes()), int64(buf.Len())
+
+	output, err := parquet.Read[Row](data, size)
+	if err != nil {
+		t.Fatalf("failed to read: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedRows, output) {
+		t.Errorf("data mismatch:\nwant: %+v\ngot:  %+v", expectedRows, output)
+	}
+}


### PR DESCRIPTION
The issue is that today writing an optional list field with the [generic writer's reflection path](https://github.com/parquet-go/parquet-go/blob/main/writer.go#L137-L151) will result in a column that contains only nulls. This is because the optionality of the list element is lost during writing, and as such the definition levels weren't being incremented correctly. The fix is pretty similar to the one in https://github.com/parquet-go/parquet-go/pull/513, which is to add the required node wrapper only for true repeated fields.