### PR TITLE
feat: verbatim column-chunk copy in Writer.WriteRowGroup

### DIFF
--- a/config.go
+++ b/config.go
@@ -319,6 +319,7 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 		SkipPageBounds:               coalesceSlices(c.SkipPageBounds, config.SkipPageBounds),
 		SkipPageStatistics:           coalesceSlices(c.SkipPageStatistics, config.SkipPageStatistics),
 		Encodings:                    encodings,
+		DictionaryMaxBytes:           cmp.Or(c.DictionaryMaxBytes, config.DictionaryMaxBytes),
 		SchemaConfig:                 cmp.Or(c.SchemaConfig, config.SchemaConfig),
 		Encryption:                   cmp.Or(c.Encryption, config.Encryption),
 	}

--- a/docs/merge-copy-optimization.md
+++ b/docs/merge-copy-optimization.md
@@ -294,24 +294,97 @@ Guards that keep the change scoped and correct:
 - Splitting only happens when at least one segment is copy-eligible, so pure
   re-encode merges keep their existing output structure.
 
-### Increment 4 — L2/L3 partial layers (DEFERRED, optional)
+### Increment 4 — L2/L3 partial layers (L3 DONE, L2 DESIGNED)
 
-Deliberately not implemented. The config-mismatch case (different codec or
-encoding) already produces correct output via the row-oriented re-encode
-fallback; L2/L3 would only make it faster. The plan marked this increment
-optional, and L2's raw-page recompression carries file-corruption risk
-(notably the DataPageV2 layout, below) that is disproportionate to a marginal
-speed gain on a non-primary case. Documented mechanism for a future, deliberate
-implementation:
+The config-mismatch case already produces correct output via the row-oriented
+re-encode fallback; L2/L3 only make it faster. **L3 is implemented** (see below).
+L2 is designed but not implemented; it is worth doing for codec-migration
+workloads (e.g. recompress an existing Snappy file to Zstd) because it skips
+value decode and re-encode, paying only decompress + recompress.
 
-- **L2 (decompress, recompress, skip decode)** for encoding-matches /
-  codec-differs (e.g. recompress Snappy→Zstd): iterate raw pages, decompress the
-  body, recompress with the destination codec, rewrite the page header
-  (`CompressedPageSize`, CRC), copy statistics, rebuild the offset index.
-  Caveat: DataPageV2 stores repetition/definition levels *uncompressed* ahead of
-  the values, so only the values portion may be recompressed
-  (`{Repetition,Definition}LevelsByteLength`); the simplest safe first cut would
-  handle DataPageV1 only and demote V2.
-- **L3 (decode, skip row assembly)** mainly buys per-column parallelism over the
-  re-encode path (the payoff for `WriteColumnConcurrency` on mismatched configs);
-  lower priority than L2.
+#### L2 — transcode compression, skip value decode
+
+Fires when, per column chunk: physical type matches, **encoding matches**, data
+page version matches, no encryption, no writer-requested bloom filter, source
+column + offset index present, and the **codec differs** from the writer's
+configured codec (if the codec also matched, that is L0).
+
+Per-page transcode (validated against the decode path in `column.go`):
+
+- **DataPage (v1) and DictionaryPage:** the whole body is one compressed blob.
+  `decompressed = srcCodec.Decode(body)`; `newBody = dstCodec.Encode(decompressed)`.
+- **DataPageV2:** the body is
+  `[rep levels: RepetitionLevelsByteLength bytes][def levels:
+  DefinitionLevelsByteLength bytes][compressed values]`; the levels are
+  **uncompressed**. So `levelsLen = repLen + defLen`; keep `body[:levelsLen]`
+  verbatim, recompress only `body[levelsLen:]`:
+  `newBody = body[:levelsLen] ++ dstCodec.Encode(srcCodec.Decode(body[levelsLen:]))`.
+  Respect `IsCompressed` (false ⇒ source values are raw).
+- Rewrite the page header: new `CompressedPageSize`, recomputed CRC;
+  `UncompressedPageSize`, encoding, levels lengths, num values, and page
+  statistics are unchanged.
+
+Because the codec change alters compressed sizes, L2 cannot stream a contiguous
+range like L0. It transcodes page-by-page into a staging buffer and rebuilds the
+**offset index** from the new per-page compressed sizes. The **column index** and
+chunk statistics are codec-independent, so they are copied verbatim from the
+source (as in L0). `TotalCompressedSize` is recomputed.
+
+Building blocks already present: a raw page iterator can be built by reading the
+chunk section `[baseOffset, +TotalCompressedSize)` and decoding each
+`format.PageHeader` followed by `CompressedPageSize` body bytes (the same seam
+`FilePages.readPage` uses before decode); `compress.Codec.Encode/Decode` for the
+transcode; `writerBuffers.crc32` for the CRC; the thrift encoder for the header.
+
+Integration: extend the per-chunk predicate to return a tier (L0 / L2 / none).
+L2 stages transcoded data pages in the column's page buffer (reintroducing the
+buffering that L0 avoids — acceptable here since L2 is already CPU-bound on
+(de)compression) plus a transcoded dictionary page, with a prebuilt column index;
+`writeRowGroup` writes them much like the pre-streaming L0 path did.
+
+Risk: page-layout surgery (esp. the V2 levels boundary), CRC, and offset-index
+rebuild — all file-corruption-class if wrong. Mitigation: round-trip tests per
+page version and per codec, plus a property test comparing L2 output bytes'
+decoded values against the source.
+
+Expected gain: skips value decode + re-encode but keeps (de)compression, so
+~2–4× over full re-encode for a codec change (vs L0's ~350×, which also skips
+(de)compression).
+
+#### L3 — re-encode column-by-column, skip row assembly (DONE)
+
+Implemented in `writer_reencode.go`. When a single file-backed source row group's
+schema matches the writer but it cannot be copied verbatim (codec/encoding/etc.
+differ), `WriteRowGroup` re-encodes it **column-by-column** instead of the
+row-oriented fallback: it reads each column's values directly
+(`ColumnChunkValueReader`) and feeds them to the column writer's
+`WriteRowValues`, which re-encodes, re-compresses, computes statistics, and
+populates bloom filters exactly as the row path would. This skips the wasteful
+round-trip of interleaving columns into `Row` objects and immediately tearing
+them back apart.
+
+Fires when every column unwraps to a file-backed chunk (guaranteeing that
+reading column-wise preserves row order — this excludes overlapping heap merges,
+whose order depends on cross-column interleaving) and the source row count fits
+the configured row group size. Output is data-identical to the row path (only
+config-unspecified page boundaries may differ).
+
+Measured (200k rows, codec differs from source so L0 can't fire, → `io.Discard`):
+
+| workload | row path | L3 | speedup | L3 allocs |
+|---|---|---|---|---|
+| 6 cols, uncompressed dest | ~23.4 ms | ~12.3 ms | **1.90×** | 6× less |
+| 6 cols, Zstd dest | ~33.6 ms | ~23.0 ms | **1.46×** | 4× less |
+| 24 cols, Zstd dest | ~76.8 ms | ~55.0 ms | **1.40×** | 2× less |
+
+The uncompressed case isolates the win (no compression cost in either arm): the
+entire ~1.9× and the 6× allocation drop come purely from avoiding the row
+round-trip. With compression the relative speedup shrinks (compression is a
+fixed cost in both paths) but remains a real wall-clock saving.
+
+Column concurrency was prototyped on top of L3 (the per-column re-encode is
+genuinely CPU-heavy, unlike L0): it added a further ~1.2–1.7× depending on
+workload, but its benefit is workload-dependent and its peak memory scales with
+the worker count (decompressed column working sets held concurrently). It was
+left out for now to keep L3 simple and allocation-light; it can be added later as
+an opt-in `WriterConfig` knob if a concrete workload justifies it.

--- a/docs/merge-copy-optimization.md
+++ b/docs/merge-copy-optimization.md
@@ -281,10 +281,37 @@ Two parts:
 
 Decision on the transparency invariant: row-group partitioning *below*
 `MaxRowsPerRowGroup` is treated as an unspecified internal (the same class as
-page boundaries/sizing, which the invariant already permits to differ). Emitting
-one output row group per copyable segment preserves all rows, their order, and
-correct per-row-group statistics/indexes; only the number of row groups (each
-still ≤ `MaxRowsPerRowGroup`) may differ from the re-encode path.
+page boundaries/sizing, which the invariant already permits to differ). Output
+row groups preserve all rows, their order, and correct per-row-group
+statistics/indexes; only the number of row groups (each still ≤
+`MaxRowsPerRowGroup`) may differ from the re-encode path.
+
+Packing toward `MaxRowsPerRowGroup`: `MaxRowsPerRowGroup` is a maximum, not an
+exact target, and undershooting is fine. Consecutive non-overlapping
+(file-backed) segments are greedily packed into output row groups up to the
+limit (`writeSegmentsPacked`):
+
+- a **single-segment batch** is written through the normal path, preserving the
+  verbatim **L0** copy for the common 1:1 rewrite (each source row group already
+  ≈ the target size);
+- a **multi-segment batch** (many small inputs being consolidated) is written as
+  one output row group via **L3** column-by-column re-encode
+  (`packSegmentsByColumn`) — undershooting the limit rather than emitting one
+  tiny row group per source.
+
+Why multi-segment packing can't stay L0: a verbatim copy writes a *complete*
+column chunk, so it cannot append a second source's pages to a partially-filled
+chunk. Consolidating K sources into one output chunk therefore requires
+value-level writing (L3) for the whole batch. For dictionary-encoded columns
+this is unavoidable regardless (each source chunk has its own dictionary, which
+cannot be concatenated); page-concatenation of non-dictionary columns is a
+possible future refinement on top.
+
+The reverse case — a source row group *larger* than `MaxRowsPerRowGroup` — cannot
+be copied or column-packed at all, because column page boundaries do not align
+at a common interior row, so there is nowhere to split without decoding a page.
+Both L0 and L3 demote such a row group to the row path, which splits it
+correctly.
 
 Guards that keep the change scoped and correct:
 - `mergedRowGroup` (overlapping heap merge) returns nil segments — it is never

--- a/docs/merge-copy-optimization.md
+++ b/docs/merge-copy-optimization.md
@@ -1,0 +1,317 @@
+# Merge & Copy Optimization Design
+
+This document audits the optimizations that already exist in the row/page/value
+copy and merge paths, and specifies the design for two new optimizations:
+
+1. **Skip decompression / re-encoding** when pages can be copied from source to
+   destination (priority 1).
+2. **Multi-CPU parallel processing of columns** (priority 2).
+
+## Governing invariant
+
+> The copy optimization must be **semantically transparent**: the output must
+> honor every aspect of the writer configuration (encoding, codec, data page
+> version, statistics, bloom filters, encryption). Any property where a verbatim
+> copy would diverge from configured behavior forces demotion to the layer that
+> can satisfy it — down to full decode. Only config-unspecified internals (exact
+> page boundaries / sizing) may differ.
+
+Correctness dominates. The fast path is a pure accelerator that never changes
+results. The output must be byte-identical regardless of worker count (the
+parallel path buffers and assembles columns in deterministic column order, never
+in completion order).
+
+## Existing optimizations (audit)
+
+### `CopyRows` (row.go:305)
+
+- Schema conversion is applied **only** when `targetSchema != sourceSchema`
+  (`EqualNodes`), explicitly trading away the `RowWriterTo` fast path for safety
+  in the rare evolving-schema case.
+- Two interface fast paths: `src.(RowWriterTo).WriteRowsTo(dst)` and
+  `dst.(RowReaderFrom).ReadRowsFrom(src)`.
+- Otherwise a batched copy through a reusable `[]Row` buffer
+  (`defaultRowBufferSize`), with `clearRows` recycling.
+
+### `CopyValues` (value.go:102)
+
+- Same shape: `ValueWriterTo` / `ValueReaderFrom` fast paths, else a batched
+  buffer copy.
+
+### `CopyPages` (page.go:340)
+
+- Plain `ReadPage` → `WritePage` loop with `Release(p)` recycling. No fast-path
+  interface.
+
+### `MergeRowGroups` (merge.go:25)
+
+- Empty / schema auto-merge handling via `MergeNodes`.
+- No effective sorting columns → `multiRowGroup` **concatenation**
+  (deterministic, no heap).
+- **Non-overlapping segment detection** (`overlappingRowGroups`, merge.go:127):
+  uses the column-index min/max of the sorting columns to partition row groups
+  into segments. Single-row-group segments are concatenated directly; only
+  overlapping segments go through the heap merge. *This is already a "direct copy
+  of non-overlapping ranges", but at row-group granularity.*
+- Dedup wrapping only when configured.
+
+### `MergeRowReaders` (merge.go:472)
+
+- Specialized by arity: 0 → empty, 1 → passthrough, 2 → `mergedRowReader2`
+  (no heap, bulk-drains the survivor when one side ends), N → heap
+  `mergedRowReader`. Both buffer 24 rows via `bufferedRowReader`.
+
+### The gap
+
+`Writer.WriteRowGroup` (writer.go:536) always does `rowGroup.Rows()` →
+`CopyRows` → `WriteRows` → column buffers → `writeDataPage` (writer.go:2240),
+which **re-encodes and re-compresses every value** (`buf.compress`,
+writer.go:2269). Nothing in the merge/copy path ever moves compressed page bytes
+through intact.
+
+The read seam already exists: `FilePages.readPage` (file.go:1371) reads the
+**compressed** page bytes into a buffer; decompression + decode only happen later
+in `decodeDataPageV1/V2`. So `(header, compressed-bytes)` is available before any
+codec work. There is no "decompressed-but-not-decoded" page object today — L2
+needs a new intermediate construct.
+
+## The copy cascade (priority 1)
+
+The copy unit is the **column chunk**; layer selection is per column chunk (and
+within a chunk, uniform across its pages, since pages of one chunk share encoding
+and codec). Four layers, each firing in strictly more situations than the one
+above:
+
+| Layer | What it skips | Fires when |
+|-------|---------------|------------|
+| **L0** — chunk copy | decompress + decode + encode + compress | `enc_src == enc_dst && codec_src == codec_dst && type matches` and no disqualifier |
+| **L1** — page copy, skip decompression | decompress + decode + encode + compress (per page) | same as L0 but applied page-by-page (mainly relevant to coalescing, deprioritized) |
+| **L2** — page copy, decompress but skip decoding | decode + encode | `enc_src == enc_dst && codec_src != codec_dst` |
+| **L3** — page copy, decode but skip row assembly | per-row deconstruct/reconstruct | `enc_src != enc_dst`, or any demotion below |
+
+Since each output row group derives from exactly **one** source row group (1:1,
+see use case below), the output column chunk is built entirely from one source
+chunk — including its dictionary page — so even per-page copies stay
+dictionary-safe. No cross-source dictionary remapping is needed.
+
+### Codec/encoding reconciliation
+
+Strict: the output **honors the writer's configuration**. Optimizations fire only
+when source and destination configs match. The per-chunk predicate is therefore
+deterministic (see table). This mirrors the existing `CopyRows` philosophy
+(convert only when schemas differ; optimize the matched-config common case).
+
+### Statistics, indexes, bloom filters
+
+For verbatim-copied (L0/L1) chunks:
+
+- Copy each page's `Statistics` from the source page header.
+- Copy the source `ColumnIndex` min/max/null/nan arrays verbatim; **regenerate
+  the `OffsetIndex`** from the new file positions (every page lands at a new
+  offset, so `OffsetIndex` and the chunk's dictionary/data offsets in
+  `ColumnMetaData` must be rewritten even though the bytes are verbatim).
+- Copy the source bloom filter bytes if present **and** the writer is configured
+  to want one for that column.
+
+Demotions required to preserve the invariant:
+
+- **Incompatible bloom-filter configuration** (writer wants a filter the source
+  lacks) → demote to **L3** (decode and rebuild). Most columns have no filter, so
+  the gains hold.
+- **Missing source statistics** + writer configured to write stats → demote to
+  **L3** (decode and compute). Conservative: respect the writer config rather
+  than silently dropping stats.
+
+### Hard disqualifiers (force L3 / full decode)
+
+- **Encryption** on either side — per-page AAD keys on row-group/column/page
+  ordinals change in the output; re-encryption needs the plaintext.
+- **Data page version mismatch** (V1 vs V2) — byte layout differs even at equal
+  encoding; transcoding needs decoded levels/values.
+
+CRC stays valid for L0/L1 (bytes unchanged); L2 (recompress) must recompute it.
+
+## Use case: rewrite large row groups 1:1
+
+The primary use case is **rewriting / merging row groups that are already at or
+near target size**, not consolidating many tiny row groups into fewer large ones.
+
+Consequence: a verbatim L0 chunk copy is inherently **1:1** (source row group →
+output row group). Cross-source **L1 coalescing** (concatenating pages from
+multiple source chunks to hit a target row-group size) is **out of scope** for
+the initial design; it is a partial win anyway because dict-encoded columns would
+fall to L3.
+
+## Dispatch (transparent)
+
+The optimization is transparent through `Writer.WriteRowGroup` — no new public
+API the caller must opt into. A copyable source advertises its capability via a
+**fast-path interface** (a raw-page capability, analogous to `RowReaderFrom` /
+`RowWriterTo`). `WriteRowGroup` detects it and routes per column chunk to the
+copy path, falling back to the existing re-encode path for any non-matching
+column.
+
+The capability must be **forwarded through wrappers**: `Convert` returns
+`identity` for equal nodes (convert.go:341) and `ConvertRowGroup` returns the row
+group unwrapped when `EqualNodes` holds (convert.go:541), but reindexed columns
+get a `convertedColumnChunk`, and merge segments get `multiColumnChunk`. These
+wrappers must delegate the raw-page interface to the underlying chunk for the
+transparent path to survive a merge.
+
+Write side: a sibling to `writeDataPage`, e.g. `writeRawPage(header,
+compressedBytes, copiedStats)`, writes verbatim bytes to the column's buffer via
+`writePageTo` and records the copied stats / column-index entries (instead of
+computing them). Columns fill independent buffers; `writeRowGroup` assembles them
+in column order — which is also the parallelism boundary.
+
+## Parallel column processing (priority 2)
+
+- **Unit:** columns within a row group. Each column chunk's bytes are produced
+  concurrently into independent buffers, then written sequentially in column
+  order. (Row-group-level parallelism already exists via `BeginRowGroup` /
+  `ConcurrentRowGroupWriter`.)
+- **Bounding:** a bounded worker pool (default `GOMAXPROCS`, configurable via a
+  `WriterConfig` knob), processing columns in waves so peak memory is ≈ *degree*
+  column chunks, not all of them. Critical for wide schemas (thousands of leaf
+  columns).
+- **Determinism:** completed-but-not-yet-writable columns buffer until their turn
+  in column order. A slow column can stall writing of later columns it finished
+  first; that is accepted to preserve byte-identical output.
+- **Opt-in:** default off (degree 1). Concurrent reads multiply memory and load
+  on the source `ReaderAt`; not every caller wants that tradeoff.
+- **Source restriction:** random-access (`io.ReaderAt`) sources only. Each
+  `ColumnChunk.Pages()` creates its own `FilePages` reading its byte range via
+  the file's `ReaderAt`, so concurrent column readers are naturally isolated.
+- **Path coverage:** only the single-source row-group path (plain rewrite +
+  non-overlapping segments). The overlapping-segment **heap merge**
+  (`mergedRowReader`) is row-oriented and stays sequential — partitioning a
+  sorted output range across workers is a separate, harder problem not justified
+  by the primary use case.
+
+## Delivery sequence
+
+1. **Increment 1 — single-source L0 copy through `WriteRowGroup`.** Detect a
+   copyable file-backed row group, copy whole column chunks verbatim (dict + data
+   pages), offset-translate the column/offset index, copy stats; demote any
+   non-matching column to the existing re-encode path. Delivers the headline win
+   for plain file rewrites; does not touch `MergeRowGroups`.
+2. **Increment 2 — column parallelism.** `WriterConfig` knob, bounded pool, over
+   the single-source path.
+3. **Increment 3 — merge integration.** Teach `MergeRowGroups` to surface
+   non-overlapping single-source segments through the same fast-path interface.
+4. **Increment 4 (optional) — L2/L3 partial layers** for codec/encoding-mismatched
+   columns, and only-if-needed L1 coalescing.
+
+Each increment is independently shippable. The transparency invariant means each
+is a pure accelerator that can be merged without behavior change.
+
+## Implementation status
+
+### Increment 1 — single-source L0 copy (DONE)
+
+`writer_copy.go` + hooks in `writer.go`. `Writer.WriteRowGroup` detects when an
+input row group's column chunks can be copied verbatim and splices the
+contiguous source byte range (dictionary page + data pages) into the output,
+copying statistics, column index, and offset index (offset-translated). The
+existing re-encode path is untouched (it now lives in the `else` branch of the
+column loop in `writeRowGroup`). All-or-nothing per row group: if any column is
+not copyable the whole row group falls back.
+
+Predicate (`columnChunkIsCopyable`): matching physical type, codec, encoding, and
+data page version; source not encrypted and writer not encrypting; no
+writer-requested bloom filter; source column index and offset index present.
+Anything else demotes to the re-encode path (honoring the transparency
+invariant).
+
+The copy path streams each source byte range (dictionary + data pages) straight
+into the output via `offsetTrackingWriter.ReadFrom` → `bufio.ReadFrom`, with no
+intermediate buffer and no per-chunk allocation. An earlier version staged the
+bytes in a `make([]byte, TotalCompressedSize)` per chunk; profiling showed that
+allocation was ~96% of all allocations and the resulting GC/scheduler churn
+dominated CPU (the throughput was alloc/GC-bound, *not* memory-bandwidth-bound).
+Removing it cut time/op ~3× and B/op ~27×.
+
+Benchmark (`BenchmarkWriteRowGroupCopy` vs `…Reencode`, Apple M4 Max, 200k rows,
+6 columns, Snappy, 4 row groups, in-memory source → `io.Discard`):
+
+| | ns/op | throughput | B/op | allocs/op |
+|---|---|---|---|---|
+| Copy (L0) | ~86,000 | ~30 GB/s | 104 KB | 408 |
+| Re-encode | ~30,300,000 | ~87 MB/s | 23.2 MB | 2,579 |
+| Ratio | **~350×** | ~350× | ~220× | ~6× |
+
+Single-threaded (`GOMAXPROCS=1`) the copy path sustains ~28 GB/s; the remaining
+cost is the actual byte copy (`bufio.ReadFrom`) plus footer thrift-encoding of
+the copied page indexes, both largely irreducible. This is CPU/allocation
+savings; with real disk/network I/O the wall-clock multiple compresses (I/O
+becomes a larger share) but the CPU/alloc wins hold.
+
+### Increment 2 — column parallelism (EVALUATED, REMOVED)
+
+A `WriteColumnConcurrency` `WriterConfig` option with a bounded worker pool was
+implemented and verified deterministic/race-free, then **removed**. Rationale:
+
+The streaming rewrite (see Increment 1) made `loadCopiedChunk` cheap — it reads
+only the small page index and records byte ranges; the actual data copy happens
+sequentially in `writeRowGroup`. So the concurrency knob parallelized only the
+*cheap* index reads while the *expensive* data copy stayed serial, yielding no
+measurable benefit on any source (neutral-to-negative in every benchmark).
+Shipping a public API option that can't be justified by a benchmark is a
+liability (removal would be breaking), so it was dropped.
+
+Parallelism should be reintroduced only where the per-column work is actually
+expensive — i.e. alongside the L2/L3 re-encode layers (below), or as parallel
+*data* prefetch into pooled buffers for high-latency sources — and designed for
+that case rather than retrofitted onto the now-trivial copy load.
+
+### Increment 3 — merge integration (DONE)
+
+Two parts:
+
+1. `fileColumnChunkOf` unwraps `convertedColumnChunk` (positional column remap,
+   e.g. column reordering from `MergeNodes`) to reach the underlying file-backed
+   chunk, so copy fires through that wrapper. A type difference is still caught
+   and demoted by the predicate's type check.
+2. Segment splitting: `WriteRowGroup` recognizes a row group that is the in-order
+   concatenation of independently writable segments
+   (`orderedRowGroupSegments`) and, when at least one segment is copyable, writes
+   each segment as its own output row group — so a merge of non-overlapping,
+   sorted inputs copies its segments verbatim while re-encoding only the
+   overlapping ones.
+
+Decision on the transparency invariant: row-group partitioning *below*
+`MaxRowsPerRowGroup` is treated as an unspecified internal (the same class as
+page boundaries/sizing, which the invariant already permits to differ). Emitting
+one output row group per copyable segment preserves all rows, their order, and
+correct per-row-group statistics/indexes; only the number of row groups (each
+still ≤ `MaxRowsPerRowGroup`) may differ from the re-encode path.
+
+Guards that keep the change scoped and correct:
+- `mergedRowGroup` (overlapping heap merge) returns nil segments — it is never
+  split, because its order depends on cross-row-group interleaving.
+- `sortedSegmentRowGroup` returns nil segments when `dropDuplicatedRows` is set —
+  deduplication spans segment boundaries and would be lost by independent writes.
+- Splitting only happens when at least one segment is copy-eligible, so pure
+  re-encode merges keep their existing output structure.
+
+### Increment 4 — L2/L3 partial layers (DEFERRED, optional)
+
+Deliberately not implemented. The config-mismatch case (different codec or
+encoding) already produces correct output via the row-oriented re-encode
+fallback; L2/L3 would only make it faster. The plan marked this increment
+optional, and L2's raw-page recompression carries file-corruption risk
+(notably the DataPageV2 layout, below) that is disproportionate to a marginal
+speed gain on a non-primary case. Documented mechanism for a future, deliberate
+implementation:
+
+- **L2 (decompress, recompress, skip decode)** for encoding-matches /
+  codec-differs (e.g. recompress Snappy→Zstd): iterate raw pages, decompress the
+  body, recompress with the destination codec, rewrite the page header
+  (`CompressedPageSize`, CRC), copy statistics, rebuild the offset index.
+  Caveat: DataPageV2 stores repetition/definition levels *uncompressed* ahead of
+  the values, so only the values portion may be recompressed
+  (`{Repetition,Definition}LevelsByteLength`); the simplest safe first cut would
+  handle DataPageV1 only and demote V2.
+- **L3 (decode, skip row assembly)** mainly buys per-column parallelism over the
+  re-encode path (the payoff for `WriteColumnConcurrency` on mismatched configs);
+  lower priority than L2.

--- a/merge.go
+++ b/merge.go
@@ -278,6 +278,12 @@ type mergedRowGroup struct {
 	dropDuplicatedRows bool
 }
 
+// rowGroupSegments opts out of segment splitting: a mergedRowGroup interleaves
+// rows from overlapping row groups via a heap merge, so its row groups cannot be
+// written independently without losing the merged ordering. It overrides the
+// method promoted from the embedded multiRowGroup.
+func (m *mergedRowGroup) rowGroupSegments() []RowGroup { return nil }
+
 func (m *mergedRowGroup) Rows() Rows {
 	// The row group needs to respect a sorting order; the merged row reader
 	// uses a heap to merge rows from the row groups.
@@ -305,6 +311,18 @@ type sortedSegmentRowGroup struct {
 	segments           []RowGroup
 	compare            func(Row, Row) int
 	dropDuplicatedRows bool
+}
+
+// rowGroupSegments implements orderedRowGroupSegments: the segments are already
+// in sorted order and each segment's own Rows() preserves its internal ordering,
+// so writing them in sequence preserves the global order. It returns nil when
+// dropping duplicates, because deduplication spans segment boundaries and would
+// be lost if segments were written independently.
+func (s *sortedSegmentRowGroup) rowGroupSegments() []RowGroup {
+	if s.dropDuplicatedRows {
+		return nil
+	}
+	return s.segments
 }
 
 func (s *sortedSegmentRowGroup) Rows() Rows {

--- a/multi_row_group.go
+++ b/multi_row_group.go
@@ -126,6 +126,11 @@ func (m *multiRowGroup) Schema() *Schema { return m.schema }
 
 func (m *multiRowGroup) Rows() Rows { return NewRowGroupRowReader(m) }
 
+// rowGroupSegments implements orderedRowGroupSegments: a multiRowGroup is the
+// in-order concatenation of its row groups, so each may be written independently
+// while preserving row order.
+func (m *multiRowGroup) rowGroupSegments() []RowGroup { return m.rowGroups }
+
 type multiColumnChunk struct {
 	rowGroup  *multiRowGroup
 	column    int

--- a/writer.go
+++ b/writer.go
@@ -549,15 +549,7 @@ func (w *Writer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 	// so the copyable ones take the fast path. Row group sizing below
 	// MaxRowsPerRowGroup is an unspecified internal; data and order are preserved.
 	if segments, ok := w.splittableCopyableSegments(rowGroup); ok {
-		var total int64
-		for _, seg := range segments {
-			n, err := w.WriteRowGroup(seg)
-			if err != nil {
-				return total, err
-			}
-			total += n
-		}
-		return total, nil
+		return w.writeSegmentsPacked(segments, rowGroup.Schema(), rowGroup.SortingColumns())
 	}
 	if err := w.writer.flush(); err != nil {
 		return 0, err

--- a/writer.go
+++ b/writer.go
@@ -571,6 +571,16 @@ func (w *Writer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 		}
 		return w.writer.writeRowGroup(w.writer.currentRowGroup, rowGroup.Schema(), rowGroup.SortingColumns())
 	}
+	// L3 fast path: a file-backed source whose schema matches but cannot be
+	// copied verbatim (config differs) is re-encoded column-by-column, skipping
+	// the row assembly/deconstruction round-trip of the path below.
+	if cols, ok := w.reencodableRowGroup(rowGroup); ok {
+		w.writer.currentRowGroup.configureBloomFilters(rowGroup.ColumnChunks())
+		if err := w.writeRowGroupByColumn(cols); err != nil {
+			return 0, err
+		}
+		return w.writer.writeRowGroup(w.writer.currentRowGroup, rowGroup.Schema(), rowGroup.SortingColumns())
+	}
 	w.writer.currentRowGroup.configureBloomFilters(rowGroup.ColumnChunks())
 	rows := rowGroup.Rows()
 	defer rows.Close()

--- a/writer.go
+++ b/writer.go
@@ -543,8 +543,33 @@ func (w *Writer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 	case !EqualNodes(w.schema, rowGroupSchema):
 		return 0, ErrRowGroupSchemaMismatch
 	}
+	// When the row group is the in-order concatenation of independently writable
+	// segments and at least one segment can be copied verbatim (e.g. a merge of
+	// non-overlapping row groups), write each segment as its own output row group
+	// so the copyable ones take the fast path. Row group sizing below
+	// MaxRowsPerRowGroup is an unspecified internal; data and order are preserved.
+	if segments, ok := w.splittableCopyableSegments(rowGroup); ok {
+		var total int64
+		for _, seg := range segments {
+			n, err := w.WriteRowGroup(seg)
+			if err != nil {
+				return total, err
+			}
+			total += n
+		}
+		return total, nil
+	}
 	if err := w.writer.flush(); err != nil {
 		return 0, err
+	}
+	// Fast path: when the whole row group can be copied verbatim from a source
+	// file, splice the compressed bytes in directly instead of decoding and
+	// re-encoding every value (see writer_copy.go).
+	if srcs, ok := w.copyableColumnChunks(rowGroup); ok {
+		if err := w.loadCopiedChunks(srcs); err != nil {
+			return 0, err
+		}
+		return w.writer.writeRowGroup(w.writer.currentRowGroup, rowGroup.Schema(), rowGroup.SortingColumns())
 	}
 	w.writer.currentRowGroup.configureBloomFilters(rowGroup.ColumnChunks())
 	rows := rowGroup.Rows()
@@ -1444,6 +1469,34 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 	fileOffset := w.writer.offset
 
 	for i, c := range rg.columns {
+		if c.copied != nil {
+			// Column copied verbatim: use the source's column index and size
+			// statistics, and stream the dictionary and data page bytes straight
+			// from the source file into the output (no intermediate buffer).
+			cc := c.copied
+			rg.columnIndex[i] = cc.columnIndex
+			c.columnChunk.MetaData.SizeStatistics = cc.sizeStats
+
+			if cc.dictLength > 0 {
+				c.columnChunk.MetaData.DictionaryPageOffset = w.writer.offset
+				if _, err := w.writer.ReadFrom(io.NewSectionReader(cc.reader, cc.dictOffset, cc.dictLength)); err != nil {
+					return 0, fmt.Errorf("writing copied dictionary page of row group column %d: %w", i, err)
+				}
+			}
+
+			dataPageOffset := w.writer.offset
+			c.columnChunk.MetaData.DataPageOffset = dataPageOffset
+			for j := range c.offsetIndex.PageLocations {
+				c.offsetIndex.PageLocations[j].Offset += dataPageOffset
+			}
+			if cc.dataLength > 0 {
+				if _, err := w.writer.ReadFrom(io.NewSectionReader(cc.reader, cc.dataOffset, cc.dataLength)); err != nil {
+					return 0, fmt.Errorf("writing copied data pages of row group column %d: %w", i, err)
+				}
+			}
+			continue
+		}
+
 		rg.columnIndex[i] = c.columnIndex.ColumnIndex()
 		rg.columnIndex[i].RepetitionLevelHistogram = append(rg.columnIndex[i].RepetitionLevelHistogram[:0], c.pageRepetitionLevelHistograms...)
 		rg.columnIndex[i].DefinitionLevelHistogram = append(rg.columnIndex[i].DefinitionLevelHistogram[:0], c.pageDefinitionLevelHistograms...)
@@ -1839,6 +1892,10 @@ type ColumnWriter struct {
 	hasSwitchedToPlain bool  // Tracks if dictionary encoding was switched to PLAIN
 	dictionaryMaxBytes int64 // Per-column dictionary size limit
 
+	// Set when this column is being copied verbatim from a source file for the
+	// current row group (see writer_copy.go). nil for the regular re-encode path.
+	copied *copiedChunk
+
 	// Encryption state; nil encKey means column is not encrypted.
 	encKey          []byte
 	rowGroupOrdinal int16
@@ -1878,6 +1935,7 @@ func (c *ColumnWriter) reset() {
 		c.pageBuffer = nil
 	}
 	c.numPages = 0
+	c.copied = nil
 	// Bloom filters may change in size between row groups, but we retain the
 	// buffer to avoid reallocating large memory blocks.
 	c.filter = c.filter[:0]

--- a/writer_copy.go
+++ b/writer_copy.go
@@ -1,0 +1,343 @@
+package parquet
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"sync/atomic"
+
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// copyPathCounter counts column chunks copied verbatim. It exists so tests can
+// assert that the L0 fast path was taken; it is otherwise unused.
+var copyPathCounter atomic.Int64
+
+// disableWriteCopy forces WriteRowGroup onto the regular re-encode path. It
+// exists only so benchmarks can measure the copy optimization against an
+// otherwise identical baseline.
+var disableWriteCopy bool
+
+// This file implements the "L0" copy optimization for Writer.WriteRowGroup:
+// when a source row group's column chunks can be copied verbatim (compressed
+// bytes moved through without decompression, decoding, re-encoding, or
+// re-compression), the writer splices the source bytes directly into the output
+// and copies the associated statistics and page index.
+//
+// The optimization is transparent: WriteRowGroup detects copyable sources and
+// falls back to the regular re-encode path otherwise. It is conservative — it
+// only fires when a verbatim copy is provably indistinguishable from the
+// configured re-encode behavior (matching type, encoding, codec, data page
+// version; no encryption; no writer-requested bloom filter; source statistics
+// and page index present). See docs/merge-copy-optimization.md.
+//
+// Increment 1 is all-or-nothing per row group: every column chunk must be
+// copyable, otherwise the whole row group falls back to the regular path.
+
+// copiedChunk holds the prebuilt metadata for a column chunk copied verbatim
+// from a source file, plus the source byte ranges of its dictionary and data
+// pages. The bytes are streamed directly from the source into the output during
+// row group assembly (no intermediate buffer or per-chunk allocation).
+type copiedChunk struct {
+	reader        io.ReaderAt // source file reader
+	dictOffset    int64       // byte offset of the dictionary page in the source
+	dictLength    int64       // length of the dictionary page, 0 if none
+	dataOffset    int64       // byte offset of the first data page in the source
+	dataLength    int64       // length of all data pages
+	columnIndex   format.ColumnIndex
+	sizeStats     format.SizeStatistics
+	statistics    format.Statistics
+	encodingStats []format.PageEncodingStats
+	numValues     int64
+	numRows       int64
+
+	totalUncompressedSize int64
+	totalCompressedSize   int64
+}
+
+// orderedRowGroupSegments is implemented by row groups that are the in-order
+// concatenation of independently writable sub-row-groups: writing the segments
+// in sequence yields the same rows, in the same order, as reading Rows(). It is
+// used so the writer can route copyable segments of a merge through the verbatim
+// copy fast path. A row group whose order depends on interleaving across its
+// children (e.g. an overlapping heap merge) or that applies cross-segment
+// deduplication must return nil to opt out.
+type orderedRowGroupSegments interface {
+	rowGroupSegments() []RowGroup
+}
+
+// splittableCopyableSegments returns the writable segments of rowGroup when it
+// is a segmented row group and at least one segment can be copied verbatim. The
+// writer then emits one output row group per segment so the copyable ones take
+// the fast path. Splitting is gated on copy-eligibility so that pure re-encode
+// merges keep their existing output structure.
+func (w *Writer) splittableCopyableSegments(rowGroup RowGroup) ([]RowGroup, bool) {
+	if disableWriteCopy {
+		return nil, false
+	}
+	v, ok := rowGroup.(orderedRowGroupSegments)
+	if !ok {
+		return nil, false
+	}
+	segments := v.rowGroupSegments()
+	if len(segments) <= 1 {
+		return nil, false
+	}
+	for _, seg := range segments {
+		if _, ok := w.copyableColumnChunks(seg); ok {
+			return segments, true
+		}
+	}
+	return nil, false
+}
+
+// copyableColumnChunks returns the source column chunks of rowGroup if the whole
+// row group can be copied verbatim into the writer's output, along with true.
+// Otherwise it returns nil and false, indicating the caller must fall back to
+// the regular re-encode path.
+func (w *Writer) copyableColumnChunks(rowGroup RowGroup) ([]*FileColumnChunk, bool) {
+	if disableWriteCopy {
+		return nil, false
+	}
+	// A verbatim byte copy cannot honor encryption: per-page AAD keys depend on
+	// the output row-group/column/page ordinals, so an encrypted output requires
+	// re-encoding from plaintext.
+	if w.writer.encryption != nil {
+		return nil, false
+	}
+
+	dst := w.writer.currentRowGroup.columns
+	columns := rowGroup.ColumnChunks()
+	if len(columns) != len(dst) {
+		return nil, false
+	}
+
+	srcs := make([]*FileColumnChunk, len(columns))
+	for i, col := range columns {
+		// Unwrap to the underlying file-backed chunk. This handles both directly
+		// file-backed row groups (plain file rewrites) and ConvertRowGroup's
+		// positional remap wrapper (column reordering produced by MergeNodes,
+		// e.g. a single source row group passed through MergeRowGroups). A
+		// genuine type conversion would be caught and demoted by the type check
+		// in columnChunkIsCopyable.
+		fc, ok := fileColumnChunkOf(col)
+		if !ok {
+			return nil, false
+		}
+		if !columnChunkIsCopyable(dst[i], fc) {
+			return nil, false
+		}
+		srcs[i] = fc
+	}
+	return srcs, true
+}
+
+// fileColumnChunkOf unwraps positional-remap wrappers to reach the underlying
+// file-backed column chunk, returning false if the chunk is not (or does not
+// wrap) a *FileColumnChunk.
+func fileColumnChunkOf(col ColumnChunk) (*FileColumnChunk, bool) {
+	for {
+		switch c := col.(type) {
+		case *FileColumnChunk:
+			return c, true
+		case *convertedColumnChunk:
+			col = c.chunk
+		default:
+			return nil, false
+		}
+	}
+}
+
+// loadCopiedChunks stages every source column chunk into its destination
+// ColumnWriter. The per-column work here is cheap (it reads only the page index
+// and records byte ranges); the data bytes are streamed straight to the output
+// during row group assembly, so this is done sequentially.
+func (w *Writer) loadCopiedChunks(srcs []*FileColumnChunk) error {
+	cols := w.writer.currentRowGroup.columns
+	for i, src := range srcs {
+		if err := cols[i].loadCopiedChunk(src); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// columnChunkIsCopyable reports whether the source chunk can be copied verbatim
+// into the column managed by dst, producing output indistinguishable from the
+// configured re-encode behavior.
+func columnChunkIsCopyable(dst *ColumnWriter, src *FileColumnChunk) bool {
+	// Source must be plaintext; we cannot copy ciphertext into a plaintext file.
+	if src.decryptionKey != nil {
+		return false
+	}
+	// Destination must not be encrypting (also covered by the writer-level check,
+	// kept here for defensiveness).
+	if dst.encKey != nil {
+		return false
+	}
+
+	meta := &src.chunk.MetaData
+
+	// Physical type must match.
+	if meta.Type != format.Type(dst.columnType.Kind()) {
+		return false
+	}
+	// Compression codec must match the configured codec.
+	if meta.Codec != dst.compression.CompressionCodec() {
+		return false
+	}
+	// A writer-requested bloom filter would have to be recomputed from decoded
+	// values, which a verbatim copy cannot do. Demote.
+	if dst.columnFilter != nil {
+		return false
+	}
+	// We copy statistics and the page index from the source; require both to be
+	// present so the output honors the writer's statistics configuration.
+	if src.chunk.ColumnIndexOffset == 0 || src.chunk.OffsetIndexOffset == 0 {
+		return false
+	}
+	// All data pages must use the configured encoding and data page version, and
+	// dictionary presence must match the configured encoding.
+	if !encodingStatsMatch(meta.EncodingStats, dst) {
+		return false
+	}
+	return true
+}
+
+// encodingStatsMatch reports whether every page recorded in the source encoding
+// stats is compatible with the destination column's configured encoding and
+// data page version.
+func encodingStatsMatch(stats []format.PageEncodingStats, dst *ColumnWriter) bool {
+	if len(stats) == 0 {
+		return false // cannot verify the source encodings; demote
+	}
+
+	wantPageType := dst.header.page.Type // DataPage (v1) or DataPageV2
+	wantEncoding := dst.encoding.Encoding()
+	wantDict := dst.dictionary != nil
+	sawDict := false
+
+	for _, s := range stats {
+		switch s.PageType {
+		case format.DictionaryPage:
+			sawDict = true
+			if !wantDict {
+				return false
+			}
+		case format.DataPage, format.DataPageV2:
+			if s.PageType != wantPageType {
+				return false // data page version mismatch
+			}
+			if s.Encoding != wantEncoding {
+				return false // encoding mismatch
+			}
+		default:
+			return false
+		}
+	}
+
+	if wantDict != sawDict {
+		return false
+	}
+	return true
+}
+
+// loadCopiedChunk prepares the destination ColumnWriter to emit a source column
+// chunk verbatim during row group assembly. It does not read the page bytes —
+// only the (much smaller) page index and statistics — and records the source
+// byte ranges so the data can be streamed straight to the output later, avoiding
+// a per-chunk allocation and an extra copy.
+func (c *ColumnWriter) loadCopiedChunk(src *FileColumnChunk) error {
+	meta := &src.chunk.MetaData
+
+	// The dictionary page (if any) and the data pages are contiguous byte ranges
+	// in the source file.
+	dataOffset := meta.DataPageOffset
+	dataLength := meta.TotalCompressedSize
+	var dictOffset, dictLength int64
+	if meta.DictionaryPageOffset != 0 {
+		dictOffset = meta.DictionaryPageOffset
+		dictLength = meta.DataPageOffset - meta.DictionaryPageOffset
+		if dictLength < 0 || dictLength > meta.TotalCompressedSize {
+			return fmt.Errorf("invalid source column chunk layout: dictionary offset %d, data offset %d, total %d",
+				meta.DictionaryPageOffset, meta.DataPageOffset, meta.TotalCompressedSize)
+		}
+		dataLength = meta.TotalCompressedSize - dictLength
+	}
+
+	// Copy the column index verbatim (type matches, so the raw min/max bytes are
+	// directly reusable).
+	ci, err := src.ColumnIndex()
+	if err != nil {
+		return fmt.Errorf("reading source column index: %w", err)
+	}
+
+	// Rebuild page locations relative to the start of the data region; the writer
+	// re-absolutizes them once the output data page offset is known.
+	oi, err := src.OffsetIndex()
+	if err != nil {
+		return fmt.Errorf("reading source offset index: %w", err)
+	}
+	srcLocations := oi.(*FileOffsetIndex).index.PageLocations
+	locations := make([]format.PageLocation, len(srcLocations))
+	for i, loc := range srcLocations {
+		loc.Offset -= meta.DataPageOffset
+		locations[i] = loc
+	}
+
+	cc := &copiedChunk{
+		reader:                src.file.reader,
+		dictOffset:            dictOffset,
+		dictLength:            dictLength,
+		dataOffset:            dataOffset,
+		dataLength:            dataLength,
+		columnIndex:           cloneColumnIndex(ci.(*FileColumnIndex).index),
+		sizeStats:             cloneSizeStatistics(meta.SizeStatistics),
+		statistics:            cloneStatistics(meta.Statistics),
+		encodingStats:         slices.Clone(meta.EncodingStats),
+		numValues:             meta.NumValues,
+		numRows:               src.rowGroup.NumRows,
+		totalUncompressedSize: meta.TotalUncompressedSize,
+		totalCompressedSize:   meta.TotalCompressedSize,
+	}
+
+	c.copied = cc
+	c.numRows = cc.numRows
+	c.numPages = len(locations)
+	c.offsetIndex.PageLocations = locations
+	copyPathCounter.Add(1)
+
+	// Populate the column chunk metadata that the regular path would accumulate
+	// via recordPageStats.
+	c.columnChunk.MetaData.NumValues = cc.numValues
+	c.columnChunk.MetaData.TotalUncompressedSize = cc.totalUncompressedSize
+	c.columnChunk.MetaData.TotalCompressedSize = cc.totalCompressedSize
+	c.columnChunk.MetaData.Statistics = cc.statistics
+	c.columnChunk.MetaData.EncodingStats = append(c.columnChunk.MetaData.EncodingStats[:0], cc.encodingStats...)
+	return nil
+}
+
+func cloneStatistics(s format.Statistics) format.Statistics {
+	s.Min = slices.Clone(s.Min)
+	s.Max = slices.Clone(s.Max)
+	s.MinValue = slices.Clone(s.MinValue)
+	s.MaxValue = slices.Clone(s.MaxValue)
+	return s
+}
+
+func cloneSizeStatistics(s format.SizeStatistics) format.SizeStatistics {
+	s.RepetitionLevelHistogram = slices.Clone(s.RepetitionLevelHistogram)
+	s.DefinitionLevelHistogram = slices.Clone(s.DefinitionLevelHistogram)
+	return s
+}
+
+func cloneColumnIndex(index *format.ColumnIndex) format.ColumnIndex {
+	out := *index
+	out.NullPages = slices.Clone(index.NullPages)
+	out.MinValues = slices.Clone(index.MinValues)
+	out.MaxValues = slices.Clone(index.MaxValues)
+	out.NullCounts = slices.Clone(index.NullCounts)
+	out.RepetitionLevelHistogram = slices.Clone(index.RepetitionLevelHistogram)
+	out.DefinitionLevelHistogram = slices.Clone(index.DefinitionLevelHistogram)
+	return out
+}

--- a/writer_copy.go
+++ b/writer_copy.go
@@ -105,6 +105,12 @@ func (w *Writer) copyableColumnChunks(rowGroup RowGroup) ([]*FileColumnChunk, bo
 	if w.writer.encryption != nil {
 		return nil, false
 	}
+	// A verbatim copy reproduces the source row group as a single output row
+	// group, so it cannot honor a smaller configured MaxRowsPerRowGroup. When the
+	// source exceeds the limit, demote so the row path splits it correctly.
+	if rowGroup.NumRows() > w.writer.currentRowGroup.maxRows {
+		return nil, false
+	}
 
 	dst := w.writer.currentRowGroup.columns
 	columns := rowGroup.ColumnChunks()

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -273,7 +273,7 @@ func makeBenchRows(n int) []benchRow {
 	return rows
 }
 
-func benchmarkWriteRowGroupRewrite(b *testing.B, disableCopy bool) {
+func benchmarkWriteRowGroupRewrite(b *testing.B, baseline bool) {
 	const numRows = 200_000
 	rows := makeBenchRows(numRows)
 
@@ -291,8 +291,11 @@ func benchmarkWriteRowGroupRewrite(b *testing.B, disableCopy bool) {
 	}
 	rowGroups := file.RowGroups()
 
-	defer func(prev bool) { disableWriteCopy = prev }(disableWriteCopy)
-	disableWriteCopy = disableCopy
+	// The baseline is the pure row-oriented path: disable both fast paths so it
+	// measures full decode + row assembly + re-encode.
+	defer func(c, r bool) { disableWriteCopy = c; disableWriteReencode = r }(disableWriteCopy, disableWriteReencode)
+	disableWriteCopy = baseline
+	disableWriteReencode = baseline
 
 	b.ReportAllocs()
 	b.SetBytes(int64(src.Len()))
@@ -405,4 +408,160 @@ func TestWriteRowGroupCopyMergeNonOverlapping(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatal("merged+copied rows differ from expected")
 	}
+}
+
+// TestWriteRowGroupReencodeMatchesRowPath verifies that the L3 column-oriented
+// re-encode produces the same data as the row-oriented fallback, and that it
+// actually fires (config differs from source, so L0 cannot apply).
+func TestWriteRowGroupReencodeMatchesRowPath(t *testing.T) {
+	rows := makeCopyTestRows(5000)
+	src := writeCopyTestFile(t, rows, Compression(&Snappy))
+
+	rewrite := func(reencode bool) []byte {
+		defer func(prev bool) { disableWriteReencode = prev }(disableWriteReencode)
+		disableWriteReencode = !reencode
+		var dst bytes.Buffer
+		// Codec differs from source (Snappy -> Zstd) so L0 cannot fire.
+		w := NewGenericWriter[copyTestRow](&dst, Compression(&Zstd))
+		for _, rg := range src.RowGroups() {
+			if _, err := w.WriteRowGroup(rg); err != nil {
+				t.Fatalf("WriteRowGroup(reencode=%v): %v", reencode, err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return dst.Bytes()
+	}
+
+	before := reencodePathCounter.Load()
+	l3 := rewrite(true)
+	if reencodePathCounter.Load() == before {
+		t.Fatal("expected the L3 re-encode path to fire")
+	}
+	rowPath := rewrite(false)
+
+	gotL3 := readCopyTestRows(t, l3, len(rows))
+	gotRow := readCopyTestRows(t, rowPath, len(rows))
+	if !reflect.DeepEqual(gotL3, rows) {
+		t.Fatal("L3 output differs from source data")
+	}
+	if !reflect.DeepEqual(gotL3, gotRow) {
+		t.Fatal("L3 output differs from row-path output")
+	}
+}
+
+// BenchmarkWriteRowGroupReencodePaths compares the L3 column-oriented re-encode
+// against the row-oriented fallback. The codec differs from the source (Snappy)
+// so L0 cannot fire. The "uncompressed" dest isolates the row round-trip cost
+// (no compression in the write); the "zstd" dest reflects a realistic codec
+// migration.
+func BenchmarkWriteRowGroupReencodePaths(b *testing.B) {
+	rows := makeBenchRows(200_000)
+	var src bytes.Buffer
+	sw := NewGenericWriter[benchRow](&src, Compression(&Snappy), MaxRowsPerRowGroup(50_000))
+	if _, err := sw.Write(rows); err != nil {
+		b.Fatal(err)
+	}
+	if err := sw.Close(); err != nil {
+		b.Fatal(err)
+	}
+	file, err := OpenFile(bytes.NewReader(src.Bytes()), int64(src.Len()))
+	if err != nil {
+		b.Fatal(err)
+	}
+	rowGroups := file.RowGroups()
+
+	run := func(b *testing.B, compression WriterOption, reencode bool) {
+		defer func(d bool) { disableWriteReencode = d }(disableWriteReencode)
+		disableWriteReencode = !reencode
+		b.ReportAllocs()
+		b.SetBytes(int64(src.Len()))
+		b.ResetTimer()
+		for b.Loop() {
+			w := NewGenericWriter[benchRow](io.Discard, compression, MaxRowsPerRowGroup(50_000))
+			for _, rg := range rowGroups {
+				if _, err := w.WriteRowGroup(rg); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	for _, c := range []struct {
+		name string
+		opt  WriterOption
+	}{
+		{"uncompressed", Compression(&Uncompressed)},
+		{"zstd", Compression(&Zstd)},
+	} {
+		b.Run(c.name+"/rowpath", func(b *testing.B) { run(b, c.opt, false) })
+		b.Run(c.name+"/L3", func(b *testing.B) { run(b, c.opt, true) })
+	}
+}
+
+type wideRow struct {
+	C0, C1, C2, C3, C4, C5, C6, C7, C8, C9           int64
+	C10, C11, C12, C13, C14, C15, C16, C17, C18, C19 int64
+	S0, S1, S2, S3                                   string
+}
+
+func makeWideRows(n int) []wideRow {
+	rows := make([]wideRow, n)
+	for i := range rows {
+		v := int64(i)
+		rows[i] = wideRow{
+			C0: v, C1: v + 1, C2: v + 2, C3: v + 3, C4: v + 4,
+			C5: v + 5, C6: v + 6, C7: v + 7, C8: v + 8, C9: v + 9,
+			C10: v, C11: v + 1, C12: v + 2, C13: v + 3, C14: v + 4,
+			C15: v + 5, C16: v + 6, C17: v + 7, C18: v + 8, C19: v + 9,
+			S0: fmt.Sprintf("a%d", i%97), S1: fmt.Sprintf("b%d", i%89),
+			S2: fmt.Sprintf("c%d", i%83), S3: fmt.Sprintf("d%d", i%79),
+		}
+	}
+	return rows
+}
+
+// BenchmarkWriteRowGroupReencodeWide measures L3 vs the row path on a wide
+// (24-column) schema, where the row round-trip has more to do.
+func BenchmarkWriteRowGroupReencodeWide(b *testing.B) {
+	rows := makeWideRows(100_000)
+	var src bytes.Buffer
+	sw := NewGenericWriter[wideRow](&src, Compression(&Snappy), MaxRowsPerRowGroup(25_000))
+	if _, err := sw.Write(rows); err != nil {
+		b.Fatal(err)
+	}
+	if err := sw.Close(); err != nil {
+		b.Fatal(err)
+	}
+	file, err := OpenFile(bytes.NewReader(src.Bytes()), int64(src.Len()))
+	if err != nil {
+		b.Fatal(err)
+	}
+	rowGroups := file.RowGroups()
+
+	run := func(b *testing.B, reencode bool) {
+		defer func(d bool) { disableWriteReencode = d }(disableWriteReencode)
+		disableWriteReencode = !reencode
+		b.ReportAllocs()
+		b.SetBytes(int64(src.Len()))
+		b.ResetTimer()
+		for b.Loop() {
+			w := NewGenericWriter[wideRow](io.Discard, Compression(&Zstd), MaxRowsPerRowGroup(25_000))
+			for _, rg := range rowGroups {
+				if _, err := w.WriteRowGroup(rg); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.Run("rowpath", func(b *testing.B) { run(b, false) })
+	b.Run("L3", func(b *testing.B) { run(b, true) })
 }

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -565,3 +565,192 @@ func BenchmarkWriteRowGroupReencodeWide(b *testing.B) {
 	b.Run("rowpath", func(b *testing.B) { run(b, false) })
 	b.Run("L3", func(b *testing.B) { run(b, true) })
 }
+
+// buildIDFile writes a single-row-group file whose rows are sorted by id. The
+// caller must pass ids in ascending order. Other fields are derived from id so
+// that the fully-sorted sequence of rows is uniquely determined by the id set.
+func buildIDFile(t *testing.T, ids []int64) *File {
+	t.Helper()
+	rows := make([]copyTestRow, len(ids))
+	for i, id := range ids {
+		rows[i] = copyTestRow{ID: id, Name: fmt.Sprintf("n%d", id%13), Val: float64(id)}
+	}
+	return writeCopyTestFile(t, rows, SortingWriterConfig(SortingColumns(Ascending("id"))))
+}
+
+func idSeq(start, end int64) []int64 {
+	out := make([]int64, 0, end-start+1)
+	for v := start; v <= end; v++ {
+		out = append(out, v)
+	}
+	return out
+}
+
+func idStride(start, end, step int64) []int64 {
+	var out []int64
+	for v := start; v <= end; v += step {
+		out = append(out, v)
+	}
+	return out
+}
+
+// TestWriteRowGroupMergeRangePatterns exercises the segment-splitting logic for a
+// variety of overlapping/non-overlapping range mixes. For each pattern it
+// verifies that the optimized merge (L0 copy of non-overlapping single-row-group
+// segments + heap merge of overlapping segments) produces exactly the same
+// globally-sorted rows as the pure row-path reference, and that the number of
+// column chunks copied matches the expected number of single-row-group segments.
+func TestWriteRowGroupMergeRangePatterns(t *testing.T) {
+	const numColumns = 3 // id, name, val
+
+	patterns := []struct {
+		name string
+		// each entry is one source file's ascending id list; files overlap iff
+		// their [min,max] ranges intersect.
+		idLists [][]int64
+		// number of single-row-group (non-overlapping) segments, each of which is
+		// copied verbatim (numColumns chunks each).
+		wantCopiedSegments int
+	}{
+		{
+			name:               "non_overlapping",
+			idLists:            [][]int64{idSeq(0, 99), idSeq(100, 199), idSeq(200, 299)},
+			wantCopiedSegments: 3,
+		},
+		{
+			name:               "all_overlapping",
+			idLists:            [][]int64{idStride(0, 299, 3), idStride(1, 299, 3), idStride(2, 299, 3)},
+			wantCopiedSegments: 0,
+		},
+		{
+			name: "mixed",
+			idLists: [][]int64{
+				idSeq(0, 49),          // isolated  -> copied
+				idStride(100, 198, 2), // overlaps next
+				idStride(101, 199, 2), // overlaps prev -> merged
+				idSeq(300, 349),       // isolated  -> copied
+			},
+			wantCopiedSegments: 2,
+		},
+		{
+			name: "two_overlapping_pairs",
+			idLists: [][]int64{
+				idStride(0, 98, 2), idStride(1, 99, 2), // pair -> merged
+				idStride(200, 298, 2), idStride(201, 299, 2), // pair -> merged
+			},
+			wantCopiedSegments: 0,
+		},
+		{
+			name: "isolated_then_triple_overlap",
+			idLists: [][]int64{
+				idSeq(0, 99),                                                        // isolated -> copied
+				idStride(200, 299, 3), idStride(201, 299, 3), idStride(202, 299, 3), // triple -> merged
+			},
+			wantCopiedSegments: 1,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.name, func(t *testing.T) {
+			files := make([]*File, len(p.idLists))
+			var allIDs []int64
+			for i, ids := range p.idLists {
+				files[i] = buildIDFile(t, ids)
+				allIDs = append(allIDs, ids...)
+			}
+			slices.Sort(allIDs)
+			expected := make([]copyTestRow, len(allIDs))
+			for i, id := range allIDs {
+				expected[i] = copyTestRow{ID: id, Name: fmt.Sprintf("n%d", id%13), Val: float64(id)}
+			}
+
+			writeMerged := func(fastPaths bool) ([]byte, int64) {
+				rgs := make([]RowGroup, len(files))
+				for i, f := range files {
+					rgs[i] = f.RowGroups()[0]
+				}
+				merged, err := MergeRowGroups(rgs, SortingRowGroupConfig(SortingColumns(Ascending("id"))))
+				if err != nil {
+					t.Fatalf("MergeRowGroups: %v", err)
+				}
+				defer func(c, r bool) { disableWriteCopy = c; disableWriteReencode = r }(disableWriteCopy, disableWriteReencode)
+				disableWriteCopy = !fastPaths
+				disableWriteReencode = !fastPaths
+
+				before := copyPathCounter.Load()
+				var dst bytes.Buffer
+				w := NewGenericWriter[copyTestRow](&dst, SortingWriterConfig(SortingColumns(Ascending("id"))))
+				if _, err := w.WriteRowGroup(merged); err != nil {
+					t.Fatalf("WriteRowGroup: %v", err)
+				}
+				if err := w.Close(); err != nil {
+					t.Fatalf("Close: %v", err)
+				}
+				return dst.Bytes(), copyPathCounter.Load() - before
+			}
+
+			ref, _ := writeMerged(false)
+			opt, copied := writeMerged(true)
+
+			gotRef := readCopyTestRows(t, ref, len(expected))
+			gotOpt := readCopyTestRows(t, opt, len(expected))
+
+			if !reflect.DeepEqual(gotRef, expected) {
+				t.Fatalf("reference (row-path) output is not globally sorted as expected (%d rows)", len(gotRef))
+			}
+			if !reflect.DeepEqual(gotOpt, expected) {
+				t.Fatalf("optimized output differs from expected globally-sorted rows (%d rows)", len(gotOpt))
+			}
+			if want := int64(p.wantCopiedSegments * numColumns); copied != want {
+				t.Fatalf("copied column chunks = %d, want %d (%d single-row-group segments * %d columns)",
+					copied, want, p.wantCopiedSegments, numColumns)
+			}
+		})
+	}
+}
+
+// TestWriteRowGroupMergeDropDuplicates verifies that when duplicate rows are
+// dropped, the merge is NOT split for verbatim copy (dedup spans segment
+// boundaries) and the output is correctly deduplicated and sorted.
+func TestWriteRowGroupMergeDropDuplicates(t *testing.T) {
+	// Overlapping ranges that also share ids 50..99.
+	fileA := buildIDFile(t, idSeq(0, 99))
+	fileB := buildIDFile(t, idSeq(50, 149))
+
+	merged, err := MergeRowGroups(
+		[]RowGroup{fileA.RowGroups()[0], fileB.RowGroups()[0]},
+		SortingRowGroupConfig(SortingColumns(Ascending("id")), DropDuplicatedRows(true)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := copyPathCounter.Load()
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst, SortingWriterConfig(SortingColumns(Ascending("id"))))
+	if _, err := w.WriteRowGroup(merged); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if copied := copyPathCounter.Load() - before; copied != 0 {
+		t.Fatalf("expected no verbatim copy when dropping duplicates, but %d chunks were copied", copied)
+	}
+
+	out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Deduplicated union of [0,99] and [50,149] is [0,149].
+	if got := out.NumRows(); got != 150 {
+		t.Fatalf("deduplicated row count = %d, want 150", got)
+	}
+	got := readCopyTestRows(t, dst.Bytes(), 150)
+	for i, r := range got {
+		if r.ID != int64(i) {
+			t.Fatalf("row %d has id %d, want %d (expected deduplicated 0..149 sorted)", i, r.ID, i)
+		}
+	}
+}

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -1,0 +1,408 @@
+package parquet
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+type copyTestRow struct {
+	ID   int64   `parquet:"id"`
+	Name string  `parquet:"name,dict"`
+	Val  float64 `parquet:"val"`
+}
+
+func makeCopyTestRows(n int) []copyTestRow {
+	rows := make([]copyTestRow, n)
+	for i := range rows {
+		rows[i] = copyTestRow{
+			ID:   int64(i),
+			Name: fmt.Sprintf("name-%d", i%10),
+			Val:  float64(i) * 1.5,
+		}
+	}
+	return rows
+}
+
+func writeCopyTestFile(t *testing.T, rows []copyTestRow, opts ...WriterOption) *File {
+	t.Helper()
+	var buf bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&buf, opts...)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatalf("writing source rows: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing source writer: %v", err)
+	}
+	f, err := OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("opening source file: %v", err)
+	}
+	return f
+}
+
+func readCopyTestRows(t *testing.T, b []byte, n int) []copyTestRow {
+	t.Helper()
+	r := NewGenericReader[copyTestRow](bytes.NewReader(b))
+	defer r.Close()
+	got := make([]copyTestRow, n)
+	read := 0
+	for read < n {
+		m, err := r.Read(got[read:])
+		read += m
+		if err != nil {
+			break
+		}
+	}
+	return got[:read]
+}
+
+// TestWriteRowGroupCopyFastPath verifies that rewriting a file's row groups with
+// a matching writer configuration takes the verbatim-copy fast path and produces
+// a file with identical data.
+func TestWriteRowGroupCopyFastPath(t *testing.T) {
+	rows := makeCopyTestRows(1000)
+	src := writeCopyTestFile(t, rows)
+
+	before := copyPathCounter.Load()
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst)
+	for _, rg := range src.RowGroups() {
+		if _, err := w.WriteRowGroup(rg); err != nil {
+			t.Fatalf("WriteRowGroup: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing dst writer: %v", err)
+	}
+
+	if copied := copyPathCounter.Load() - before; copied == 0 {
+		t.Fatal("expected the copy fast path to fire, but no columns were copied")
+	}
+
+	got := readCopyTestRows(t, dst.Bytes(), len(rows))
+	if !reflect.DeepEqual(got, rows) {
+		t.Fatalf("round-tripped rows differ from source: got %d rows", len(got))
+	}
+}
+
+// TestWriteRowGroupCopyMultipleRowGroupsAndIndexes rewrites a multi-row-group
+// file via the copy path and verifies the output's offset index (via SeekToRow)
+// and column index bounds are intact — properties a plain sequential read would
+// not exercise.
+func TestWriteRowGroupCopyMultipleRowGroupsAndIndexes(t *testing.T) {
+	rows := makeCopyTestRows(1000)
+	// Force several row groups in the source.
+	src := writeCopyTestFile(t, rows, MaxRowsPerRowGroup(250))
+	if got := len(src.RowGroups()); got < 2 {
+		t.Fatalf("expected multiple source row groups, got %d", got)
+	}
+
+	before := copyPathCounter.Load()
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst, MaxRowsPerRowGroup(250))
+	for _, rg := range src.RowGroups() {
+		if _, err := w.WriteRowGroup(rg); err != nil {
+			t.Fatalf("WriteRowGroup: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing dst writer: %v", err)
+	}
+
+	// Every column of every row group should have been copied (3 columns).
+	if copied := copyPathCounter.Load() - before; copied != int64(3*len(src.RowGroups())) {
+		t.Fatalf("expected %d copied columns, got %d", 3*len(src.RowGroups()), copied)
+	}
+
+	out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+	if err != nil {
+		t.Fatalf("opening output file: %v", err)
+	}
+	if got := out.NumRows(); got != int64(len(rows)) {
+		t.Fatalf("output row count = %d, want %d", got, len(rows))
+	}
+
+	// Exercise the offset index: seek into the middle of each row group's "id"
+	// column and confirm the value matches the global row position.
+	rowBase := int64(0)
+	for _, rg := range out.RowGroups() {
+		idChunk := rg.ColumnChunks()[0] // "id"
+		oi, err := idChunk.OffsetIndex()
+		if err != nil {
+			t.Fatalf("output offset index missing: %v", err)
+		}
+		if oi.NumPages() == 0 {
+			t.Fatal("output offset index has no pages")
+		}
+
+		pages := idChunk.Pages()
+		seekTo := rg.NumRows() / 2
+		if err := pages.SeekToRow(seekTo); err != nil {
+			pages.Close()
+			t.Fatalf("SeekToRow(%d): %v", seekTo, err)
+		}
+		page, err := pages.ReadPage()
+		if err != nil {
+			pages.Close()
+			t.Fatalf("ReadPage after seek: %v", err)
+		}
+		vals := make([]Value, 1)
+		n, _ := page.Values().ReadValues(vals)
+		if n != 1 {
+			pages.Close()
+			t.Fatal("expected to read one value after seek")
+		}
+		wantID := rowBase + seekTo
+		if vals[0].Int64() != wantID {
+			pages.Close()
+			t.Fatalf("value after seek = %d, want %d", vals[0].Int64(), wantID)
+		}
+		pages.Close()
+
+		// Column index bounds for "id" must bracket the row group's id range.
+		ci, err := idChunk.ColumnIndex()
+		if err != nil {
+			t.Fatalf("output column index missing: %v", err)
+		}
+		minSeen := ci.MinValue(0).Int64()
+		maxSeen := ci.MaxValue(ci.NumPages() - 1).Int64()
+		if minSeen != rowBase {
+			t.Fatalf("column index min = %d, want %d", minSeen, rowBase)
+		}
+		if want := rowBase + rg.NumRows() - 1; maxSeen != want {
+			t.Fatalf("column index max = %d, want %d", maxSeen, want)
+		}
+
+		rowBase += rg.NumRows()
+	}
+
+	got := readCopyTestRows(t, dst.Bytes(), len(rows))
+	if !reflect.DeepEqual(got, rows) {
+		t.Fatal("round-tripped rows differ across multiple row groups")
+	}
+}
+
+// TestWriteRowGroupCopyWithCompression exercises the copy path with a matching
+// non-default compression codec.
+func TestWriteRowGroupCopyWithCompression(t *testing.T) {
+	rows := makeCopyTestRows(1000)
+	src := writeCopyTestFile(t, rows, Compression(&Snappy))
+
+	before := copyPathCounter.Load()
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst, Compression(&Snappy))
+	for _, rg := range src.RowGroups() {
+		if _, err := w.WriteRowGroup(rg); err != nil {
+			t.Fatalf("WriteRowGroup: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing dst writer: %v", err)
+	}
+
+	if copied := copyPathCounter.Load() - before; copied == 0 {
+		t.Fatal("expected the copy fast path to fire with matching compression")
+	}
+
+	got := readCopyTestRows(t, dst.Bytes(), len(rows))
+	if !reflect.DeepEqual(got, rows) {
+		t.Fatalf("round-tripped rows differ from source with compression")
+	}
+}
+
+// TestWriteRowGroupCopyDemotesOnCodecMismatch verifies that a mismatched
+// compression codec disables the fast path (falling back to re-encode) while
+// still producing correct data.
+func TestWriteRowGroupCopyDemotesOnCodecMismatch(t *testing.T) {
+	rows := makeCopyTestRows(1000)
+	src := writeCopyTestFile(t, rows, Compression(&Snappy))
+
+	before := copyPathCounter.Load()
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst, Compression(&Zstd))
+	for _, rg := range src.RowGroups() {
+		if _, err := w.WriteRowGroup(rg); err != nil {
+			t.Fatalf("WriteRowGroup: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing dst writer: %v", err)
+	}
+
+	if copied := copyPathCounter.Load() - before; copied != 0 {
+		t.Fatalf("expected codec mismatch to disable copy, but %d columns were copied", copied)
+	}
+
+	got := readCopyTestRows(t, dst.Bytes(), len(rows))
+	if !reflect.DeepEqual(got, rows) {
+		t.Fatalf("round-tripped rows differ from source after demotion")
+	}
+}
+
+// benchRow is a wider record used to make the re-encode cost of the baseline
+// meaningful (compression + multiple typed columns including a dictionary).
+type benchRow struct {
+	ID    int64   `parquet:"id"`
+	Name  string  `parquet:"name,dict"`
+	Email string  `parquet:"email"`
+	Score float64 `parquet:"score"`
+	Flag  bool    `parquet:"flag"`
+	Count int32   `parquet:"count"`
+}
+
+func makeBenchRows(n int) []benchRow {
+	rows := make([]benchRow, n)
+	for i := range rows {
+		rows[i] = benchRow{
+			ID:    int64(i),
+			Name:  fmt.Sprintf("category-%d", i%32),
+			Email: fmt.Sprintf("user%d@example.com", i),
+			Score: float64(i) * 0.125,
+			Flag:  i%2 == 0,
+			Count: int32(i % 1000),
+		}
+	}
+	return rows
+}
+
+func benchmarkWriteRowGroupRewrite(b *testing.B, disableCopy bool) {
+	const numRows = 200_000
+	rows := makeBenchRows(numRows)
+
+	var src bytes.Buffer
+	sw := NewGenericWriter[benchRow](&src, Compression(&Snappy), MaxRowsPerRowGroup(50_000))
+	if _, err := sw.Write(rows); err != nil {
+		b.Fatal(err)
+	}
+	if err := sw.Close(); err != nil {
+		b.Fatal(err)
+	}
+	file, err := OpenFile(bytes.NewReader(src.Bytes()), int64(src.Len()))
+	if err != nil {
+		b.Fatal(err)
+	}
+	rowGroups := file.RowGroups()
+
+	defer func(prev bool) { disableWriteCopy = prev }(disableWriteCopy)
+	disableWriteCopy = disableCopy
+
+	b.ReportAllocs()
+	b.SetBytes(int64(src.Len()))
+	b.ResetTimer()
+
+	for b.Loop() {
+		w := NewGenericWriter[benchRow](io.Discard, Compression(&Snappy), MaxRowsPerRowGroup(50_000))
+		for _, rg := range rowGroups {
+			if _, err := w.WriteRowGroup(rg); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWriteRowGroupCopy(b *testing.B) {
+	benchmarkWriteRowGroupRewrite(b, false)
+}
+
+func BenchmarkWriteRowGroupReencode(b *testing.B) {
+	benchmarkWriteRowGroupRewrite(b, true)
+}
+
+// TestFileColumnChunkOfUnwrap verifies that the copy path can see through a
+// positional-remap wrapper to the underlying file-backed chunk, while rejecting
+// non-file chunks.
+func TestFileColumnChunkOfUnwrap(t *testing.T) {
+	rows := makeCopyTestRows(100)
+	src := writeCopyTestFile(t, rows)
+	fc := src.RowGroups()[0].ColumnChunks()[0].(*FileColumnChunk)
+
+	if got, ok := fileColumnChunkOf(fc); !ok || got != fc {
+		t.Fatal("expected direct *FileColumnChunk to unwrap to itself")
+	}
+
+	wrapped := &convertedColumnChunk{chunk: fc, targetColumnIndex: ^uint16(2)}
+	if got, ok := fileColumnChunkOf(wrapped); !ok || got != fc {
+		t.Fatal("expected convertedColumnChunk to unwrap to inner *FileColumnChunk")
+	}
+
+	if _, ok := fileColumnChunkOf(&emptyColumnChunk{}); ok {
+		t.Fatal("expected non-file chunk to fail unwrap")
+	}
+}
+
+// TestWriteRowGroupCopyMergeNonOverlapping verifies that writing the result of
+// MergeRowGroups over non-overlapping, sorted inputs takes the copy fast path
+// per segment and preserves global sort order and data.
+func TestWriteRowGroupCopyMergeNonOverlapping(t *testing.T) {
+	// Two files with disjoint, sorted id ranges.
+	first := make([]copyTestRow, 500)
+	for i := range first {
+		first[i] = copyTestRow{ID: int64(i), Name: fmt.Sprintf("a-%d", i%7), Val: float64(i)}
+	}
+	second := make([]copyTestRow, 500)
+	for i := range second {
+		id := int64(1000 + i)
+		second[i] = copyTestRow{ID: id, Name: fmt.Sprintf("b-%d", i%7), Val: float64(id)}
+	}
+
+	writerSorting := SortingWriterConfig(SortingColumns(Ascending("id")))
+	f1 := writeCopyTestFile(t, first, writerSorting)
+	f2 := writeCopyTestFile(t, second, writerSorting)
+
+	merged, err := MergeRowGroups(
+		[]RowGroup{f1.RowGroups()[0], f2.RowGroups()[0]},
+		SortingRowGroupConfig(SortingColumns(Ascending("id"))),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := copyPathCounter.Load()
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst, writerSorting)
+	if _, err := w.WriteRowGroup(merged); err != nil {
+		t.Fatalf("WriteRowGroup(merged): %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if copied := copyPathCounter.Load() - before; copied == 0 {
+		t.Fatal("expected the copy fast path to fire for non-overlapping merge segments")
+	}
+
+	out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := out.NumRows(); got != 1000 {
+		t.Fatalf("output row count = %d, want 1000", got)
+	}
+
+	// Verify data and global sort order.
+	got := readCopyTestRows(t, dst.Bytes(), 1000)
+	if len(got) != 1000 {
+		t.Fatalf("read %d rows, want 1000", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].ID < got[i-1].ID {
+			t.Fatalf("rows out of order at %d: %d < %d", i, got[i].ID, got[i-1].ID)
+		}
+	}
+	want := slices.Concat(first, second)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("merged+copied rows differ from expected")
+	}
+}

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -374,7 +374,10 @@ func TestWriteRowGroupCopyMergeNonOverlapping(t *testing.T) {
 	before := copyPathCounter.Load()
 
 	var dst bytes.Buffer
-	w := NewGenericWriter[copyTestRow](&dst, writerSorting)
+	// MaxRowsPerRowGroup equal to each source segment's row count so the two
+	// non-overlapping segments are not packed together and each takes the
+	// verbatim L0 copy path.
+	w := NewGenericWriter[copyTestRow](&dst, writerSorting, MaxRowsPerRowGroup(500))
 	if _, err := w.WriteRowGroup(merged); err != nil {
 		t.Fatalf("WriteRowGroup(merged): %v", err)
 	}
@@ -586,14 +589,6 @@ func idSeq(start, end int64) []int64 {
 	return out
 }
 
-func idStride(start, end, step int64) []int64 {
-	var out []int64
-	for v := start; v <= end; v += step {
-		out = append(out, v)
-	}
-	return out
-}
-
 // TestWriteRowGroupMergeRangePatterns exercises the segment-splitting logic for a
 // variety of overlapping/non-overlapping range mixes. For each pattern it
 // verifies that the optimized merge (L0 copy of non-overlapping single-row-group
@@ -602,59 +597,59 @@ func idStride(start, end, step int64) []int64 {
 // column chunks copied matches the expected number of single-row-group segments.
 func TestWriteRowGroupMergeRangePatterns(t *testing.T) {
 	const numColumns = 3 // id, name, val
+	// All source files have the same row count and the destination uses that as
+	// MaxRowsPerRowGroup, so non-overlapping segments are never packed together
+	// (any two would exceed the limit). Each isolated segment therefore takes the
+	// verbatim L0 copy path, letting the copied-chunk count verify the
+	// segmentation decision directly. Packing is covered separately.
+	const rowsPerFile = 64
+
+	// spec describes one source file: count ids starting at start, spaced by step
+	// (so files overlap iff their [start, start+(count-1)*step] ranges intersect,
+	// while staying unique within a pattern via disjoint step residues).
+	type spec struct{ start, step int64 }
 
 	patterns := []struct {
-		name string
-		// each entry is one source file's ascending id list; files overlap iff
-		// their [min,max] ranges intersect.
-		idLists [][]int64
-		// number of single-row-group (non-overlapping) segments, each of which is
-		// copied verbatim (numColumns chunks each).
-		wantCopiedSegments int
+		name               string
+		files              []spec
+		wantCopiedSegments int // isolated single-row-group segments (numColumns chunks each)
 	}{
 		{
 			name:               "non_overlapping",
-			idLists:            [][]int64{idSeq(0, 99), idSeq(100, 199), idSeq(200, 299)},
+			files:              []spec{{0, 1}, {100, 1}, {200, 1}},
 			wantCopiedSegments: 3,
 		},
 		{
 			name:               "all_overlapping",
-			idLists:            [][]int64{idStride(0, 299, 3), idStride(1, 299, 3), idStride(2, 299, 3)},
+			files:              []spec{{0, 3}, {1, 3}, {2, 3}},
 			wantCopiedSegments: 0,
 		},
 		{
-			name: "mixed",
-			idLists: [][]int64{
-				idSeq(0, 49),          // isolated  -> copied
-				idStride(100, 198, 2), // overlaps next
-				idStride(101, 199, 2), // overlaps prev -> merged
-				idSeq(300, 349),       // isolated  -> copied
-			},
+			name:               "mixed",
+			files:              []spec{{0, 1}, {100, 2}, {101, 2}, {300, 1}}, // iso, overlap-pair, iso
 			wantCopiedSegments: 2,
 		},
 		{
-			name: "two_overlapping_pairs",
-			idLists: [][]int64{
-				idStride(0, 98, 2), idStride(1, 99, 2), // pair -> merged
-				idStride(200, 298, 2), idStride(201, 299, 2), // pair -> merged
-			},
+			name:               "two_overlapping_pairs",
+			files:              []spec{{0, 2}, {1, 2}, {200, 2}, {201, 2}},
 			wantCopiedSegments: 0,
 		},
 		{
-			name: "isolated_then_triple_overlap",
-			idLists: [][]int64{
-				idSeq(0, 99),                                                        // isolated -> copied
-				idStride(200, 299, 3), idStride(201, 299, 3), idStride(202, 299, 3), // triple -> merged
-			},
+			name:               "isolated_then_triple_overlap",
+			files:              []spec{{0, 1}, {200, 3}, {201, 3}, {202, 3}},
 			wantCopiedSegments: 1,
 		},
 	}
 
 	for _, p := range patterns {
 		t.Run(p.name, func(t *testing.T) {
-			files := make([]*File, len(p.idLists))
+			files := make([]*File, len(p.files))
 			var allIDs []int64
-			for i, ids := range p.idLists {
+			for i, s := range p.files {
+				ids := make([]int64, rowsPerFile)
+				for j := range ids {
+					ids[j] = s.start + int64(j)*s.step
+				}
 				files[i] = buildIDFile(t, ids)
 				allIDs = append(allIDs, ids...)
 			}
@@ -679,7 +674,7 @@ func TestWriteRowGroupMergeRangePatterns(t *testing.T) {
 
 				before := copyPathCounter.Load()
 				var dst bytes.Buffer
-				w := NewGenericWriter[copyTestRow](&dst, SortingWriterConfig(SortingColumns(Ascending("id"))))
+				w := NewGenericWriter[copyTestRow](&dst, SortingWriterConfig(SortingColumns(Ascending("id"))), MaxRowsPerRowGroup(rowsPerFile))
 				if _, err := w.WriteRowGroup(merged); err != nil {
 					t.Fatalf("WriteRowGroup: %v", err)
 				}
@@ -794,5 +789,65 @@ func TestWriteRowGroupCopyHonorsSmallerMaxRows(t *testing.T) {
 	got := readCopyTestRows(t, dst.Bytes(), len(rows))
 	if !reflect.DeepEqual(got, rows) {
 		t.Fatal("round-tripped rows differ after maxRows split")
+	}
+}
+
+// TestWriteRowGroupMergePacksToMaxRows verifies that merging many small
+// non-overlapping row groups packs them into output row groups up to
+// MaxRowsPerRowGroup (undershooting, never exceeding) rather than emitting one
+// tiny output row group per source segment, while preserving data and order.
+func TestWriteRowGroupMergePacksToMaxRows(t *testing.T) {
+	// 20 disjoint files of 100 rows each (ids 0..1999).
+	const numFiles, perFile = 20, 100
+	files := make([]*File, numFiles)
+	for i := range files {
+		files[i] = buildIDFile(t, idSeq(int64(i*perFile), int64(i*perFile+perFile-1)))
+	}
+
+	write := func(maxRows int64) *File {
+		rgs := make([]RowGroup, numFiles)
+		for i, f := range files {
+			rgs[i] = f.RowGroups()[0]
+		}
+		merged, err := MergeRowGroups(rgs, SortingRowGroupConfig(SortingColumns(Ascending("id"))))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var dst bytes.Buffer
+		w := NewGenericWriter[copyTestRow](&dst, SortingWriterConfig(SortingColumns(Ascending("id"))), MaxRowsPerRowGroup(maxRows))
+		if _, err := w.WriteRowGroup(merged); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Verify data and global order.
+		got := readCopyTestRows(t, dst.Bytes(), numFiles*perFile)
+		for i, r := range got {
+			if r.ID != int64(i) {
+				t.Fatalf("row %d has id %d, want %d", i, r.ID, i)
+			}
+		}
+		return out
+	}
+
+	// Large limit: all 2000 rows pack into a single output row group.
+	if out := write(100000); len(out.RowGroups()) != 1 {
+		t.Fatalf("with large MaxRowsPerRowGroup: output row groups = %d, want 1 (packed)", len(out.RowGroups()))
+	}
+
+	// Limit of 500: 2000 rows pack into 4 output row groups, none exceeding 500.
+	out := write(500)
+	if got := len(out.RowGroups()); got != 4 {
+		t.Fatalf("with MaxRowsPerRowGroup=500: output row groups = %d, want 4", got)
+	}
+	for i, rg := range out.RowGroups() {
+		if rg.NumRows() > 500 {
+			t.Fatalf("row group %d has %d rows, exceeds MaxRowsPerRowGroup=500", i, rg.NumRows())
+		}
 	}
 }

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -754,3 +754,45 @@ func TestWriteRowGroupMergeDropDuplicates(t *testing.T) {
 		}
 	}
 }
+
+// TestWriteRowGroupCopyHonorsSmallerMaxRows verifies that a source row group
+// larger than the destination's MaxRowsPerRowGroup is NOT copied verbatim (which
+// would exceed the configured limit) but split by the row path instead, while
+// still producing correct data.
+func TestWriteRowGroupCopyHonorsSmallerMaxRows(t *testing.T) {
+	rows := makeCopyTestRows(1000)
+	src := writeCopyTestFile(t, rows) // single 1000-row row group
+
+	before := copyPathCounter.Load()
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst, MaxRowsPerRowGroup(100))
+	for _, rg := range src.RowGroups() {
+		if _, err := w.WriteRowGroup(rg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if copied := copyPathCounter.Load() - before; copied != 0 {
+		t.Fatalf("expected no verbatim copy when source exceeds MaxRowsPerRowGroup, but %d chunks were copied", copied)
+	}
+
+	out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(out.RowGroups()); got != 10 {
+		t.Fatalf("output row group count = %d, want 10 (1000 rows / 100 max)", got)
+	}
+	for _, rg := range out.RowGroups() {
+		if rg.NumRows() > 100 {
+			t.Fatalf("output row group exceeds MaxRowsPerRowGroup: %d > 100", rg.NumRows())
+		}
+	}
+	got := readCopyTestRows(t, dst.Bytes(), len(rows))
+	if !reflect.DeepEqual(got, rows) {
+		t.Fatal("round-tripped rows differ after maxRows split")
+	}
+}

--- a/writer_reencode.go
+++ b/writer_reencode.go
@@ -1,0 +1,98 @@
+package parquet
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// This file implements the "L3" re-encode path for Writer.WriteRowGroup: when a
+// single file-backed source row group's schema matches the writer but it cannot
+// be copied verbatim (the configured codec/encoding/etc. differ), re-encode it
+// column-by-column instead of assembling rows and then deconstructing them.
+//
+// The regular fallback reads the source columns, interleaves their values into
+// Row objects, then immediately tears those rows back apart into columns to
+// re-encode. L3 skips that round-trip: it reads each column's values directly
+// and writes them straight through the column writer (which still re-encodes,
+// re-compresses, computes statistics, and populates bloom filters exactly as the
+// row path would).
+//
+// L3 still decodes and re-encodes values, so it is far less of a win than the
+// verbatim copy (L0); its benefit is avoiding the row round-trip (measured
+// ~1.4–1.8x faster with notably less garbage). See
+// docs/merge-copy-optimization.md.
+
+// reencodePathCounter counts row groups written via the L3 column-oriented
+// re-encode path. Test/benchmark instrumentation only.
+var reencodePathCounter atomic.Int64
+
+// disableWriteReencode forces WriteRowGroup onto the row-oriented fallback. It
+// exists only so benchmarks can measure L3 against an otherwise identical
+// baseline.
+var disableWriteReencode bool
+
+// reencodableRowGroup reports whether rowGroup can be written via the L3
+// column-oriented re-encode path: every column must unwrap to a file-backed
+// chunk (which guarantees reading column-wise preserves row order — this
+// excludes overlapping heap merges, whose order depends on cross-column row
+// interleaving), and the source row count must fit the configured row group
+// size (otherwise the row path's row-group splitting would differ).
+func (w *Writer) reencodableRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
+	if disableWriteReencode {
+		return nil, false
+	}
+	dst := w.writer.currentRowGroup.columns
+	columns := rowGroup.ColumnChunks()
+	if len(columns) == 0 || len(columns) != len(dst) {
+		return nil, false
+	}
+	for _, col := range columns {
+		if _, ok := fileColumnChunkOf(col); !ok {
+			return nil, false
+		}
+	}
+	if rowGroup.NumRows() > w.writer.currentRowGroup.maxRows {
+		return nil, false
+	}
+	return columns, true
+}
+
+// writeRowGroupByColumn re-encodes each source column chunk into its destination
+// column writer, reading values column-wise instead of materializing rows.
+func (w *Writer) writeRowGroupByColumn(columns []ColumnChunk) error {
+	dst := w.writer.currentRowGroup.columns
+	for i, col := range columns {
+		if err := copyColumnValues(dst[i], col); err != nil {
+			return err
+		}
+	}
+	reencodePathCounter.Add(1)
+	return nil
+}
+
+// reencodeValueBufferSize is the batch size for column-wise value copies. Larger
+// than the default value buffer to amortize per-call overhead.
+const reencodeValueBufferSize = 1024
+
+// copyColumnValues reads every value of src in order and writes it to dst,
+// without materializing rows.
+func copyColumnValues(dst *ColumnWriter, src ColumnChunk) error {
+	reader := NewColumnChunkValueReader(src)
+	defer reader.Close()
+
+	buf := make([]Value, reencodeValueBufferSize)
+	for {
+		n, err := reader.ReadValues(buf)
+		if n > 0 {
+			if _, werr := dst.WriteRowValues(buf[:n]); werr != nil {
+				return werr
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/writer_reencode.go
+++ b/writer_reencode.go
@@ -31,16 +31,13 @@ var reencodePathCounter atomic.Int64
 // baseline.
 var disableWriteReencode bool
 
-// reencodableRowGroup reports whether rowGroup can be written via the L3
-// column-oriented re-encode path: every column must unwrap to a file-backed
-// chunk (which guarantees reading column-wise preserves row order — this
-// excludes overlapping heap merges, whose order depends on cross-column row
-// interleaving), and the source row count must fit the configured row group
-// size (otherwise the row path's row-group splitting would differ).
-func (w *Writer) reencodableRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
-	if disableWriteReencode {
-		return nil, false
-	}
+// fileBackedRowGroup reports whether every column of rowGroup unwraps to a
+// file-backed chunk and the row count fits the configured row group size.
+// File-backed columns guarantee that reading column-wise preserves row order
+// (this excludes overlapping heap merges, whose order depends on cross-column
+// row interleaving); the size check ensures column-wise writing does not produce
+// a row group larger than the row path would.
+func (w *Writer) fileBackedRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
 	dst := w.writer.currentRowGroup.columns
 	columns := rowGroup.ColumnChunks()
 	if len(columns) == 0 || len(columns) != len(dst) {
@@ -55,6 +52,112 @@ func (w *Writer) reencodableRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
 		return nil, false
 	}
 	return columns, true
+}
+
+// reencodableRowGroup reports whether rowGroup can be written via the L3
+// column-oriented re-encode path.
+func (w *Writer) reencodableRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
+	if disableWriteReencode {
+		return nil, false
+	}
+	return w.fileBackedRowGroup(rowGroup)
+}
+
+// writeSegmentsPacked writes the segments of a split merge, packing consecutive
+// file-backed (non-overlapping) segments into output row groups up to the
+// configured MaxRowsPerRowGroup. A single-segment batch is written through the
+// normal path (preserving the verbatim L0 fast path for the 1:1 case); a
+// multi-segment batch is consolidated column-by-column via L3 into one output
+// row group, undershooting MaxRowsPerRowGroup as needed. Non-file-backed
+// segments (overlapping heap merges) or segments larger than the limit flush the
+// pending batch and are written individually through the row path.
+func (w *Writer) writeSegmentsPacked(segments []RowGroup, schema *Schema, sortingColumns []SortingColumn) (int64, error) {
+	maxRows := w.writer.currentRowGroup.maxRows
+
+	var (
+		total       int64
+		pending     []RowGroup
+		pendingRows int64
+	)
+
+	flushPending := func() error {
+		var (
+			n   int64
+			err error
+		)
+		switch len(pending) {
+		case 0:
+			return nil
+		case 1:
+			n, err = w.WriteRowGroup(pending[0])
+		default:
+			n, err = w.packSegmentsByColumn(pending, schema, sortingColumns)
+		}
+		total += n
+		pending = pending[:0]
+		pendingRows = 0
+		return err
+	}
+
+	for _, seg := range segments {
+		if _, ok := w.fileBackedRowGroup(seg); ok {
+			if pendingRows > 0 && pendingRows+seg.NumRows() > maxRows {
+				if err := flushPending(); err != nil {
+					return total, err
+				}
+			}
+			pending = append(pending, seg)
+			pendingRows += seg.NumRows()
+			continue
+		}
+		if err := flushPending(); err != nil {
+			return total, err
+		}
+		n, err := w.WriteRowGroup(seg)
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	if err := flushPending(); err != nil {
+		return total, err
+	}
+	return total, nil
+}
+
+// packSegmentsByColumn consolidates several file-backed segments into a single
+// output row group by re-encoding each column across all segments in order.
+func (w *Writer) packSegmentsByColumn(segments []RowGroup, schema *Schema, sortingColumns []SortingColumn) (int64, error) {
+	if err := w.writer.flush(); err != nil {
+		return 0, err
+	}
+	dst := w.writer.currentRowGroup.columns
+	w.configureBloomFiltersForSegments(segments)
+	for _, seg := range segments {
+		columns := seg.ColumnChunks()
+		for i := range columns {
+			if err := copyColumnValues(dst[i], columns[i]); err != nil {
+				return 0, err
+			}
+		}
+	}
+	reencodePathCounter.Add(1)
+	return w.writer.writeRowGroup(w.writer.currentRowGroup, schema, sortingColumns)
+}
+
+// configureBloomFiltersForSegments sizes each column's bloom filter for the
+// total number of values across all segments being packed together.
+func (w *Writer) configureBloomFiltersForSegments(segments []RowGroup) {
+	for i, c := range w.writer.currentRowGroup.columns {
+		if c.columnFilter == nil {
+			continue
+		}
+		var total int64
+		for _, seg := range segments {
+			total += seg.ColumnChunks()[i].NumValues()
+		}
+		c.resizeBloomFilter(total)
+	}
 }
 
 // writeRowGroupByColumn re-encodes each source column chunk into its destination


### PR DESCRIPTION
## Summary

Speeds up `Writer.WriteRowGroup` when the source is a file-backed row group, via a layered set of fast paths that fall back transparently to the regular re-encode when they don't apply. All paths honor the full writer configuration; only config-unspecified internals (page/row-group sizing) may differ.

### L0 — verbatim column-chunk copy

When a source row group's column chunks can be copied as-is, stream the compressed bytes (dictionary + data pages) straight from the source file into the output and copy the statistics and page index — instead of decoding and re-encoding every value. The whole chunk is a contiguous byte range, so it's a single streamed range (`offsetTrackingWriter.ReadFrom` → `bufio.ReadFrom`) with **no intermediate buffer and no per-chunk allocation**.

Fires only when a verbatim copy is provably indistinguishable from the configured re-encode: matching type/encoding/codec/page-version, no encryption, no writer-requested bloom filter, source column + offset index present. Anything else demotes.

### Merge integration

`WriteRowGroup` splits a row group that is the in-order concatenation of independently writable segments (`orderedRowGroupSegments`) into one output row group per copyable segment — so a merge of **non-overlapping, sorted** inputs copies its segments verbatim. Overlapping (heap-merged) and dedup row groups opt out; splitting happens only when ≥1 segment is copy-eligible, so pure re-encode merges keep their existing structure.

### L3 — column-oriented re-encode (for non-copyable, file-backed sources)

When the schema matches but the config differs (so L0 can't apply), re-encode column-by-column instead of the row-oriented fallback: read each column's values directly and feed `WriteRowValues`, skipping the wasteful round-trip of interleaving columns into `Row`s and immediately tearing them apart. Data-identical to the row path.

## Performance (Apple M4 Max, 200k rows, → `io.Discard`)

**L0 vs full re-encode** (matching config):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| Re-encode (row path) | ~31,000,000 | ~23 MB | ~2,580 |
| **L0 copy** | ~90,000 | ~104 KB | ~408 |
| **Ratio** | **~350×** | ~220× | ~6× |

**L3 vs row path** (codec differs, so L0 can't fire):

| workload | row path | L3 | speedup |
|---|---|---|---|
| 6 cols, uncompressed dest | ~23.4 ms | ~12.3 ms | **1.90×** (6× less garbage) |
| 6 cols, Zstd dest | ~33.6 ms | ~23.0 ms | **1.46×** |
| 24 cols, Zstd dest | ~76.8 ms | ~55.0 ms | **1.40×** |

## Tests

`writer_copy_internal_test.go`: L0 fires with matching config (incl. compression), demotes on codec mismatch, multi-row-group offset/column-index integrity via `SeekToRow`, non-overlapping merge order+data, wrapper unwrap; L3 fires on config mismatch and is data-identical to the row path. Full `./...` + `-race` pass; `make format` applied.

## Notes for reviewers

- **Drive-by fix:** `DictionaryMaxBytes` was silently dropped in `WriterConfig.ConfigureWriter`; fixed here.
- **Test instrumentation:** `copyPathCounter` / `reencodePathCounter` (atomic) and `disableWriteCopy` / `disableWriteReencode` (bool) are test/benchmark-only globals in `writer_copy.go` / `writer_reencode.go` (assert which path fired / force the row-path baseline). Cheap, but live in non-test files — happy to relocate.
- **Deferred:** column concurrency (prototyped on both L0 and L3 — only worthwhile on L3, ~1.2–1.7×, workload-dependent, memory scales with worker count) and the L2 codec-transcode layer are documented as optional future work in `docs/merge-copy-optimization.md`.

See `docs/merge-copy-optimization.md` for the full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)