### PR TITLE
fix: zero trailing bits in boolean column buffer writes (#520)

### DIFF
--- a/column_buffer_boolean.go
+++ b/column_buffer_boolean.go
@@ -153,6 +153,7 @@ func (col *booleanColumnBuffer) writeValues(_ columnLevels, rows sparse.Array) {
 	}
 
 	col.bits.Resize(bitpack.ByteCount(uint(col.numValues)))
+	col.clearTrailingBits()
 }
 
 func (col *booleanColumnBuffer) writeBoolean(levels columnLevels, value bool) {
@@ -170,6 +171,20 @@ func (col *booleanColumnBuffer) writeBoolean(levels columnLevels, value bool) {
 	}
 	bits[x] = (bit << y) | (bits[x] & ^(1 << y))
 	col.numValues++
+	col.clearTrailingBits()
+}
+
+// clearTrailingBits zeros bit positions beyond numValues in the last byte of
+// the bit-packed buffer. SliceBuffer growth does not zero new bytes, so a
+// partial trailing byte can otherwise leak stale pool memory and produce
+// non-deterministic encoded output (https://github.com/parquet-go/parquet-go/issues/520).
+func (col *booleanColumnBuffer) clearTrailingBits() {
+	extra := uint(col.numValues) % 8
+	if extra == 0 {
+		return
+	}
+	bits := col.bits.Slice()
+	bits[len(bits)-1] &= byte(1<<extra) - 1
 }
 
 func (col *booleanColumnBuffer) writeInt32(levels columnLevels, value int32) {

--- a/column_buffer_boolean_test.go
+++ b/column_buffer_boolean_test.go
@@ -1,6 +1,8 @@
 package parquet
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"math"
 	"testing"
 )
@@ -231,6 +233,90 @@ func TestColumnBufferBooleanEdgeCases(t *testing.T) {
 			t.Errorf("expected negative float to be true")
 		}
 	})
+}
+
+// TestIssue520BooleanDeterministicTrailingBits verifies that writing a
+// non-multiple-of-8 number of booleans produces deterministic bytes even when
+// the underlying SliceBuffer carries stale memory from a pool.
+// Issue: https://github.com/parquet-go/parquet-go/issues/520
+func TestIssue520BooleanDeterministicTrailingBits(t *testing.T) {
+	contaminate := func(col *booleanColumnBuffer) {
+		col.bits.Grow(8)
+		col.bits.Resize(8)
+		slice := col.bits.Slice()
+		for i := range slice {
+			slice[i] = 0xFF
+		}
+		col.bits.Resize(0)
+	}
+
+	t.Run("WriteBooleans", func(t *testing.T) {
+		col := newBooleanColumnBuffer(BooleanType, 0, 0)
+		contaminate(col)
+		if _, err := col.WriteBooleans([]bool{true, true, true, true}); err != nil {
+			t.Fatal(err)
+		}
+		got := col.bits.Slice()
+		want := []byte{0x0F}
+		if !bytes.Equal(got, want) {
+			t.Errorf("bits = % x, want % x", got, want)
+		}
+	})
+
+	t.Run("writeBoolean", func(t *testing.T) {
+		col := newBooleanColumnBuffer(BooleanType, 0, 0)
+		contaminate(col)
+		for range 4 {
+			col.writeBoolean(columnLevels{}, true)
+		}
+		got := col.bits.Slice()
+		want := []byte{0x0F}
+		if !bytes.Equal(got, want) {
+			t.Errorf("bits = % x, want % x", got, want)
+		}
+	})
+}
+
+// TestIssue520WriterByteDeterminism mirrors the reproducer from the issue:
+// the same 4-row boolean column written N times must produce byte-identical
+// Parquet files.
+func TestIssue520WriterByteDeterminism(t *testing.T) {
+	type Row struct {
+		N      int32 `parquet:"n"`
+		Retain bool  `parquet:"retain"`
+	}
+
+	rows := []Row{
+		{N: 1, Retain: true},
+		{N: 2, Retain: true},
+		{N: 3, Retain: true},
+		{N: 4, Retain: true},
+	}
+
+	n := 500
+	if testing.Short() {
+		n = 50
+	}
+
+	hashes := map[[32]byte]int{}
+	for range n {
+		var buf bytes.Buffer
+		w := NewGenericWriter[Row](&buf)
+		if _, err := w.Write(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		hashes[sha256.Sum256(buf.Bytes())]++
+	}
+
+	if len(hashes) != 1 {
+		t.Errorf("expected 1 distinct hash across %d runs, got %d", n, len(hashes))
+		for h, c := range hashes {
+			t.Logf("  %x ×%d", h, c)
+		}
+	}
 }
 
 // TestIssue406BooleanDictionaryLookup tests that boolean dictionary lookup correctly


### PR DESCRIPTION
## Summary
- Fixes #520: boolean column writes whose row count is not a multiple of 8 leaked stale bytes from the pool-backed `SliceBuffer` into the high bits of the final bit-packed byte, producing non-deterministic Parquet output at a low (~0.6%) rate.
- Root cause: `booleanColumnBuffer.writeValues` / `writeBoolean` only OR'd individual bits into the partial trailing byte and never zeroed the unused high bits, so anything the pool returned in those positions flowed straight into the encoded page (and page CRC).
- Fix: add `clearTrailingBits` and call it at the end of both write paths so the partial byte is deterministic regardless of pool state. `sparse.GatherBits` fully overwrites whole bytes and is unaffected; `setValueAt` only touches positions `< numValues` and is unaffected.

## Test plan
- [x] New `TestIssue520BooleanDeterministicTrailingBits` contaminates the underlying `SliceBuffer` with `0xFF` then writes 4 booleans and asserts the byte is `0x0F`. Covers both `WriteBooleans` (bulk path) and per-value `writeBoolean`. Verified failing without the fix (`bits = ff, want 0f`).
- [x] New `TestIssue520WriterByteDeterminism` mirrors the reproducer from the issue: writes a 4-row schema with a `bool` column N times (500, or 50 under `-short`) and asserts a single SHA-256 across all runs.
- [x] `make test` (race + cover) green across all packages.
- [x] `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)