### PR TITLE
fix: restore zero-value-as-null for optional value-type columns

### DIFF
--- a/column_buffer_reflect.go
+++ b/column_buffer_reflect.go
@@ -33,13 +33,13 @@ import (
 )
 
 // isNullValue determines if a reflect.Value represents a null value for parquet encoding.
-// Only nil-able types can be null:
+// This handles various types that can represent null including:
 // - Invalid reflect values
 // - Nil pointers/interfaces/slices/maps
 // - json.RawMessage containing "null"
 // - *jsonlite.Value with Kind == jsonlite.Null
 // - *structpb.Value with NullValue kind
-// Value types (bool, int, float, string, struct, etc.) are never null.
+// - Zero values for value types (bool, int, float, string, struct, etc.)
 func isNullValue(value reflect.Value) bool {
 	switch value.Kind() {
 	case reflect.Invalid:
@@ -71,7 +71,7 @@ func isNullValue(value reflect.Value) bool {
 		return value.IsNil()
 
 	default:
-		return false
+		return value.IsZero()
 	}
 }
 
@@ -609,12 +609,7 @@ func writeValueFuncOfGroup(columnIndex uint16, node Node) (uint16, writeValueFun
 				v := new(string)
 				for i := range writers {
 					w := &writers[i]
-					s, ok := m[w.fieldName]
-					if !ok {
-						w.writeValue(columns, levels, reflect.Value{})
-						continue
-					}
-					*v = s
+					*v = m[w.fieldName]
 					w.writeValue(columns, levels, reflect.ValueOf(v).Elem())
 				}
 

--- a/column_buffer_reflect_test.go
+++ b/column_buffer_reflect_test.go
@@ -2,6 +2,7 @@ package parquet
 
 import (
 	"bytes"
+	"io"
 	"reflect"
 	"testing"
 	"time"
@@ -98,14 +99,19 @@ func TestWriteValueFuncOfOptional(t *testing.T) {
 		{
 			name:       "zero value",
 			value:      int32(0),
-			expectNull: false,
-			expected:   int32(0),
+			expectNull: true,
 		},
 		{
 			name:       "non zero value",
 			value:      int32(42),
 			expectNull: false,
 			expected:   int32(42),
+		},
+		{
+			name:       "pointer to zero value",
+			value:      ptrTo(int32(0)),
+			expectNull: false,
+			expected:   int32(0),
 		},
 	}
 
@@ -178,10 +184,9 @@ func TestWriteValueFuncOfOptionalGroup(t *testing.T) {
 		{
 			name:        "empty id",
 			value:       Record{Point: &Point{X: 3.5, Y: 4.5}, ID: ""},
-			expectNulls: [3]bool{false, false, false},
+			expectNulls: [3]bool{false, false, true},
 			expectX:     3.5,
 			expectY:     4.5,
-			expectID:    "",
 		},
 	}
 
@@ -1997,9 +2002,10 @@ func TestGenericWriterAnyPointerVsOptionalTag(t *testing.T) {
 	}
 }
 
-// TestWriteOptionalZeroValuesAreNotNull verifies that zero values of value types
-// are written as values (not null) for optional columns.
-func TestWriteOptionalZeroValuesAreNotNull(t *testing.T) {
+// TestWriteOptionalZeroValues verifies the nullability of optional columns:
+// value-type zeros are written as null, non-nil pointers to zero values are
+// written as non-null values, and nil pointers are written as null.
+func TestWriteOptionalZeroValues(t *testing.T) {
 	tests := []struct {
 		name       string
 		schema     Node
@@ -2011,43 +2017,37 @@ func TestWriteOptionalZeroValuesAreNotNull(t *testing.T) {
 			name:       "bool false",
 			schema:     Optional(Leaf(BooleanType)),
 			value:      false,
-			expectNull: false,
-			expected:   false,
+			expectNull: true,
 		},
 		{
 			name:       "int32 zero",
 			schema:     Optional(Leaf(Int32Type)),
 			value:      int32(0),
-			expectNull: false,
-			expected:   int32(0),
+			expectNull: true,
 		},
 		{
 			name:       "int64 zero",
 			schema:     Optional(Leaf(Int64Type)),
 			value:      int64(0),
-			expectNull: false,
-			expected:   int64(0),
+			expectNull: true,
 		},
 		{
 			name:       "float32 zero",
 			schema:     Optional(Leaf(FloatType)),
 			value:      float32(0),
-			expectNull: false,
-			expected:   float32(0),
+			expectNull: true,
 		},
 		{
 			name:       "float64 zero",
 			schema:     Optional(Leaf(DoubleType)),
 			value:      float64(0),
-			expectNull: false,
-			expected:   float64(0),
+			expectNull: true,
 		},
 		{
 			name:       "empty string",
 			schema:     Optional(Leaf(ByteArrayType)),
 			value:      "",
-			expectNull: false,
-			expected:   "",
+			expectNull: true,
 		},
 		{
 			name:       "empty byte slice",
@@ -2101,10 +2101,11 @@ func TestWriteOptionalZeroValuesAreNotNull(t *testing.T) {
 	}
 }
 
-// TestGenericWriterStructOptionalZeroValues is an end-to-end test that writes a struct
-// with all zero-valued optional fields and verifies they are present (not null).
+// TestGenericWriterStructOptionalZeroValues is an end-to-end test verifying
+// that zero-valued optional value-type fields are written as null, while
+// non-nil pointers to zero values are written as non-null.
 func TestGenericWriterStructOptionalZeroValues(t *testing.T) {
-	type Record struct {
+	type ValueRecord struct {
 		Bool    bool    `parquet:"bool,optional"`
 		Int32   int32   `parquet:"int32,optional"`
 		Int64   int64   `parquet:"int64,optional"`
@@ -2112,55 +2113,6 @@ func TestGenericWriterStructOptionalZeroValues(t *testing.T) {
 		Float64 float64 `parquet:"float64,optional"`
 		String  string  `parquet:"string,optional"`
 	}
-
-	// Write zero values
-	buf := new(bytes.Buffer)
-	writer := NewGenericWriter[Record](buf)
-	_, err := writer.Write([]Record{{
-		Bool:    false,
-		Int32:   0,
-		Int64:   0,
-		Float32: 0,
-		Float64: 0,
-		String:  "",
-	}})
-	if err != nil {
-		t.Fatalf("error writing: %v", err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatalf("error closing writer: %v", err)
-	}
-
-	// Read back as structs
-	rows, err := Read[Record](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-	if err != nil {
-		t.Fatalf("error reading: %v", err)
-	}
-	if len(rows) != 1 {
-		t.Fatalf("expected 1 row, got %d", len(rows))
-	}
-
-	row := rows[0]
-	if row.Bool != false {
-		t.Errorf("Bool: expected false, got %v", row.Bool)
-	}
-	if row.Int32 != 0 {
-		t.Errorf("Int32: expected 0, got %v", row.Int32)
-	}
-	if row.Int64 != 0 {
-		t.Errorf("Int64: expected 0, got %v", row.Int64)
-	}
-	if row.Float32 != 0 {
-		t.Errorf("Float32: expected 0, got %v", row.Float32)
-	}
-	if row.Float64 != 0 {
-		t.Errorf("Float64: expected 0, got %v", row.Float64)
-	}
-	if row.String != "" {
-		t.Errorf("String: expected empty, got %q", row.String)
-	}
-
-	// Cross-verify: read into pointer-field struct to check definition levels
 	type PtrRecord struct {
 		Bool    *bool    `parquet:"bool,optional"`
 		Int32   *int32   `parquet:"int32,optional"`
@@ -2170,6 +2122,16 @@ func TestGenericWriterStructOptionalZeroValues(t *testing.T) {
 		String  *string  `parquet:"string,optional"`
 	}
 
+	// Part 1: write zero values via value-type fields -> all written as null.
+	buf := new(bytes.Buffer)
+	writer := NewGenericWriter[ValueRecord](buf)
+	if _, err := writer.Write([]ValueRecord{{}}); err != nil {
+		t.Fatalf("error writing: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("error closing writer: %v", err)
+	}
+
 	ptrRows, err := Read[PtrRecord](bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	if err != nil {
 		t.Fatalf("error reading as PtrRecord: %v", err)
@@ -2177,42 +2139,74 @@ func TestGenericWriterStructOptionalZeroValues(t *testing.T) {
 	if len(ptrRows) != 1 {
 		t.Fatalf("expected 1 PtrRecord row, got %d", len(ptrRows))
 	}
-
 	prow := ptrRows[0]
-	if prow.Bool == nil {
-		t.Error("Bool pointer is nil, expected non-nil")
-	} else if *prow.Bool != false {
-		t.Errorf("Bool: expected false, got %v", *prow.Bool)
+	if prow.Bool != nil {
+		t.Errorf("Bool: expected nil (null), got %v", *prow.Bool)
 	}
-	if prow.Int32 == nil {
-		t.Error("Int32 pointer is nil, expected non-nil")
-	} else if *prow.Int32 != 0 {
-		t.Errorf("Int32: expected 0, got %v", *prow.Int32)
+	if prow.Int32 != nil {
+		t.Errorf("Int32: expected nil (null), got %v", *prow.Int32)
 	}
-	if prow.Int64 == nil {
-		t.Error("Int64 pointer is nil, expected non-nil")
-	} else if *prow.Int64 != 0 {
-		t.Errorf("Int64: expected 0, got %v", *prow.Int64)
+	if prow.Int64 != nil {
+		t.Errorf("Int64: expected nil (null), got %v", *prow.Int64)
 	}
-	if prow.Float32 == nil {
-		t.Error("Float32 pointer is nil, expected non-nil")
-	} else if *prow.Float32 != 0 {
-		t.Errorf("Float32: expected 0, got %v", *prow.Float32)
+	if prow.Float32 != nil {
+		t.Errorf("Float32: expected nil (null), got %v", *prow.Float32)
 	}
-	if prow.Float64 == nil {
-		t.Error("Float64 pointer is nil, expected non-nil")
-	} else if *prow.Float64 != 0 {
-		t.Errorf("Float64: expected 0, got %v", *prow.Float64)
+	if prow.Float64 != nil {
+		t.Errorf("Float64: expected nil (null), got %v", *prow.Float64)
 	}
-	if prow.String == nil {
-		t.Error("String pointer is nil, expected non-nil")
-	} else if *prow.String != "" {
-		t.Errorf("String: expected empty, got %q", *prow.String)
+	if prow.String != nil {
+		t.Errorf("String: expected nil (null), got %v", *prow.String)
+	}
+
+	// Part 2: write non-nil pointers to zero values -> all written as non-null.
+	buf2 := new(bytes.Buffer)
+	writer2 := NewGenericWriter[PtrRecord](buf2)
+	if _, err := writer2.Write([]PtrRecord{{
+		Bool:    ptr(false),
+		Int32:   ptr(int32(0)),
+		Int64:   ptr(int64(0)),
+		Float32: ptr(float32(0)),
+		Float64: ptr(float64(0)),
+		String:  ptr(""),
+	}}); err != nil {
+		t.Fatalf("error writing PtrRecord: %v", err)
+	}
+	if err := writer2.Close(); err != nil {
+		t.Fatalf("error closing PtrRecord writer: %v", err)
+	}
+
+	ptrRows2, err := Read[PtrRecord](bytes.NewReader(buf2.Bytes()), int64(buf2.Len()))
+	if err != nil {
+		t.Fatalf("error reading PtrRecord: %v", err)
+	}
+	if len(ptrRows2) != 1 {
+		t.Fatalf("expected 1 PtrRecord row, got %d", len(ptrRows2))
+	}
+	prow2 := ptrRows2[0]
+	if prow2.Bool == nil || *prow2.Bool != false {
+		t.Errorf("Bool: expected false (non-null), got %v", prow2.Bool)
+	}
+	if prow2.Int32 == nil || *prow2.Int32 != 0 {
+		t.Errorf("Int32: expected 0 (non-null), got %v", prow2.Int32)
+	}
+	if prow2.Int64 == nil || *prow2.Int64 != 0 {
+		t.Errorf("Int64: expected 0 (non-null), got %v", prow2.Int64)
+	}
+	if prow2.Float32 == nil || *prow2.Float32 != 0 {
+		t.Errorf("Float32: expected 0 (non-null), got %v", prow2.Float32)
+	}
+	if prow2.Float64 == nil || *prow2.Float64 != 0 {
+		t.Errorf("Float64: expected 0 (non-null), got %v", prow2.Float64)
+	}
+	if prow2.String == nil || *prow2.String != "" {
+		t.Errorf("String: expected empty (non-null), got %v", prow2.String)
 	}
 }
 
-// TestGenericWriterMapStringAnyOptionalZeroValues verifies that zero values
-// written via map[string]any are stored as values (not null), and missing keys produce null.
+// TestGenericWriterMapStringAnyOptionalZeroValues verifies that values written
+// via map[string]any to optional columns follow the same nullability rule as
+// value-typed struct fields: zero values are null, non-zero values round-trip.
 func TestGenericWriterMapStringAnyOptionalZeroValues(t *testing.T) {
 	type Record struct {
 		Bool    bool    `parquet:"bool,optional"`
@@ -2226,7 +2220,7 @@ func TestGenericWriterMapStringAnyOptionalZeroValues(t *testing.T) {
 	buf := new(bytes.Buffer)
 	writer := NewGenericWriter[any](buf, schema)
 
-	// Write zero values (all present)
+	// Row 0: present zero values -> all written as null.
 	_, err := writer.Write([]any{map[string]any{
 		"bool":    false,
 		"int32":   int32(0),
@@ -2237,7 +2231,7 @@ func TestGenericWriterMapStringAnyOptionalZeroValues(t *testing.T) {
 		t.Fatalf("error writing zero values: %v", err)
 	}
 
-	// Write row with missing keys (should produce null)
+	// Row 1: only "bool":true present, rest missing -> bool is true, rest null.
 	_, err = writer.Write([]any{map[string]any{
 		"bool": true,
 	}})
@@ -2264,22 +2258,22 @@ func TestGenericWriterMapStringAnyOptionalZeroValues(t *testing.T) {
 		t.Fatalf("expected 2 rows, got %d", len(rows))
 	}
 
-	// Row 0: all zero values present (not null)
+	// Row 0: zero values -> null
 	r0 := rows[0]
-	if r0.Bool == nil || *r0.Bool != false {
-		t.Errorf("row 0 Bool: expected false, got %v", r0.Bool)
+	if r0.Bool != nil {
+		t.Errorf("row 0 Bool: expected nil, got %v", *r0.Bool)
 	}
-	if r0.Int32 == nil || *r0.Int32 != 0 {
-		t.Errorf("row 0 Int32: expected 0, got %v", r0.Int32)
+	if r0.Int32 != nil {
+		t.Errorf("row 0 Int32: expected nil, got %v", *r0.Int32)
 	}
-	if r0.Float64 == nil || *r0.Float64 != 0 {
-		t.Errorf("row 0 Float64: expected 0, got %v", r0.Float64)
+	if r0.Float64 != nil {
+		t.Errorf("row 0 Float64: expected nil, got %v", *r0.Float64)
 	}
-	if r0.String == nil || *r0.String != "" {
-		t.Errorf("row 0 String: expected empty, got %v", r0.String)
+	if r0.String != nil {
+		t.Errorf("row 0 String: expected nil, got %v", *r0.String)
 	}
 
-	// Row 1: missing keys produce null
+	// Row 1: bool present (non-zero) round-trips, rest are null.
 	r1 := rows[1]
 	if r1.Bool == nil || *r1.Bool != true {
 		t.Errorf("row 1 Bool: expected true, got %v", r1.Bool)
@@ -2295,8 +2289,10 @@ func TestGenericWriterMapStringAnyOptionalZeroValues(t *testing.T) {
 	}
 }
 
-// TestGenericWriterMapStringStringOptionalMissingKeys tests that missing keys in
-// map[string]string produce null, while present empty strings produce empty string values.
+// TestGenericWriterMapStringStringOptionalMissingKeys tests that map[string]string
+// values written to optional string columns follow the same nullability rule as
+// value-typed struct fields: both missing keys and present empty strings produce
+// null; present non-empty strings round-trip as values.
 func TestGenericWriterMapStringStringOptionalMissingKeys(t *testing.T) {
 	type Record struct {
 		Name  string `parquet:"name,optional"`
@@ -2308,7 +2304,7 @@ func TestGenericWriterMapStringStringOptionalMissingKeys(t *testing.T) {
 	buf := new(bytes.Buffer)
 	writer := NewGenericWriter[map[string]string](buf, schema)
 
-	// Row with both keys present (value is empty string)
+	// Row 0: both keys present, value is empty string -> empty collapses to null
 	_, err := writer.Write([]map[string]string{
 		{"name": "test", "value": ""},
 	})
@@ -2316,7 +2312,7 @@ func TestGenericWriterMapStringStringOptionalMissingKeys(t *testing.T) {
 		t.Fatalf("error writing: %v", err)
 	}
 
-	// Row with missing key
+	// Row 1: missing key -> null
 	_, err = writer.Write([]map[string]string{
 		{"name": "test2"},
 	})
@@ -2341,17 +2337,15 @@ func TestGenericWriterMapStringStringOptionalMissingKeys(t *testing.T) {
 		t.Fatalf("expected 2 rows, got %d", len(rows))
 	}
 
-	// Row 0: both present, value is empty string (not null)
+	// Row 0: name round-trips, present empty value is null.
 	if rows[0].Name == nil || *rows[0].Name != "test" {
 		t.Errorf("row 0 Name: expected 'test', got %v", rows[0].Name)
 	}
-	if rows[0].Value == nil {
-		t.Error("row 0 Value: expected empty string, got nil (null)")
-	} else if *rows[0].Value != "" {
-		t.Errorf("row 0 Value: expected empty string, got %q", *rows[0].Value)
+	if rows[0].Value != nil {
+		t.Errorf("row 0 Value: expected nil (null), got %q", *rows[0].Value)
 	}
 
-	// Row 1: missing key produces null
+	// Row 1: missing key -> null
 	if rows[1].Name == nil || *rows[1].Name != "test2" {
 		t.Errorf("row 1 Name: expected 'test2', got %v", rows[1].Name)
 	}
@@ -2360,55 +2354,136 @@ func TestGenericWriterMapStringStringOptionalMissingKeys(t *testing.T) {
 	}
 }
 
-// TestDeconstructOptionalZeroValues tests that row deconstruction correctly handles
-// zero values as non-null for value types.
+// TestDeconstructOptionalZeroValues verifies row deconstruction nullability:
+// value-type zero fields deconstruct as null (definitionLevel=0); non-nil
+// pointers to zero values deconstruct as non-null (definitionLevel=1).
 func TestDeconstructOptionalZeroValues(t *testing.T) {
-	type Record struct {
+	type ValueRecord struct {
 		Bool    bool    `parquet:"bool,optional"`
 		Int32   int32   `parquet:"int32,optional"`
 		Float64 float64 `parquet:"float64,optional"`
 		String  string  `parquet:"string,optional"`
 	}
 
-	schema := SchemaOf(Record{})
-	row := Record{
-		Bool:    false,
-		Int32:   0,
-		Float64: 0,
-		String:  "",
-	}
-
-	values := make([]Value, 0, 4)
-	deconstructed := schema.Deconstruct(values, row)
-
+	schema := SchemaOf(ValueRecord{})
+	deconstructed := schema.Deconstruct(make([]Value, 0, 4), ValueRecord{})
 	if len(deconstructed) != 4 {
 		t.Fatalf("expected 4 values, got %d", len(deconstructed))
 	}
-
-	// All values should have definitionLevel 1 (present, not null)
 	for i, v := range deconstructed {
-		if v.DefinitionLevel() != 1 {
-			t.Errorf("value %d: expected definitionLevel=1, got %d", i, v.DefinitionLevel())
+		if v.DefinitionLevel() != 0 {
+			t.Errorf("value %d: expected definitionLevel=0 (null), got %d", i, v.DefinitionLevel())
 		}
 	}
 
-	// Check the actual values
-	if deconstructed[0].Boolean() != false {
-		t.Errorf("Bool: expected false, got %v", deconstructed[0].Boolean())
+	type PtrRecord struct {
+		Bool    *bool    `parquet:"bool,optional"`
+		Int32   *int32   `parquet:"int32,optional"`
+		Float64 *float64 `parquet:"float64,optional"`
+		String  *string  `parquet:"string,optional"`
 	}
-	if deconstructed[1].Int32() != 0 {
-		t.Errorf("Int32: expected 0, got %v", deconstructed[1].Int32())
+
+	ptrSchema := SchemaOf(PtrRecord{})
+	ptrDeconstructed := ptrSchema.Deconstruct(make([]Value, 0, 4), PtrRecord{
+		Bool:    ptr(false),
+		Int32:   ptr(int32(0)),
+		Float64: ptr(float64(0)),
+		String:  ptr(""),
+	})
+	if len(ptrDeconstructed) != 4 {
+		t.Fatalf("expected 4 values, got %d", len(ptrDeconstructed))
 	}
-	if deconstructed[2].Double() != 0 {
-		t.Errorf("Float64: expected 0, got %v", deconstructed[2].Double())
+	for i, v := range ptrDeconstructed {
+		if v.DefinitionLevel() != 1 {
+			t.Errorf("ptr value %d: expected definitionLevel=1 (non-null), got %d", i, v.DefinitionLevel())
+		}
 	}
-	if string(deconstructed[3].ByteArray()) != "" {
-		t.Errorf("String: expected empty, got %q", string(deconstructed[3].ByteArray()))
+	if ptrDeconstructed[0].Boolean() != false {
+		t.Errorf("Bool: expected false, got %v", ptrDeconstructed[0].Boolean())
+	}
+	if ptrDeconstructed[1].Int32() != 0 {
+		t.Errorf("Int32: expected 0, got %v", ptrDeconstructed[1].Int32())
+	}
+	if ptrDeconstructed[2].Double() != 0 {
+		t.Errorf("Float64: expected 0, got %v", ptrDeconstructed[2].Double())
+	}
+	if string(ptrDeconstructed[3].ByteArray()) != "" {
+		t.Errorf("String: expected empty, got %q", string(ptrDeconstructed[3].ByteArray()))
 	}
 }
 
 func ptr[T any](v T) *T {
 	return &v
+}
+
+// TestOptionalZeroValueIsNullValueType locks in the v0.27.0 contract: when an
+// optional struct field has a Go value type (not a pointer) and is set to its
+// zero value, the column writes null (definitionLevel=0). This test exists to
+// prevent silent re-introduction of the regression that landed in v0.29.0
+// (PR #480), where value-type zeros began round-tripping as non-null values.
+func TestOptionalZeroValueIsNullValueType(t *testing.T) {
+	t.Run("int32", func(t *testing.T) {
+		type Record struct {
+			V int32 `parquet:"v,optional"`
+		}
+		assertOptionalZeroIsNull[Record](t, Record{})
+	})
+	t.Run("int64", func(t *testing.T) {
+		type Record struct {
+			V int64 `parquet:"v,optional"`
+		}
+		assertOptionalZeroIsNull[Record](t, Record{})
+	})
+	t.Run("bool", func(t *testing.T) {
+		type Record struct {
+			V bool `parquet:"v,optional"`
+		}
+		assertOptionalZeroIsNull[Record](t, Record{})
+	})
+	t.Run("float64", func(t *testing.T) {
+		type Record struct {
+			V float64 `parquet:"v,optional"`
+		}
+		assertOptionalZeroIsNull[Record](t, Record{})
+	})
+	t.Run("string", func(t *testing.T) {
+		type Record struct {
+			V string `parquet:"v,optional"`
+		}
+		assertOptionalZeroIsNull[Record](t, Record{})
+	})
+	t.Run("time.Time", func(t *testing.T) {
+		type Record struct {
+			V time.Time `parquet:"v,optional,timestamp(microsecond)"`
+		}
+		assertOptionalZeroIsNull[Record](t, Record{})
+	})
+}
+
+func assertOptionalZeroIsNull[T any](t *testing.T, row T) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	writer := NewGenericWriter[T](buf)
+	if _, err := writer.Write([]T{row}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reader := NewReader(bytes.NewReader(buf.Bytes()))
+	defer reader.Close()
+	rows := make([]Row, 1)
+	if _, err := reader.ReadRows(rows); err != nil && err != io.EOF {
+		t.Fatalf("read rows: %v", err)
+	}
+	if len(rows[0]) != 1 {
+		t.Fatalf("expected 1 column, got %d", len(rows[0]))
+	}
+	v := rows[0][0]
+	if !v.IsNull() {
+		t.Errorf("expected null, got definitionLevel=%d value=%v", v.DefinitionLevel(), v)
+	}
 }
 
 // TestIssue417MapStructOptionalField tests that GenericWriter[any] can write

--- a/column_buffer_write.go
+++ b/column_buffer_write.go
@@ -299,12 +299,6 @@ func writeRowsFuncOfOptional(t reflect.Type, schema *Schema, path columnPath, wr
 				}
 			}
 		}
-		// []byte: fall through to nullIndex (nil = null, non-nil = value)
-	case reflect.Pointer, reflect.Map:
-		// Fall through to nullIndex (nil = null, non-nil = value)
-	default:
-		// Value types (bool, int, float, string, struct, etc.) are never null
-		return writeOptional
 	}
 
 	nullIndex := nullIndexFuncOf(t)
@@ -618,6 +612,11 @@ func writeRowsFuncOfStruct(t reflect.Type, schema *Schema, path columnPath, tagR
 			case f.Type == reflect.TypeFor[json.RawMessage]():
 				// json.RawMessage handles its own definition levels through
 				// writeRowsFuncOfJSONRawMessage -> writeValueFuncOf -> writeValueFuncOfOptional
+			case f.Type == reflect.TypeFor[time.Time]():
+				// time.Time is a struct but has IsZero() method,
+				// so it needs special handling.
+				// Don't use writeRowsFuncOfOptional which relies
+				// on bitmap batching.
 			default:
 				writeRows = writeRowsFuncOfOptional(f.Type, schema, columnPath, writeRows)
 			}
@@ -929,15 +928,42 @@ func writeRowsFuncOfTime(_ reflect.Type, schema *Schema, path columnPath, tagRep
 		unit = lt.Timestamp.Unit
 	}
 
+	// Check if the column is optional
+	isOptional := col.Node.Optional()
+
 	return func(columns []ColumnBuffer, levels columnLevels, rows sparse.Array) {
 		if rows.Len() == 0 {
 			writeRows(columns, levels, rows)
 			return
 		}
 
+		// If we're optional and the current definition level is already > 0,
+		// then we're in a pointer/nested context where writeRowsFuncOfPointer
+		// already handles optionality.
+		//
+		// Don't double-handle it here. For simple optional fields,
+		// definitionLevel starts at 0.
+		alreadyHandled := isOptional && levels.definitionLevel > 0
+
 		times := rows.TimeArray()
 		for i := range times.Len() {
 			t := times.Index(i)
+
+			// For optional fields, check if the value is zero
+			// (unless already handled by pointer wrapper).
+			elemLevels := levels
+			if isOptional && !alreadyHandled && t.IsZero() {
+				// Write as NULL (don't increment definition level).
+				empty := sparse.Array{}
+				writeRows(columns, elemLevels, empty)
+				continue
+			}
+
+			// For optional non-zero values, increment definition level
+			// (unless already handled).
+			if isOptional && !alreadyHandled {
+				elemLevels.definitionLevel++
+			}
 
 			var val int64
 			switch {
@@ -950,7 +976,7 @@ func writeRowsFuncOfTime(_ reflect.Type, schema *Schema, path columnPath, tagRep
 			}
 
 			a := makeArray(reflectValueData(reflect.ValueOf(val)), 1, elemSize)
-			writeRows(columns, levels, a)
+			writeRows(columns, elemLevels, a)
 		}
 	}
 }

--- a/row_test.go
+++ b/row_test.go
@@ -316,8 +316,8 @@ func TestDeconstructionReconstruction(t *testing.T) {
 				// User.Details
 				1: {parquet.ValueOf("Luke").Level(0, 2, 0)},
 				2: {parquet.ValueOf("Skywalker").Level(0, 2, 0)},
-				3: {parquet.ValueOf(int64(0)).Level(0, 3, 0)},
-				4: {parquet.ValueOf(float64(0)).Level(0, 3, 0)},
+				3: {parquet.ValueOf(nil).Level(0, 2, 0)},
+				4: {parquet.ValueOf(nil).Level(0, 2, 0)},
 
 				5: { // User.Friends.ID
 					parquet.ValueOf(uuid.MustParse("1B76F8D0-82C6-403F-A104-DCDA69207220")).Level(0, 2, 0),
@@ -338,15 +338,15 @@ func TestDeconstructionReconstruction(t *testing.T) {
 				},
 
 				8: { // User.Friends.Details.Person.Age
-					parquet.ValueOf(int64(0)).Level(0, 5, 0),
-					parquet.ValueOf(int64(0)).Level(1, 5, 0),
-					parquet.ValueOf(int64(0)).Level(1, 5, 0),
+					parquet.ValueOf(nil).Level(0, 4, 0),
+					parquet.ValueOf(nil).Level(1, 4, 0),
+					parquet.ValueOf(nil).Level(1, 4, 0),
 				},
 
 				9: { // User.Friends.Details.Person.Weight
-					parquet.ValueOf(float64(0)).Level(0, 5, 0),
-					parquet.ValueOf(float64(0)).Level(1, 5, 0),
-					parquet.ValueOf(float64(0)).Level(1, 5, 0),
+					parquet.ValueOf(nil).Level(0, 4, 0),
+					parquet.ValueOf(nil).Level(1, 4, 0),
+					parquet.ValueOf(nil).Level(1, 4, 0),
 				},
 			},
 		},
@@ -509,7 +509,7 @@ func TestDeconstructionReconstruction(t *testing.T) {
 				},
 				3: { // AddressBook.contacts.phoneNumber
 					parquet.ValueOf("555 987 6543").Level(0, 2, 0),
-					parquet.ValueOf("").Level(1, 2, 0),
+					parquet.ValueOf(nil).Level(1, 1, 0),
 				},
 			},
 		},

--- a/type_test.go
+++ b/type_test.go
@@ -389,10 +389,9 @@ func TestOptionalTimeZeroValue(t *testing.T) {
 		Time time.Time `parquet:"time,optional,timestamp(microsecond)"`
 	}
 
-	// Create records with zero and non-zero time.Time values.
-	// Value types (including time.Time) are never null — zero time is a valid value.
+	// Create records with zero and non-zero time.Time values
 	records := []Record{
-		{ID: 1, Time: time.Time{}},                                 // zero value - stored as value (not NULL)
+		{ID: 1, Time: time.Time{}},                                 // zero value - should be NULL
 		{ID: 2, Time: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)}, // non-zero value
 		{ID: 3, Time: time.Time{}},                                 // another zero value
 	}
@@ -423,8 +422,13 @@ func TestOptionalTimeZeroValue(t *testing.T) {
 		t.Fatalf("expected %d rows, got %d", len(records), n)
 	}
 
-	// All time values should be non-null (definitionLevel=1) since
-	// value types are never null.
+	// Check definition levels
+	// For record 1 (zero time): should have definitionLevel=0 (NULL)
+	// For record 2 (non-zero time): should have definitionLevel=1 (non-NULL)
+	// For record 3 (zero time): should have definitionLevel=0 (NULL)
+
+	expectedDefinitionLevels := []int{0, 1, 0} // ID column has 0 (required), Time column varies
+
 	for i, row := range rows[:n] {
 		if len(row) < 2 {
 			t.Fatalf("row %d has less than 2 columns", i)
@@ -433,20 +437,25 @@ func TestOptionalTimeZeroValue(t *testing.T) {
 		timeValue := row[1] // Second column is Time
 		definitionLevel := int(timeValue.DefinitionLevel())
 
-		if definitionLevel != 1 {
-			t.Errorf("row %d: expected definitionLevel=1 for Time column, got %d",
-				i, definitionLevel)
+		if definitionLevel != expectedDefinitionLevels[i] {
+			t.Errorf("row %d: expected definitionLevel=%d for Time column, got %d",
+				i, expectedDefinitionLevels[i], definitionLevel)
 		}
 
-		if timeValue.IsNull() {
-			t.Errorf("row %d: expected IsNull()=false, got true", i)
+		// For NULL values, IsNull() should return true
+		if expectedDefinitionLevels[i] == 0 && !timeValue.IsNull() {
+			t.Errorf("row %d: expected IsNull()=true for zero time.Time, got false", i)
+		}
+
+		// For non-NULL values, check the actual value
+		if expectedDefinitionLevels[i] == 1 {
+			if timeValue.IsNull() {
+				t.Errorf("row %d: expected IsNull()=false for non-zero time.Time, got true", i)
+			}
 		}
 	}
 
-	// Read back using GenericReader to verify non-zero values round-trip.
-	// Note: time.Time{} (year 1 AD) does not round-trip correctly through
-	// microsecond timestamps due to int64 overflow in the reader's nanos
-	// conversion. This is a pre-existing reader limitation.
+	// Also read back using GenericReader to verify the values
 	genReader := parquet.NewGenericReader[Record](bytes.NewReader(buf.Bytes()))
 	defer genReader.Close()
 
@@ -458,8 +467,17 @@ func TestOptionalTimeZeroValue(t *testing.T) {
 
 	readRecords = readRecords[:n2]
 
+	// Verify that zero time.Time values are preserved as zero
+	if !readRecords[0].Time.IsZero() {
+		t.Errorf("record 0: expected zero time.Time, got %v", readRecords[0].Time)
+	}
+
 	if readRecords[1].Time.IsZero() {
 		t.Errorf("record 1: expected non-zero time.Time, got zero")
+	}
+
+	if !readRecords[2].Time.IsZero() {
+		t.Errorf("record 2: expected zero time.Time, got %v", readRecords[2].Time)
 	}
 
 	// Verify IDs are correct
@@ -496,9 +514,10 @@ func TestOptionalTimeWithMillisecond(t *testing.T) {
 	n, _ := reader.Read(readRecords)
 	readRecords = readRecords[:n]
 
-	// Note: time.Time{} (year 1 AD) does not round-trip correctly through
-	// millisecond timestamps due to int64 overflow in the reader's nanos
-	// conversion. Verify the non-zero time round-trips correctly.
+	if !readRecords[0].Time.IsZero() {
+		t.Errorf("expected zero time, got %v", readRecords[0].Time)
+	}
+
 	if readRecords[1].Time.IsZero() {
 		t.Errorf("expected non-zero time, got zero")
 	}
@@ -530,34 +549,27 @@ func TestOptionalTimeWithNanosecond(t *testing.T) {
 	n, _ := reader.Read(readRecords)
 	readRecords = readRecords[:n]
 
-	// Note: Nanosecond timestamps (int64) cannot represent time.Time{} (year 1 AD)
-	// due to int64 overflow. The zero time is stored as a non-null value but
-	// doesn't round-trip correctly. Users needing null semantics should use *time.Time.
-	// We just verify the non-zero time round-trips correctly.
+	if !readRecords[0].Time.IsZero() {
+		t.Errorf("expected zero time, got %v", readRecords[0].Time)
+	}
+
 	if readRecords[1].Time.IsZero() {
 		t.Errorf("expected non-zero time, got zero")
 	}
-	if !readRecords[1].Time.Equal(time.Date(2024, 12, 25, 0, 0, 0, 123456789, time.UTC)) {
-		t.Errorf("expected 2024-12-25, got %v", readRecords[1].Time)
-	}
 }
 
-// TestIssue155 verifies that time.Time value types are stored as values (not null).
-// Previously, zero time.Time was stored as null, but the fix for #153 changes this:
-// value types are never null. Users who need null semantics should use *time.Time.
-//
-// Note: The default timestamp unit is nanosecond. Nanosecond int64 cannot represent
-// time.Time{} (year 1 AD) due to overflow, so the zero time doesn't round-trip.
-// Users needing zero-time round-trip should use microsecond or millisecond timestamps,
-// or use *time.Time for null semantics.
+// TestIssue155 verifies the fix for https://github.com/parquet-go/parquet-go/issues/155
+// The issue reported that empty time.Time{} values were being serialized as "1754-08-30"
+// instead of being preserved as zero values (NULL) when using optional timestamp fields.
 func TestIssue155(t *testing.T) {
 	type TestStruct struct {
 		TestDate time.Time `parquet:"test_date,optional,timestamp"`
 		TestInt  int       `parquet:"test_int"`
 	}
 
+	// Create a record with an empty time.Time (zero value)
 	original := TestStruct{
-		TestDate: time.Time{},
+		TestDate: time.Time{}, // empty/zero time - should be preserved
 		TestInt:  123,
 	}
 
@@ -587,6 +599,18 @@ func TestIssue155(t *testing.T) {
 	// Verify the TestInt field is preserved
 	if result[0].TestInt != 123 {
 		t.Errorf("expected TestInt=123, got %d", result[0].TestInt)
+	}
+
+	// The critical assertion from issue #155:
+	// An empty time.Time should remain zero after round-trip
+	if !result[0].TestDate.IsZero() {
+		t.Errorf("expected TestDate.IsZero()=true, got false with value: %v (was: %s)",
+			result[0].TestDate, result[0].TestDate.Format("2006-01-02"))
+	}
+
+	// Also verify it's not the erroneous "1754-08-30" date that was reported
+	if result[0].TestDate.Year() == 1754 {
+		t.Errorf("got the erroneous 1754-08-30 date that was reported in issue #155")
 	}
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -1301,13 +1301,13 @@ message AddressBook {
 }
 
 
-Row group 0:  count: 2  376.50 B records  start: 4  total(compressed): 753 B total(uncompressed):676 B
+Row group 0:  count: 2  387.00 B records  start: 4  total(compressed): 774 B total(uncompressed):697 B
 --------------------------------------------------------------------------------
                       type      encodings count     avg size   nulls   min / max
 owner                 BINARY    Z         2         71.00 B    0       "A. Nonymous" / "Julien Le Dem"
 ownerPhoneNumbers     BINARY    G         3         81.00 B    1       "555 123 4567" / "555 666 1337"
 contacts.name         BINARY    _         3         70.67 B    1       "Chris Aniszczyk" / "Dmitriy Ryaboy"
-contacts.phoneNumber  BINARY    Z         3         52.00 B    1       "" / "555 987 6543"
+contacts.phoneNumber  BINARY    Z         3         59.00 B    2       "555 987 6543" / "555 987 6543"
 
 
 Column: owner
@@ -1333,7 +1333,7 @@ Column: contacts.name
 Column: contacts.phoneNumber
 --------------------------------------------------------------------------------
   page   type  enc  count   avg size   size       rows     nulls   min / max
-  0-0    data  Z D  2       18.00 B    36 B                0       "" / "555 987 6543"
+  0-0    data  Z D  2       16.50 B    33 B                1       "555 987 6543" / "555 987 6543"
   0-1    data  Z D  1       17.00 B    17 B                1
 
 `,
@@ -1380,13 +1380,13 @@ message AddressBook {
 }
 
 
-Row group 0:  count: 2  370.00 B records  start: 4  total(compressed): 740 B total(uncompressed):663 B
+Row group 0:  count: 2  380.50 B records  start: 4  total(compressed): 761 B total(uncompressed):684 B
 --------------------------------------------------------------------------------
                       type      encodings count     avg size   nulls   min / max
 owner                 BINARY    Z         2         73.50 B    0       "A. Nonymous" / "Julien Le Dem"
 ownerPhoneNumbers     BINARY    G         3         78.67 B    1       "555 123 4567" / "555 666 1337"
 contacts.name         BINARY    _         3         68.67 B    1       "Chris Aniszczyk" / "Dmitriy Ryaboy"
-contacts.phoneNumber  BINARY    Z         3         50.33 B    1       "" / "555 987 6543"
+contacts.phoneNumber  BINARY    Z         3         57.33 B    2       "555 987 6543" / "555 987 6543"
 
 
 Column: owner
@@ -1412,7 +1412,7 @@ Column: contacts.name
 Column: contacts.phoneNumber
 --------------------------------------------------------------------------------
   page   type  enc  count   avg size   size       rows     nulls   min / max
-  0-0    data  _ D  2       14.00 B    28 B       1        0       "" / "555 987 6543"
+  0-0    data  _ D  2       12.50 B    25 B       1        1       "555 987 6543" / "555 987 6543"
   0-1    data  _ D  1       9.00 B     9 B        1        1
 
 `,


### PR DESCRIPTION
## Summary

- Restores the v0.27.0 default for optional value-type columns: a Go zero value (`0`, `""`, `false`, `time.Time{}`) on an `optional` field is written as null again. PR #480 (shipped in v0.29.0) inverted this so zero values became non-null, which broke every caller relying on the old default.
- Pointer types are unchanged: a non-nil pointer to a zero value still writes as non-null, and a nil pointer writes as null. That remains the documented way to opt into "emit the zero value" semantics.
- The PR #480 design principle (*"a Go value type always holds a valid value"*) is reverted as the default. If a caller needs the old v0.29.0 behavior, they switch the field to a pointer.

## What changed

- `isNullValue` — default branch returns `value.IsZero()` again
- `writeRowsFuncOfOptional` — value types go through `nullIndex` instead of short-circuiting to `writeOptional`
- `writeRowsFuncOfTime` — re-introduces the `t.IsZero()` null branch with the `alreadyHandled` pointer-context guard
- `writeRowsFuncOfStruct` — re-adds the `time.Time` special case that skips the optional wrapper (its own null handling would otherwise double-up)
- `map[string]string` group writer — drops the key-existence distinction (present-empty collapses to null, same as a missing key)
- `deconstructFuncOfOptional` — unchanged in source; it routes through `isNullValue` and gets correct behavior automatically

## Tests

- New `TestOptionalZeroValueIsNullValueType` locks in the contract for int32/int64/bool/float64/string/time.Time as a tripwire against future re-introduction.
- The PR #480 tests (`TestWriteOptionalZeroValues*`, `TestGenericWriterStructOptionalZeroValues`, `TestGenericWriterMapStringAny*`, `TestGenericWriterMapStringStringOptionalMissingKeys`, `TestDeconstructOptionalZeroValues`) are restructured to assert the meaningful pointer-typed guarantee (`non-nil pointer at zero -> non-null`) instead of the reverted value-typed assertion.
- `row_test.go`, `type_test.go`, `writer_test.go` — assertion tables and dump expectations reverted to the v0.27.0 expected values.

## Test plan

- [x] `go test ./...` passes
- [x] `make test` (race + cover) passes
- [x] `make format` clean

Generated with [Claude Code](https://claude.com/claude-code)