### PR TITLE
feat: add BE128/UUID direct read and write interfaces

### DIFF
--- a/page_be128.go
+++ b/page_be128.go
@@ -3,7 +3,9 @@ package parquet
 import (
 	"io"
 
+	"github.com/google/uuid"
 	"github.com/parquet-go/parquet-go/encoding"
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
 )
 
 type be128Page struct {
@@ -96,4 +98,33 @@ func (r *be128PageValues) ReadValues(values []Value) (n int, err error) {
 		err = io.EOF
 	}
 	return n, err
+}
+
+func (r *be128PageValues) ReadBE128s(values [][16]byte) (n int, err error) {
+	n = copy(values, r.page.values[r.offset:])
+	r.offset += n
+	if r.offset == len(r.page.values) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+func (col *be128ColumnBuffer) WriteBE128s(values [][16]byte) (int, error) {
+	col.values = append(col.values, values...)
+	return len(values), nil
+}
+
+func (r *be128PageValues) ReadUUIDs(values []uuid.UUID) (n int, err error) {
+	pageValues := unsafecast.Slice[uuid.UUID](r.page.values)
+	n = copy(values, pageValues[r.offset:])
+	r.offset += n
+	if r.offset == len(pageValues) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+func (col *be128ColumnBuffer) WriteUUIDs(values []uuid.UUID) (int, error) {
+	col.values = append(col.values, unsafecast.Slice[[16]byte](values)...)
+	return len(values), nil
 }

--- a/page_test.go
+++ b/page_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/parquet-go/bitpack/unsafecast"
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/deprecated"
@@ -21,6 +22,7 @@ func TestPage(t *testing.T) {
 	t.Run("DOUBLE", testPageDouble)
 	t.Run("BYTE_ARRAY", testPageByteArray)
 	t.Run("FIXED_LEN_BYTE_ARRAY", testPageFixedLenByteArray)
+	t.Run("UUID", testPageUUID)
 }
 
 func testPageBoolean(t *testing.T) {
@@ -299,6 +301,52 @@ func testPageFixedLenByteArray(t *testing.T) {
 				values := make([]byte, 3*3)
 				n, err := r.(parquet.FixedLenByteArrayReader).ReadFixedLenByteArrays(values)
 				return values[:3*n], err
+			},
+		})
+	})
+}
+
+func testPageUUID(t *testing.T) {
+	schema := parquet.NewSchema("test", parquet.Group{
+		"Value": parquet.UUID(),
+	})
+
+	t.Run("be128", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (any, error) {
+				values := [][16]byte{
+					{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+					{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F},
+					{0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00},
+				}
+				n, err := w.(parquet.BE128Writer).WriteBE128s(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (any, error) {
+				values := make([][16]byte, 3)
+				n, err := r.(parquet.BE128Reader).ReadBE128s(values)
+				return values[:n], err
+			},
+		})
+	})
+
+	t.Run("uuid", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (any, error) {
+				values := []uuid.UUID{
+					uuid.MustParse("00010203-0405-0607-0809-0a0b0c0d0e0f"),
+					uuid.MustParse("10111213-1415-1617-1819-1a1b1c1d1e1f"),
+					uuid.MustParse("ffeeddcc-bbaa-9988-7766-554433221100"),
+				}
+				n, err := w.(parquet.UUIDWriter).WriteUUIDs(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (any, error) {
+				values := make([]uuid.UUID, 3)
+				n, err := r.(parquet.UUIDReader).ReadUUIDs(values)
+				return values[:n], err
 			},
 		})
 	})

--- a/value.go
+++ b/value.go
@@ -1093,3 +1093,45 @@ type FixedLenByteArrayWriter interface {
 	// is not a multiple of the expected item size.
 	WriteFixedLenByteArrays(values []byte) (int, error)
 }
+
+// BE128Reader is an interface implemented by ValueReader instances which
+// expose the content of a column of 128-bit big-endian byte array values.
+type BE128Reader interface {
+	// Read 128-bit big-endian values into the buffer passed as argument,
+	// returning the number of values read.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadBE128s(values [][16]byte) (int, error)
+}
+
+// BE128Writer is an interface implemented by ValueWriter instances which
+// support writing columns of 128-bit big-endian byte array values.
+type BE128Writer interface {
+	// Write 128-bit big-endian values.
+	//
+	// The method returns the number of values written, and any error that
+	// occurred while writing the values.
+	WriteBE128s(values [][16]byte) (int, error)
+}
+
+// UUIDReader is an interface implemented by ValueReader instances which
+// expose the content of a column of UUID values stored as 16-byte
+// FIXED_LEN_BYTE_ARRAY with the UUID logical type.
+type UUIDReader interface {
+	// Read UUID values into the buffer passed as argument, returning the
+	// number of values read.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadUUIDs(values []uuid.UUID) (int, error)
+}
+
+// UUIDWriter is an interface implemented by ValueWriter instances which
+// support writing columns of UUID values stored as 16-byte
+// FIXED_LEN_BYTE_ARRAY with the UUID logical type.
+type UUIDWriter interface {
+	// Write UUID values.
+	//
+	// The method returns the number of values written, and any error that
+	// occurred while writing the values.
+	WriteUUIDs(values []uuid.UUID) (int, error)
+}


### PR DESCRIPTION
Expand the `<type>Reader` and `<type>Writer` interfaces to cover `be128PageValues`, with both `[16]byte` and `uuid.UUUD` variants.


<details>

<summary>Benchmark not included in PR, but here for reference</summary>

```go
func BenchmarkReadUUIDPage(b *testing.B) {
	type uuidColumn struct {
		Value uuid.UUID `parquet:",uuid"`
	}

	const numRows = 500_000

	needle, haystack := uuid.New(), uuid.New()

	rows := make([]uuidColumn, numRows)
	for i := range rows {
		rows[i].Value = haystack
	}

	buf := new(bytes.Buffer)
	writer := parquet.NewGenericWriter[uuidColumn](buf)
	if _, err := writer.Write(rows); err != nil {
		b.Fatal(err)
	}
	if err := writer.Close(); err != nil {
		b.Fatal(err)
	}

	reader := bytes.NewReader(buf.Bytes())
	file, err := parquet.OpenFile(reader, reader.Size())
	if err != nil {
		b.Fatal(err)
	}

	column := file.RowGroups()[0].ColumnChunks()[0]

	for _, bm := range []struct {
		name     string
		readPage func(b *testing.B, page parquet.Page)
	}{
		{"Values", func(b *testing.B, page parquet.Page) {
			values := make([]parquet.Value, page.NumValues())
			n, err := page.Values().ReadValues(values)
			if err != nil && err != io.EOF {
				b.Fatal(err)
			}
			for i := range n {
				if bytes.Equal(values[i].ByteArray(), needle[:]) {
					b.Log("Found!")
				}
			}
		}},
		{"DirectUUIDs", func(b *testing.B, page parquet.Page) {
			values := make([]uuid.UUID, page.NumValues())
			n, err := page.Values().(parquet.UUIDReader).ReadUUIDs(values)
			if err != nil && err != io.EOF {
				b.Fatal(err)
			}
			for i := range n {
				if values[i] == needle {
					b.Log("Found!")
				}
			}
		}},
	} {
		b.Run(bm.name, func(b *testing.B) {
			b.ReportAllocs()
			b.SetBytes(16 * numRows)
			b.ResetTimer()

			for b.Loop() {
				pages := column.Pages()
				for {
					page, err := pages.ReadPage()
					if err != nil {
						if err == io.EOF {
							break
						}
						b.Fatal(err)
					}
					bm.readPage(b, page)
				}
				if err := pages.Close(); err != nil {
					b.Fatal(err)
				}
			}
		})
	}
}

```

</details>

Results:

```
goos: darwin
goarch: arm64
pkg: github.com/parquet-go/parquet-go
cpu: Apple M4 Pro
BenchmarkReadUUIDPage
BenchmarkReadUUIDPage/Values
BenchmarkReadUUIDPage/Values-14         	     373	   3044556 ns/op	2627.64 MB/s	20431578 B/op	     398 allocs/op
BenchmarkReadUUIDPage/DirectUUIDs
BenchmarkReadUUIDPage/DirectUUIDs-14    	     781	   1512946 ns/op	5287.70 MB/s	16350402 B/op	     397 allocs/op

```