### PR TITLE
perf: avoid per-row allocations when writing time columns

### DIFF
--- a/column_buffer_write.go
+++ b/column_buffer_write.go
@@ -918,7 +918,6 @@ func writeRowsFuncOfJSON(t reflect.Type, schema *Schema, path columnPath) writeR
 
 func writeRowsFuncOfTime(_ reflect.Type, schema *Schema, path columnPath, tagReplacements []StructTagOption) writeRowsFunc {
 	t := reflect.TypeFor[int64]()
-	elemSize := uintptr(t.Size())
 	writeRows := writeRowsFuncOf(t, schema, path, tagReplacements)
 
 	col, _ := schema.Lookup(path...)
@@ -932,7 +931,8 @@ func writeRowsFuncOfTime(_ reflect.Type, schema *Schema, path columnPath, tagRep
 	isOptional := col.Node.Optional()
 
 	return func(columns []ColumnBuffer, levels columnLevels, rows sparse.Array) {
-		if rows.Len() == 0 {
+		n := rows.Len()
+		if n == 0 {
 			writeRows(columns, levels, rows)
 			return
 		}
@@ -945,38 +945,53 @@ func writeRowsFuncOfTime(_ reflect.Type, schema *Schema, path columnPath, tagRep
 		// definitionLevel starts at 0.
 		alreadyHandled := isOptional && levels.definitionLevel > 0
 
+		buf := wideIntBufPool.Get(
+			func() *wideIntBuf { return new(wideIntBuf) },
+			func(b *wideIntBuf) { b.values = b.values[:0] },
+		)
+		buf.values = slices.Grow(buf.values, n)[:n]
+		defer wideIntBufPool.Put(buf)
+
 		times := rows.TimeArray()
-		for i := range times.Len() {
-			t := times.Index(i)
+		switch {
+		case unit.Millis != nil:
+			for i := range n {
+				buf.values[i] = times.Index(i).UnixMilli()
+			}
+		case unit.Micros != nil:
+			for i := range n {
+				buf.values[i] = times.Index(i).UnixMicro()
+			}
+		default:
+			for i := range n {
+				buf.values[i] = times.Index(i).UnixNano()
+			}
+		}
 
-			// For optional fields, check if the value is zero
-			// (unless already handled by pointer wrapper).
-			elemLevels := levels
-			if isOptional && !alreadyHandled && t.IsZero() {
-				// Write as NULL (don't increment definition level).
-				empty := sparse.Array{}
-				writeRows(columns, elemLevels, empty)
-				continue
+		if !isOptional || alreadyHandled {
+			writeRows(columns, levels, sparse.MakeInt64Array(buf.values).UnsafeArray())
+			return
+		}
+
+		i := 0
+		empty := sparse.Array{}
+		for i < n {
+			j := i
+			isNull := times.Index(i).IsZero()
+			for j < n && times.Index(j).IsZero() == isNull {
+				j++
 			}
 
-			// For optional non-zero values, increment definition level
-			// (unless already handled).
-			if isOptional && !alreadyHandled {
+			if isNull {
+				for k := i; k < j; k++ {
+					writeRows(columns, levels, empty)
+				}
+			} else {
+				elemLevels := levels
 				elemLevels.definitionLevel++
+				writeRows(columns, elemLevels, sparse.MakeInt64Array(buf.values[i:j]).UnsafeArray())
 			}
-
-			var val int64
-			switch {
-			case unit.Millis != nil:
-				val = t.UnixMilli()
-			case unit.Micros != nil:
-				val = t.UnixMicro()
-			default:
-				val = t.UnixNano()
-			}
-
-			a := makeArray(reflectValueData(reflect.ValueOf(val)), 1, elemSize)
-			writeRows(columns, elemLevels, a)
+			i = j
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`writeRowsFuncOfTime` wrote a time column one row at a time. For each
row it converted the `time.Time` to an `int64`, then boxed that value
through `reflect.ValueOf` and `makeArray` to hand a length-1 sparse
array to the leaf writer. That boxing allocated on the heap once per
row, so writing N rows did N allocations and repeated the per-row level
bookkeeping.

This converts the whole column to a pooled `[]int64` up front (reusing
`wideIntBufPool`), hoists the `TimeUnit` switch out of the row loop, and
hands contiguous required/null runs to the leaf writer with a single
`sparse.MakeInt64Array` call. The same values and definition levels are
written, so there is no behavior change.

## Benchmark

`BenchmarkGenericWriter/timeColumn`, 1000 rows (linux/amd64, go1.26.4, n=15):

    allocs/op   1001 -> 1       (-99.9%)
    ns/op       50002 -> 13224  (-73.6%)

Reproduce:

    go test -run=^$ -bench=BenchmarkGenericWriter/timeColumn/go1.18 -benchmem -count=15

## Tests

`go test -run TestWrite` and `go test -run TestWriteValueFuncOfOptional`
pass unchanged.

## Notes

Found and benchmarked by an automated, human-reviewed Perfloop
contribution. Full reproducible proof — the baseline and candidate
revisions, the benchmark recipe, and the measured effects — is at
https://app.perfloop.ai/t/oss/case_fxbwsnnmrj.
