### PR TITLE
fix: GenericWriter drops values after dictionary fallback to PLAIN encoding

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -206,6 +206,19 @@ func makeWriteFunc[T any](t reflect.Type, writeRows writeRowsFunc) writeFunc[T] 
 				// These fields are usually lazily initialized when writing rows,
 				// we need them to exist now tho.
 				c.columnBuffer = c.newColumnBuffer()
+				// Record the original buffer so the dictionary-encoded buffer is
+				// restored when the row group is flushed after a fallback to PLAIN
+				// switched the column to a different buffer.
+				c.originalColumnBuffer = c.columnBuffer
+				w.columns[i] = c.columnBuffer
+			}
+		} else {
+			// The column buffers may have been replaced since the previous call:
+			// when a column's dictionary outgrows DictionaryMaxBytes its buffer is
+			// swapped for a PLAIN-encoded one (fallbackDictionaryToPlain), and
+			// flushing a row group restores the original buffer. Re-resolve the
+			// cached references so rows are not written into abandoned buffers.
+			for i, c := range w.base.writer.currentRowGroup.columns {
 				w.columns[i] = c.columnBuffer
 			}
 		}

--- a/writer_dictionary_fallback_test.go
+++ b/writer_dictionary_fallback_test.go
@@ -1,0 +1,149 @@
+package parquet_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+type dictionaryFallbackRow struct {
+	ID       int64  `parquet:"id"`
+	Unique   string `parquet:"unique,dict"`
+	Repeated string `parquet:"repeated,dict"`
+}
+
+// TestGenericWriterDictionaryFallbackKeepsValues verifies that no values are
+// lost when a dict-encoded column outgrows DictionaryMaxBytes and falls back
+// to PLAIN encoding mid-file.
+//
+// Bug details:
+//   - GenericWriter.Write resolves each column's ColumnBuffer once and caches
+//     the references (makeWriteFunc).
+//   - When a column's dictionary exceeds DictionaryMaxBytes, the next page
+//     flush calls fallbackDictionaryToPlain, which swaps the ColumnWriter's
+//     columnBuffer for a new PLAIN-encoded buffer.
+//   - The cached reference still points to the abandoned dictionary buffer, so
+//     every subsequent value for that column is written into a buffer that is
+//     never flushed again: the column chunk of the current row group is
+//     silently truncated (num_values < num_rows) and the chunks of all later
+//     row groups are empty (num_values=0, data_page_offset=0).
+//   - The generic write path also never assigned originalColumnBuffer, so the
+//     per-row-group reset could not restore the dictionary buffer either.
+//
+// The resulting files are unreadable around the affected columns (readers fail
+// with value-count mismatches or decode garbage), while the writer reports
+// every row as successfully written.
+func TestGenericWriterDictionaryFallbackKeepsValues(t *testing.T) {
+	const (
+		totalRows       = 5000
+		batchRows       = 250
+		rowsPerRowGroup = 1000
+		// Small limits so the unique column overflows its dictionary and pages
+		// flush mid-row-group, which is what leaves the cached column buffer
+		// reference pointing at the abandoned dictionary buffer.
+		dictionaryMaxBytes = 1024
+		pageBufferSize     = 2048
+	)
+
+	rows := make([]dictionaryFallbackRow, totalRows)
+	for i := range rows {
+		rows[i] = dictionaryFallbackRow{
+			ID:       int64(i),
+			Unique:   fmt.Sprintf("unique-value-%032d", i),
+			Repeated: fmt.Sprintf("repeated-%d", i%3),
+		}
+	}
+
+	t.Run("concrete type", func(t *testing.T) {
+		buffer := new(bytes.Buffer)
+		writer := parquet.NewGenericWriter[dictionaryFallbackRow](buffer,
+			parquet.DictionaryMaxBytes(dictionaryMaxBytes),
+			parquet.PageBufferSize(pageBufferSize),
+			parquet.MaxRowsPerRowGroup(rowsPerRowGroup),
+		)
+		for i := 0; i < totalRows; i += batchRows {
+			if _, err := writer.Write(rows[i : i+batchRows]); err != nil {
+				t.Fatalf("writing rows %d..%d: %v", i, i+batchRows, err)
+			}
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("closing writer: %v", err)
+		}
+		assertDictionaryFallbackFileComplete(t, buffer.Bytes(), rows)
+	})
+
+	t.Run("interface type with schema", func(t *testing.T) {
+		buffer := new(bytes.Buffer)
+		writer := parquet.NewGenericWriter[any](buffer,
+			parquet.SchemaOf(dictionaryFallbackRow{}),
+			parquet.DictionaryMaxBytes(dictionaryMaxBytes),
+			parquet.PageBufferSize(pageBufferSize),
+			parquet.MaxRowsPerRowGroup(rowsPerRowGroup),
+		)
+		batch := make([]any, batchRows)
+		for i := 0; i < totalRows; i += batchRows {
+			for j := range batch {
+				batch[j] = rows[i+j]
+			}
+			if _, err := writer.Write(batch); err != nil {
+				t.Fatalf("writing rows %d..%d: %v", i, i+batchRows, err)
+			}
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("closing writer: %v", err)
+		}
+		assertDictionaryFallbackFileComplete(t, buffer.Bytes(), rows)
+	})
+}
+
+func assertDictionaryFallbackFileComplete(t *testing.T, data []byte, want []dictionaryFallbackRow) {
+	t.Helper()
+
+	file, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("opening file: %v", err)
+	}
+	if file.NumRows() != int64(len(want)) {
+		t.Fatalf("file has %d rows, want %d", file.NumRows(), len(want))
+	}
+
+	schema := file.Schema()
+	for groupIndex, rowGroup := range file.RowGroups() {
+		for _, chunk := range rowGroup.ColumnChunks() {
+			if chunk.NumValues() != rowGroup.NumRows() {
+				t.Errorf("row group %d column %q: chunk has %d values, want %d",
+					groupIndex, schema.Columns()[chunk.Column()][0], chunk.NumValues(), rowGroup.NumRows())
+			}
+		}
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	reader := parquet.NewGenericReader[dictionaryFallbackRow](bytes.NewReader(data))
+	defer reader.Close()
+
+	got := make([]dictionaryFallbackRow, 0, len(want))
+	buffer := make([]dictionaryFallbackRow, 100)
+	for {
+		n, err := reader.Read(buffer)
+		got = append(got, buffer[:n]...)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading rows back: %v", err)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("read %d rows back, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d mismatch: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`GenericWriter[T].Write` silently drops values of dict-encoded columns once their dictionary exceeds `DictionaryMaxBytes` and the column falls back to PLAIN encoding. The writer reports every row as successfully written, but the produced file is corrupt: the affected column's chunk in the current row group is truncated (`num_values < num_rows`) and its chunks in **all subsequent row groups are empty** (`num_values = 0`, `data_page_offset = 0`).

The combination that triggers it is common in practice: a workload that dictionary-encodes string columns with a size cap and writes enough rows per file for high-cardinality columns to outgrow the cap. Because the writer reports success, the corruption only surfaces later, when readers fail on the files — DuckDB with `Out of buffer` / `Invalid string encoding ... not valid UTF8` (it decodes neighboring binary pages as the truncated column), pyarrow with a column length mismatch, and parquet-go itself with `EOF` after the first chunk.

## Root cause

Two pieces interact:

1. `makeWriteFunc` resolves each column's `ColumnBuffer` **once** and caches the references in `w.columns`; every subsequent `Write` call writes rows directly into those cached buffers:

   ```go
   if w.columns == nil {
       w.columns = make([]ColumnBuffer, len(w.base.writer.currentRowGroup.columns))
       for i, c := range w.base.writer.currentRowGroup.columns {
           c.columnBuffer = c.newColumnBuffer()
           w.columns[i] = c.columnBuffer
       }
   }
   writeRows(w.columns, columnLevels{}, makeArrayFromSlice(rows))
   ```

2. When a column's dictionary outgrows `DictionaryMaxBytes`, the next page flush calls `fallbackDictionaryToPlain()`, which swaps `ColumnWriter.columnBuffer` for a freshly created PLAIN-encoded buffer:

   ```go
   c.columnBuffer = c.plainColumnBuffer
   ```

From that point on, the `ColumnWriter` flushes pages from the (empty, never again written) plain buffer, while `GenericWriter.Write` keeps appending values to the abandoned dictionary-indexed buffer through its stale cached reference. The size check in `GenericWriter[T].Write` inspects `c.columnBuffer` (the plain buffer), so it never triggers a flush either — the stale buffer just grows unboundedly until `Close`, and its contents are silently discarded.

A second, related gap: the generic write path never assigns `c.originalColumnBuffer` (only `WriteRowValues`/`writeValues` do), so the per-row-group `reset()` cannot restore the dictionary buffer after a fallback — which is why every row group after the first ends up with zero values for the column, not just a truncated chunk.

Both `GenericWriter` code paths are affected: the optimized `writeRowsFuncOf` path for concrete struct types and the deconstruct path used for `GenericWriter[any]` with an explicit schema. The row-based APIs (`WriteRows`, `ConcurrentRowGroupWriter.WriteRows`) are not affected because they resolve `c.columnBuffer` at call time.

## Fix

In `makeWriteFunc`:

- re-resolve the cached `ColumnBuffer` references from `currentRowGroup.columns` on every call (an O(columns) pointer copy), so the cache can never go stale across a dictionary fallback or a row-group reset, and
- record `c.originalColumnBuffer` when the buffers are first created, so `reset()` restores dictionary encoding for the next row group exactly as it does for the row-based write path.

## Reproduction / testing

`writer_dictionary_fallback_test.go` adds a regression test covering both generic write paths (`GenericWriter[T]` with a concrete struct and `GenericWriter[any]` with `SchemaOf`). With small limits (`DictionaryMaxBytes(1024)`, `PageBufferSize(2048)`, `MaxRowsPerRowGroup(1000)`, 5000 rows with a unique string column), the test fails on current `main`:

```
--- FAIL: TestGenericWriterDictionaryFallbackKeepsValues/concrete_type
    row group 0 column "unique": chunk has 564 values, want 1000
    row group 1 column "unique": chunk has 0 values, want 1000
    row group 2 column "unique": chunk has 0 values, want 1000
    ...
```

With the fix, the test passes: every column chunk carries one value per row, the file reads back completely, and all values round-trip exactly (the fallback itself works as designed — pre-fallback pages stay dictionary-encoded, later pages are PLAIN, mixed encodings within the chunk).

`go test .` passes on the full package.

## Notes

- Reproduces on every release that has the `w.columns` cache together with the `DictionaryMaxBytes` fallback (verified on v0.29.0, v0.30.0, v0.30.1, and current `main`).
- The corruption threshold depends only on `PageBufferSize` and value sizes: values start disappearing at the first size-triggered page flush after the dictionary crosses the cap, so affected files typically show a first chunk truncated at around ~64k values (with the default 256 KiB page buffer) and empty chunks everywhere after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
