### PR TITLE
fix: skip zero-length runs when decoding RLE/Hybrid levels

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -215,6 +215,26 @@ func TestEncoding(t *testing.T) {
 	}
 }
 
+func TestRLEDecodeLevelsToleratesEmptyRuns(t *testing.T) {
+	if cpu.IsBigEndian {
+		t.Skip("tests for RLE encoding are failing on s390x")
+	}
+
+	enc := &rle.Encoding{BitWidth: 1}
+
+	src := []byte{0x00, 0x08, 0x01}
+	want := []byte{1, 1, 1, 1}
+
+	got, err := enc.DecodeLevels(nil, src)
+	if err != nil {
+		t.Fatalf("DecodeLevels: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("DecodeLevels produced %d values, want %d (got=%v)", len(got), len(want), got)
+	}
+	assertEqualBytes(t, want, got)
+}
+
 func testEncoding(t *testing.T, e encoding.Encoding) {
 	for _, test := range [...]struct {
 		scenario string

--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -305,6 +305,9 @@ func decodeBytes(dst, src []byte, bitWidth uint) ([]byte, error) {
 		i += n
 
 		count, bitpacked := uint(u>>1), (u&1) != 0
+		if count == 0 {
+			continue
+		}
 		if count > maxSupportedValueCount {
 			return dst, fmt.Errorf("decoded run-length block cannot have more than %d values", maxSupportedValueCount)
 		}


### PR DESCRIPTION
## Summary
Some upstream parquet writers emit RLE/Hybrid level streams containing run headers with count == 0 — for example, fraugster/parquet-go writes a 0x00 level region for zero-value Data Page V2s. The decoder didn't expect empty runs and processed the nonexistent body anyway, failing two ways depending on what follows:

* Tail of stream: reads past end-of-buffer → `decoding run-length block of N values: unexpected EOF`.
* Mid-stream: consumes one byte of the next header as the empty run's body, misaligning every subsequent header and silently truncating or corrupting output.

The Parquet spec doesn't explicitly authorize empty runs, but tolerating them is harmless: an empty run has no body to read, so skipping it is the only sensible action. The library's own encoder never emits empty runs, so spec-conforming inputs are unaffected.

## What's changed
encoding/rle/rle.go: in decodeBytes, skip the run body when count == 0 so the decoder neither resizes dst nor consumes a stray value byte from src, and the read cursor stays aligned for the next header.

## Tests
encoding/encoding_test.go: adds TestRLEDecodeLevelsToleratesEmptyRuns. Decodes a hand-crafted 3-byte stream (0x00, 0x08, 0x01) representing an empty RLE run followed by a four-value RLE run of 1s. With the fix the decoder yields {1, 1, 1, 1}; without it the stray byte consumption truncates the output to empty (verified by reverting the change).