### PR TITLE
fix: always allocate fresh pointer for optional fields on reconstruct

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -1097,3 +1097,62 @@ func TestIssue406LeadingBooleanField(t *testing.T) {
 		}
 	}
 }
+
+// TestIssue522 checks that optional pointer fields are freshly allocated on
+// every Read call. Reusing the caller's previous-call pointer let downstream
+// AssignValue mutate bytes behind any retained shallow copy of an earlier
+// batch.
+// Issue: https://github.com/parquet-go/parquet-go/issues/522
+func TestIssue522(t *testing.T) {
+	type Row struct {
+		ID  int64   `parquet:"id"`
+		Opt *string `parquet:"opt,optional"`
+	}
+
+	const n = 4096
+	src := make([]Row, n)
+	for i := range src {
+		s := fmt.Sprintf("val-%04d", i)
+		src[i] = Row{ID: int64(i), Opt: &s}
+	}
+
+	buf := new(bytes.Buffer)
+	w := parquet.NewGenericWriter[Row](buf)
+	if _, err := w.Write(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := parquet.NewGenericReader[Row](bytes.NewReader(buf.Bytes()))
+	defer r.Close()
+
+	var retained []Row
+	batch := make([]Row, 256)
+	for {
+		nRead, err := r.Read(batch)
+		retained = append(retained, batch[:nRead]...)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(retained) != n {
+		t.Fatalf("retained %d rows, want %d", len(retained), n)
+	}
+
+	for i, got := range retained {
+		want := fmt.Sprintf("val-%04d", i)
+		if got.Opt == nil {
+			t.Errorf("row %d: Opt is nil, want %q", i, want)
+			continue
+		}
+		if *got.Opt != want {
+			t.Errorf("row %d: Opt = %q, want %q", i, *got.Opt, want)
+		}
+	}
+}

--- a/row.go
+++ b/row.go
@@ -616,9 +616,11 @@ func reconstructFuncOfOptional(columnIndex uint16, node Node) (uint16, reconstru
 		}
 
 		if value.Kind() == reflect.Ptr {
-			if value.IsNil() {
-				value.Set(reflect.New(value.Type().Elem()))
-			}
+			// Always allocate a fresh pointer. Reusing the caller's
+			// previous-call allocation would let downstream AssignValue
+			// mutate bytes behind any pointer the caller has retained from
+			// an earlier Read (issue #522).
+			value.Set(reflect.New(value.Type().Elem()))
 			value = value.Elem()
 		}
 


### PR DESCRIPTION
## Summary

- Fixes #522 — silent data corruption of optional pointer fields (`*string`, `*[]byte`, `*SomeStruct`) across `GenericReader.Read` calls.
- `reconstructFuncOfOptional` (`row.go`) previously only allocated a fresh pointer when the destination was nil. Because the documented usage pattern reuses the same `[]T` slice across `Read` calls, the pointer carried over from a previous call was reused; downstream `AssignValue` then mutated the bytes behind any pointer the caller had retained from an earlier batch.
- Match the unconditional-allocation pattern already used by `reconstructFuncOfRepeated` (`setMakeSlice`) and `reconstructFuncOfMap` (`reflect.MakeMap`).

The fix also covers the same bug on the non-generic `Reader.Read(row any)` and on `Schema.Reconstruct` callers, since the root cause is in the shared reconstruct closure.

## Test plan

- [x] Added `TestIssue522` regression test (4096 rows × `*string`, batched `Read` calls into a reused slice, shallow-copied into a retained slice). Confirmed it fails on the unfixed code (3840/4096 mismatches, matching the issue reporter's measurement) and passes after the fix.
- [x] `make test` passes for all 21 packages with `-race -cover`.
- [x] `make format` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)