### PR TITLE
fix: skip zero-length runs in RLE int32 and boolean decoders

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -215,24 +215,58 @@ func TestEncoding(t *testing.T) {
 	}
 }
 
-func TestRLEDecodeLevelsToleratesEmptyRuns(t *testing.T) {
+func TestRLEDecodeToleratesEmptyRuns(t *testing.T) {
 	if cpu.IsBigEndian {
 		t.Skip("tests for RLE encoding are failing on s390x")
 	}
 
-	enc := &rle.Encoding{BitWidth: 1}
-
-	src := []byte{0x00, 0x08, 0x01}
-	want := []byte{1, 1, 1, 1}
-
-	got, err := enc.DecodeLevels(nil, src)
-	if err != nil {
-		t.Fatalf("DecodeLevels: %v", err)
+	for _, tc := range []struct {
+		name   string
+		enc    *rle.Encoding
+		decode func(*rle.Encoding, []byte) ([]byte, error)
+		src    []byte
+		want   []byte
+	}{
+		{
+			name: "levels",
+			enc:  &rle.Encoding{BitWidth: 1},
+			decode: func(e *rle.Encoding, src []byte) ([]byte, error) {
+				return e.DecodeLevels(nil, src)
+			},
+			src:  []byte{0x00, 0x08, 0x01},
+			want: []byte{1, 1, 1, 1},
+		},
+		{
+			name: "int32",
+			enc:  &rle.Encoding{BitWidth: 16},
+			decode: func(e *rle.Encoding, src []byte) ([]byte, error) {
+				v, err := e.DecodeInt32(nil, src)
+				return unsafecast.Slice[byte](v), err
+			},
+			src:  []byte{0x00, 0x08, 0x07, 0x00},
+			want: unsafecast.Slice[byte]([]int32{7, 7, 7, 7}),
+		},
+		{
+			name: "boolean",
+			enc:  &rle.Encoding{BitWidth: 1},
+			decode: func(e *rle.Encoding, src []byte) ([]byte, error) {
+				return e.DecodeBoolean(nil, src)
+			},
+			src:  []byte{0x03, 0x00, 0x00, 0x00, 0x00, 0x10, 0xFF},
+			want: []byte{0xFF},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.decode(tc.enc, tc.src)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("produced %d bytes, want %d (got=%v)", len(got), len(tc.want), got)
+			}
+			assertEqualBytes(t, tc.want, got)
+		})
 	}
-	if len(got) != len(want) {
-		t.Fatalf("DecodeLevels produced %d values, want %d (got=%v)", len(got), len(want), got)
-	}
-	assertEqualBytes(t, want, got)
 }
 
 func testEncoding(t *testing.T, e encoding.Encoding) {

--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -260,6 +260,9 @@ func decodeBits(dst, src []byte) ([]byte, error) {
 		i += n
 
 		count, bitpacked := uint(u>>1), (u&1) != 0
+		if count == 0 {
+			continue
+		}
 		if count > maxSupportedValueCount {
 			return dst, fmt.Errorf("decoded run-length block cannot have more than %d values", maxSupportedValueCount)
 		}
@@ -364,6 +367,9 @@ func decodeInt32(dst, src []byte, bitWidth uint) ([]byte, error) {
 		i += n
 
 		count, bitpacked := uint(u>>1), (u&1) != 0
+		if count == 0 {
+			continue
+		}
 		if count > maxSupportedValueCount {
 			return dst, fmt.Errorf("decoded run-length block cannot have more than %d values", maxSupportedValueCount)
 		}


### PR DESCRIPTION
## Summary

Follow-up to #528, which made `decodeBytes` tolerant of empty runs in RLE/Hybrid streams. The same writer pattern can produce identical empty runs in two other decoders that #528 did not touch:

* `decodeInt32` — used for dictionary-index pages where the bit width exceeds 8. When the decoder hits an empty RLE run, it still advances the read cursor by the expected payload size and then either runs off the end of the buffer or pulls bytes from the next run's header, depending on where the empty run lands.
* `decodeBits` — used for BOOLEAN decoding. Its RLE branch unconditionally consumes one byte as the broadcast value, even when the run is empty. That byte actually belongs to the next run's header, so the stream becomes misaligned — and depending on what that byte happens to be, decoding either silently produces wrong values or fails on the following iteration with an unexpected-EOF error.

## Tests

encoding/encoding_test.go — TestRLEDecodeLevelsToleratesEmptyRuns from #528 is replaced with TestRLEDecodeToleratesEmptyRuns, a table test with one subtest per decoder (levels, int32, boolean), each pairing an empty run with a legitimate one to prove both absence of EOF and that the cursor stayed aligned for the next header.
