### PR TITLE
Add support to write Parquet files with NULL type columns (#517)

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -136,6 +136,7 @@ func (col *reversedColumnBuffer) Less(i, j int) bool { return col.ColumnBuffer.L
 var (
 	_ ColumnBuffer = (*optionalColumnBuffer)(nil)
 	_ ColumnBuffer = (*repeatedColumnBuffer)(nil)
+	_ ColumnBuffer = (*nullColumnBuffer)(nil)
 	_ ColumnBuffer = (*booleanColumnBuffer)(nil)
 	_ ColumnBuffer = (*int32ColumnBuffer)(nil)
 	_ ColumnBuffer = (*int64ColumnBuffer)(nil)

--- a/column_buffer_null.go
+++ b/column_buffer_null.go
@@ -1,0 +1,114 @@
+package parquet
+
+import (
+	"io"
+
+	"github.com/parquet-go/parquet-go/deprecated"
+	"github.com/parquet-go/parquet-go/sparse"
+)
+
+type nullColumnBuffer struct{ nullPage }
+
+func newNullColumnBuffer(typ Type, columnIndex uint16, numValues int32) *nullColumnBuffer {
+	return &nullColumnBuffer{
+		nullPage: nullPage{
+			typ:    typ,
+			column: int(columnIndex),
+			count:  int(numValues),
+		},
+	}
+}
+
+func (col *nullColumnBuffer) Clone() ColumnBuffer {
+	cloned := &nullColumnBuffer{
+		nullPage: nullPage{
+			typ:    col.typ,
+			column: col.column,
+			count:  col.count,
+		},
+	}
+	return cloned
+}
+
+func (col *nullColumnBuffer) ColumnIndex() (ColumnIndex, error) { return nil, nil }
+
+func (col *nullColumnBuffer) OffsetIndex() (OffsetIndex, error) { return nil, nil }
+
+func (col *nullColumnBuffer) BloomFilter() BloomFilter { return nil }
+
+func (col *nullColumnBuffer) Pages() Pages { return onePage(col.Page()) }
+
+func (col *nullColumnBuffer) Page() Page { return &col.nullPage }
+
+func (col *nullColumnBuffer) Reset() { col.nullPage.count = 0 }
+
+func (col *nullColumnBuffer) Cap() int { return col.nullPage.count }
+
+func (col *nullColumnBuffer) Len() int { return col.nullPage.count }
+
+func (col *nullColumnBuffer) Less(i, j int) bool { return false }
+
+func (col *nullColumnBuffer) Swap(i, j int) {}
+
+func (col *nullColumnBuffer) Size() int64 { return 0 }
+
+func (col *nullColumnBuffer) WriteValues(values []Value) (int, error) {
+	col.writeValues(columnLevels{}, makeArrayValue(values, 0))
+	return len(values), nil
+}
+
+func (col *nullColumnBuffer) writeValues(_ columnLevels, rows sparse.Array) {
+	col.nullPage.count += rows.Len()
+}
+
+func (col *nullColumnBuffer) writeBoolean(_ columnLevels, _ bool) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) writeInt32(_ columnLevels, _ int32) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) writeInt64(_ columnLevels, _ int64) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) writeInt96(_ columnLevels, _ deprecated.Int96) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) writeFloat(_ columnLevels, _ float32) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) writeDouble(_ columnLevels, _ float64) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) writeByteArray(_ columnLevels, _ []byte) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) writeNull(_ columnLevels) {
+	col.nullPage.count++
+}
+
+func (col *nullColumnBuffer) ReadValuesAt(values []Value, offset int64) (n int, err error) {
+	i := int(offset)
+	switch {
+	case i < 0:
+		return 0, errRowIndexOutOfBounds(offset, int64(col.nullPage.count))
+	case i >= int(col.nullPage.count):
+		return 0, io.EOF
+	default:
+		for n < len(values) && i < int(col.nullPage.count) {
+			values[n] = Value{columnIndex: ^uint16(col.nullPage.column)}
+			n++
+			i++
+		}
+		if n < len(values) {
+			err = io.EOF
+		}
+		return n, err
+	}
+}

--- a/column_buffer_null_test.go
+++ b/column_buffer_null_test.go
@@ -1,0 +1,175 @@
+package parquet_test
+
+import (
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+func TestNullColumnBuffer(t *testing.T) {
+	// Create a null type
+	nullType := parquet.NullType
+
+	// Create a column buffer
+	columnIndex := 0
+	buffer := nullType.NewColumnBuffer(columnIndex, 0)
+
+	// Test Type
+	if buffer.Type() != nullType {
+		t.Errorf("Type() = %v, want %v", buffer.Type(), nullType)
+	}
+
+	// Test Column
+	if buffer.Column() != columnIndex {
+		t.Errorf("Column() = %d, want %d", buffer.Column(), columnIndex)
+	}
+
+	// Test Dictionary
+	if buffer.Dictionary() != nil {
+		t.Errorf("Dictionary() = %v, want nil", buffer.Dictionary())
+	}
+
+	// Test initial Len
+	if buffer.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", buffer.Len())
+	}
+
+	// Test initial Cap
+	if buffer.Cap() != 0 {
+		t.Errorf("Cap() = %d, want 0", buffer.Cap())
+	}
+
+	// Test Size
+	if buffer.Size() != 0 {
+		t.Errorf("Size() = %d, want 0", buffer.Size())
+	}
+
+	// Test WriteValues
+	values := make([]parquet.Value, 5)
+	for i := range values {
+		values[i] = parquet.NullValue()
+	}
+	n, err := buffer.WriteValues(values)
+	if err != nil {
+		t.Fatalf("WriteValues() error = %v", err)
+	}
+	if n != 5 {
+		t.Errorf("WriteValues() = %d, want 5", n)
+	}
+
+	// Test Len after WriteValues
+	if buffer.Len() != 5 {
+		t.Errorf("Len() after WriteValues = %d, want 5", buffer.Len())
+	}
+
+	// Test Clone
+	cloned := buffer.Clone()
+	if cloned.Type() != nullType {
+		t.Errorf("Clone().Type() = %v, want %v", cloned.Type(), nullType)
+	}
+	if cloned.Len() != buffer.Len() {
+		t.Errorf("Clone().Len() = %d, want %d", cloned.Len(), buffer.Len())
+	}
+
+	// Test Reset
+	buffer.Reset()
+	if buffer.Len() != 0 {
+		t.Errorf("Len() after Reset = %d, want 0", buffer.Len())
+	}
+
+	// Write some values to test Page and Pages
+	values2 := make([]parquet.Value, 3)
+	for i := range values2 {
+		values2[i] = parquet.NullValue()
+	}
+	buffer.WriteValues(values2)
+
+	// Test Page
+	page := buffer.Page()
+	if page.Type() != nullType {
+		t.Errorf("Page().Type() = %v, want %v", page.Type(), nullType)
+	}
+	if page.NumValues() != 3 {
+		t.Errorf("Page().NumValues() = %d, want 3", page.NumValues())
+	}
+
+	// Test Pages
+	pages := buffer.Pages()
+	page2, err := pages.ReadPage()
+	if err != nil {
+		t.Fatalf("Pages().ReadPage() error = %v", err)
+	}
+	if page2.Type() != nullType {
+		t.Errorf("Pages().ReadPage().Type() = %v, want %v", page2.Type(), nullType)
+	}
+}
+
+func TestNullColumnBufferReadValuesAt(t *testing.T) {
+	nullType := parquet.NullType
+	buffer := nullType.NewColumnBuffer(0, 0)
+
+	// Write some values
+	values := make([]parquet.Value, 3)
+	for i := range values {
+		values[i] = parquet.NullValue()
+	}
+	buffer.WriteValues(values)
+
+	// Read them back
+	readValues := make([]parquet.Value, 3)
+	n, err := buffer.ReadValuesAt(readValues, 0)
+	if err != nil {
+		t.Fatalf("ReadValuesAt() error = %v", err)
+	}
+	if n != 3 {
+		t.Errorf("ReadValuesAt() = %d, want 3", n)
+	}
+
+	// Check all values are null
+	for i := range readValues {
+		if !readValues[i].IsNull() {
+			t.Errorf("readValues[%d].IsNull() = false, want true", i)
+		}
+	}
+
+	// Test reading beyond bounds
+	readValues2 := make([]parquet.Value, 1)
+	_, err = buffer.ReadValuesAt(readValues2, 3)
+	if err == nil {
+		t.Error("ReadValuesAt() at offset 3 should return error, got nil")
+	}
+
+	// Test reading with offset
+	readValues3 := make([]parquet.Value, 2)
+	n, err = buffer.ReadValuesAt(readValues3, 1)
+	if err != nil {
+		t.Fatalf("ReadValuesAt() with offset 1 error = %v", err)
+	}
+	if n != 2 {
+		t.Errorf("ReadValuesAt() with offset 1 = %d, want 2", n)
+	}
+}
+
+func TestNullColumnBufferLessAndSwap(t *testing.T) {
+	nullType := parquet.NullType
+	buffer := nullType.NewColumnBuffer(0, 0)
+
+	// Write some values
+	values := make([]parquet.Value, 3)
+	for i := range values {
+		values[i] = parquet.NullValue()
+	}
+	buffer.WriteValues(values)
+
+	// Test Less - all nulls are equal
+	if buffer.Less(0, 1) {
+		t.Error("Less(0, 1) = true, want false")
+	}
+	if buffer.Less(1, 0) {
+		t.Error("Less(1, 0) = true, want false")
+	}
+
+	// Test Swap - should not panic
+	buffer.Swap(0, 2)
+	// No way to verify swap worked since all values are null, but it shouldn't panic
+}

--- a/column_index.go
+++ b/column_index.go
@@ -752,3 +752,23 @@ func boundaryOrderOf(minOrder, maxOrder int) format.BoundaryOrder {
 	}
 	return format.Unordered
 }
+
+type nullColumnIndexer struct {
+	baseColumnIndexer
+}
+
+func newNullColumnIndexer() *nullColumnIndexer {
+	return new(nullColumnIndexer)
+}
+
+func (i *nullColumnIndexer) Reset() {
+	i.reset()
+}
+
+func (i *nullColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+}
+
+func (i *nullColumnIndexer) ColumnIndex() format.ColumnIndex {
+	return i.columnIndex(nil, nil, 0, 0)
+}

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1485,6 +1486,83 @@ func TestReadFileWithNullColumns(t *testing.T) {
 
 	if !reflect.DeepEqual(rows, expected) {
 		t.Errorf("rows mismatch:\nwant: %+v\ngot:  %+v", expected, rows)
+	}
+}
+
+// TestWriteFileWithNullColumns tests writing parquet files with NULL-type columns.
+// This test verifies the fix for the issue where parquet-go could read NULL-type columns
+// (from PyArrow-generated files) but could not write them.
+//
+// Reproduces: https://github.com/parquet-go/parquet-go/issues/517
+func TestWriteFileWithNullColumns(t *testing.T) {
+	// Read the existing test file with NULL columns
+	rows, err := parquet.ReadFile[any]("testdata/null_columns.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []any{
+		map[string]any{"name": "test1", "value": nil},
+		map[string]any{"name": "test2", "value": nil},
+		map[string]any{"name": "test3", "value": nil},
+		map[string]any{"name": "test4", "value": nil},
+	}
+
+	if !reflect.DeepEqual(rows, expected) {
+		t.Errorf("rows mismatch:\nwant: %+v\ngot:  %+v", expected, rows)
+	}
+
+	// Write the rows back to a new file using the original schema
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "output.parquet")
+
+	// We need to get the schema from the original file to preserve the NULL-type column
+	f, err := os.Open("testdata/null_columns.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := parquet.OpenFile(f, stat.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	schema := file.Schema()
+
+	out, err := os.Create(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer out.Close()
+
+	writer := parquet.NewWriter(out, schema)
+	defer writer.Close()
+
+	// Write all rows
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back the written file to verify
+	writtenRows, err := parquet.ReadFile[any](outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(writtenRows, expected) {
+		t.Errorf("written rows mismatch:\nwant: %+v\ngot:  %+v", expected, writtenRows)
 	}
 }
 

--- a/type.go
+++ b/type.go
@@ -239,6 +239,7 @@ var (
 	FloatType     Type = floatType{}
 	DoubleType    Type = doubleType{}
 	ByteArrayType Type = byteArrayType{}
+	NullType      Type = &nullType{}
 )
 
 // In the current parquet version supported by this library, only type-defined

--- a/type_null.go
+++ b/type_null.go
@@ -24,24 +24,28 @@ func (t *nullType) EstimateNumValues(int) int { return 0 }
 
 func (t *nullType) Compare(Value, Value) int { panic("cannot compare values on parquet NULL type") }
 
-func (t *nullType) ColumnOrder() *format.ColumnOrder { return nil }
+func (t *nullType) ColumnOrder() *format.ColumnOrder { return &typeDefinedColumnOrder }
 
-func (t *nullType) PhysicalType() *format.Type { return nil }
+// PhysicalType returns INT32 for NULL-type columns to match the convention used
+// by PyArrow and other Parquet implementations. PyArrow generates parquet files
+// where columns filled entirely with NULL values use INT32 as the physical type
+// with UNKNOWN as the logical type.
+func (t *nullType) PhysicalType() *format.Type { return &physicalTypes[Int32] }
 
 func (t *nullType) LogicalType() *format.LogicalType { return &nullLogicalType }
 
 func (t *nullType) ConvertedType() *deprecated.ConvertedType { return nil }
 
 func (t *nullType) NewColumnIndexer(int) ColumnIndexer {
-	panic("create create column indexer from parquet NULL type")
+	return newNullColumnIndexer()
 }
 
 func (t *nullType) NewDictionary(columnIndex, numValues int, data encoding.Values) Dictionary {
 	return newNullDictionary(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
 }
 
-func (t *nullType) NewColumnBuffer(int, int) ColumnBuffer {
-	panic("cannot create column buffer from parquet NULL type")
+func (t *nullType) NewColumnBuffer(columnIndex, numValues int) ColumnBuffer {
+	return newNullColumnBuffer(t, uint16(columnIndex), int32(numValues))
 }
 
 func (t *nullType) NewPage(columnIndex, numValues int, _ encoding.Values) Page {


### PR DESCRIPTION
The PR fixes #517 by adding support to write Parquet files with NULL logical type columns.

Changes:

- Adds nullColumnBuffer implementing the ColumnBuffer interface for NULL columns
- Adds nullColumnIndexer implementing the ColumnIndexer interface for NULL columns
- Implements NewColumnBuffer, NewColumnIndexer on nullType to return working instances
- Sets PhysicalType() to INT32 and ColumnOrder() to type-defined order (following pyarrow spec)
- Exports NullType variable for external use
- Adds test coverage for writing files with NULL columns