### PR TITLE
schema: panic on unrecognized parquet struct tag options

### DIFF
--- a/column_buffer_json_test.go
+++ b/column_buffer_json_test.go
@@ -1168,12 +1168,12 @@ func TestJSONRawMessageNumberConversions(t *testing.T) {
 func TestJSONRawMessageFixedLenByteArray(t *testing.T) {
 	type ReadRecord struct {
 		ID   int64    `parquet:"id"`
-		UUID [16]byte `parquet:"uuid,fixedlenbytearray"`
+		UUID [16]byte `parquet:"uuid"`
 	}
 
 	type WriteRecord struct {
 		ID   int64           `parquet:"id"`
-		UUID json.RawMessage `parquet:"uuid,fixedlenbytearray"`
+		UUID json.RawMessage `parquet:"uuid"`
 	}
 
 	schema := SchemaOf(ReadRecord{})

--- a/schema.go
+++ b/schema.go
@@ -750,7 +750,7 @@ func nodeOf(path []string, t reflect.Type, tags parquetTags, tagReplacements []S
 				}
 				n = FieldID(n, id)
 			default:
-				throwUnknownTag(t, "map", option)
+				throwUnknownTag(t, "map", joinOptionArgs(option, args))
 			}
 		})
 
@@ -786,6 +786,17 @@ func splitOptionArgs(s string) (option, args string) {
 		args = "()"
 	}
 	return
+}
+
+// joinOptionArgs is the inverse of splitOptionArgs for the purpose of
+// rendering a tag back to the user. splitOptionArgs returns args="()" as
+// a sentinel meaning "no parens in the source"; we drop it here so plain
+// options don't render as "foo()" in panic messages.
+func joinOptionArgs(option, args string) string {
+	if args == "()" {
+		return option
+	}
+	return option + args
 }
 
 func parseDecimalArgs(args string) (scale, precision int, err error) {
@@ -1327,6 +1338,8 @@ func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, ta
 					throwInvalidTag(t, name, option+args)
 				}
 				setNode(Geography(crs, alg))
+			default:
+				throwUnknownTag(t, name, joinOptionArgs(option, args))
 			}
 		})
 	}
@@ -1390,6 +1403,7 @@ func forEachTagOption(tags []string, do func(option, args string)) {
 			option, tag = split(tag)
 			var args string
 			option, args = splitOptionArgs(option)
+			option = strings.TrimSpace(option)
 			do(option, args)
 		}
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -517,6 +517,16 @@ func TestSchemaOf(t *testing.T) {
 	optional int64 timestamp (TIMESTAMP(isAdjustedToUTC=true,unit=MILLIS));
 }`,
 		},
+
+		// Whitespace after commas in option lists is tolerated.
+		{
+			value: new(struct {
+				Name string `parquet:"name, optional"`
+			}),
+			print: `message {
+	optional binary name (STRING);
+}`,
+		},
 	}
 
 	for _, test := range tests {
@@ -666,6 +676,34 @@ func TestInvalidSchemaOf(t *testing.T) {
 				V int `parquet:",int"`
 			}),
 			panic: `int() is an invalid parquet tag: V int [int()]`,
+		},
+		// Unrecognized options on regular struct fields must panic via
+		// throwUnknownTag, mirroring the existing strict behavior for map
+		// option tags. xitongsys/parquet-go-style tags (type=, convertedtype=,
+		// repetitiontype=) are the most common offenders.
+		{
+			value: new(struct {
+				Date time.Time `parquet:"date, type=INT64, convertedtype=TIMESTAMP_MILLIS"`
+			}),
+			panic: `type=INT64 is an unrecognized parquet tag: date time.Time [type=INT64]`,
+		},
+		{
+			value: new(struct {
+				Date time.Time `parquet:"date,convertedtype=TIMESTAMP_MILLIS"`
+			}),
+			panic: `convertedtype=TIMESTAMP_MILLIS is an unrecognized parquet tag: date time.Time [convertedtype=TIMESTAMP_MILLIS]`,
+		},
+		{
+			value: new(struct {
+				V int `parquet:",foobar"`
+			}),
+			panic: `foobar is an unrecognized parquet tag: V int [foobar]`,
+		},
+		{
+			value: new(struct {
+				V int `parquet:",foo(bar)"`
+			}),
+			panic: `foo(bar) is an unrecognized parquet tag: V int [foo(bar)]`,
 		},
 	}
 


### PR DESCRIPTION
Closes #493.

We hit this same thing at work, so I figured I'd try my hand at fixing it.

## Change

- Add `default: throwUnknownTag(...)` to the struct-field option switch in `makeNodeOf`, mirroring the existing default in the map-option switch.
- Trim each option in `forEachTagOption` so `parquet:"x, optional"` (space after comma) is parsed correctly instead of silently dropped.
- Add a small `joinOptionArgs` helper so parenthesized unknown options panic with the full token (e.g. `foo(bar)`, not just `foo`).

## Repro from #493

```go
type Record struct {
    Name string    `parquet:"name"`
    Date time.Time `parquet:"date, type=INT64, convertedtype=TIMESTAMP_MILLIS"`
}

func main() {
    rec := Record{
        Name: "test",
        Date: time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC),
    }

    buf := &bytes.Buffer{}
    writer := parquet.NewGenericWriter[Record](buf)
    if _, err := writer.Write([]Record{rec}); err != nil {
        panic(err)
    }
    if err := writer.Close(); err != nil {
        panic(err)
    }

    reader := parquet.NewGenericReader[Record](bytes.NewReader(buf.Bytes()))
    defer reader.Close()

    schema := reader.Schema()
    dateCol, _ := schema.Lookup("date")
    fmt.Printf("Date column logical type: %v\n", dateCol.Node.Type().LogicalType())

    out := make([]Record, 1)
    if _, err := reader.Read(out); err != nil && err != io.EOF {
        panic(err)
    }

    fmt.Printf("Written: %v\n", rec.Date)
    fmt.Printf("Read:    %v\n", out[0].Date)
}
```

Before this PR: runs without error; the `Date` column ends up as a nanosecond timestamp because the `type=` and `convertedtype=` options are silently dropped.

After:

```
panic: type=INT64 is an unrecognized parquet tag: date time.Time [type=INT64]
```

## Notes

- The strict default also fires for `parquet-key:` / `parquet-value:` / `parquet-element:` tags and for runtime `parquet.StructTag(...)`. Anything previously tolerated on those paths will panic on upgrade. The repo's own `TestJSONRawMessageFixedLenByteArray` was relying on a stray `,fixedlenbytearray` that's cleaned up here.
- The whitespace trim is a behavior fix as well as a diagnostic improvement — previously `parquet:"x, optional"` left the field non-optional silently. A new `TestSchemaOf` case locks the trim in.

Happy to split into two commits (strict-mode flip + whitespace handling) if you'd prefer them reviewed independently.
