### PR TITLE
Error instead of panic on invalid input

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -36,7 +36,7 @@ func NewGenericReader[T any](input io.ReaderAt, options ...ReaderOption) *Generi
 
 	f, err := openFile(input)
 	if err != nil {
-		panic(err)
+		return &GenericReader[T]{base: Reader{openErr: err}}
 	}
 
 	rowGroup := fileRowGroupOf(f)
@@ -114,6 +114,9 @@ func (r *GenericReader[T]) Reset() {
 // The method returns the number of rows read and io.EOF when no more rows
 // can be read from the reader.
 func (r *GenericReader[T]) Read(rows []T) (int, error) {
+	if r.base.openErr != nil {
+		return 0, r.base.openErr
+	}
 	return r.read(r, rows)
 }
 
@@ -245,6 +248,9 @@ type Reader struct {
 	read     reader
 	rowIndex int64
 	rowbuf   []Row
+	// We don't error when creating a reader on malformed input,
+	// but carry the error here so the first read call can fail instead
+	openErr error
 }
 
 // NewReader constructs a parquet reader reading rows from the given
@@ -277,7 +283,7 @@ func NewReader(input io.ReaderAt, options ...ReaderOption) *Reader {
 
 	f, err := openFile(input)
 	if err != nil {
-		panic(err)
+		return &Reader{openErr: err}
 	}
 
 	r := &Reader{
@@ -392,6 +398,9 @@ func (r *Reader) Reset() {
 //
 // The method returns io.EOF when no more rows can be read from r.
 func (r *Reader) Read(row any) error {
+	if r.openErr != nil {
+		return r.openErr
+	}
 	if rowType := dereference(reflect.TypeOf(row)); rowType.Kind() == reflect.Struct {
 		if r.seen != rowType {
 			if err := r.updateReadSchema(rowType); err != nil {
@@ -446,6 +455,9 @@ func (r *Reader) updateReadSchema(rowType reflect.Type) error {
 //
 // The method returns io.EOF when no more rows can be read from r.
 func (r *Reader) ReadRows(rows []Row) (int, error) {
+	if r.openErr != nil {
+		return 0, r.openErr
+	}
 	if err := r.file.SeekToRow(r.rowIndex); err != nil {
 		return 0, err
 	}
@@ -462,6 +474,9 @@ func (r *Reader) NumRows() int64 { return r.file.rowGroup.NumRows() }
 
 // SeekToRow positions r at the given row index.
 func (r *Reader) SeekToRow(rowIndex int64) error {
+	if r.openErr != nil {
+		return r.openErr
+	}
 	if err := r.file.SeekToRow(rowIndex); err != nil {
 		return err
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1103,6 +1103,56 @@ func TestIssue406LeadingBooleanField(t *testing.T) {
 // AssignValue mutate bytes behind any retained shallow copy of an earlier
 // batch.
 // Issue: https://github.com/parquet-go/parquet-go/issues/522
+// TestIssue537DeferredOpenError verifies that NewGenericReader/NewReader do
+// not panic when the input is not a readable parquet file: the open error is
+// returned from Read/ReadRows/SeekToRow instead.
+// See https://github.com/parquet-go/parquet-go/issues/537.
+func TestIssue537DeferredOpenError(t *testing.T) {
+	data := []byte("not a parquet file")
+
+	type row struct {
+		ID int64 `parquet:"id"`
+	}
+
+	t.Run("GenericReader", func(t *testing.T) {
+		r := parquet.NewGenericReader[row](bytes.NewReader(data))
+		defer r.Close()
+
+		if s := r.Schema(); s != nil {
+			t.Errorf("Schema: got %v, want nil", s)
+		}
+		if f := r.File(); f != nil {
+			t.Errorf("File: got %v, want nil", f)
+		}
+		if _, err := r.Read(make([]row, 1)); err == nil {
+			t.Fatal("Read: got nil error, want deferred open error")
+		}
+		if _, err := r.ReadRows(make([]parquet.Row, 1)); err == nil {
+			t.Fatal("ReadRows: got nil error, want deferred open error")
+		}
+		if err := r.SeekToRow(0); err == nil {
+			t.Fatal("SeekToRow: got nil error, want deferred open error")
+		}
+		r.Reset()
+	})
+
+	t.Run("Reader", func(t *testing.T) {
+		r := parquet.NewReader(bytes.NewReader(data))
+		defer r.Close()
+
+		if err := r.Read(&row{}); err == nil {
+			t.Fatal("Read: got nil error, want deferred open error")
+		}
+		if _, err := r.ReadRows(make([]parquet.Row, 1)); err == nil {
+			t.Fatal("ReadRows: got nil error, want deferred open error")
+		}
+		if err := r.SeekToRow(0); err == nil {
+			t.Fatal("SeekToRow: got nil error, want deferred open error")
+		}
+		r.Reset()
+	})
+}
+
 func TestIssue522(t *testing.T) {
 	type Row struct {
 		ID  int64   `parquet:"id"`


### PR DESCRIPTION
Following the previous PRs that return errors on malformed input, it'd be helpful if creating a reader didn't `panic` on malformed input.

I understand the motivation for issuing a `panic` on a misconfigured reader as the configuration is fully in the hands of the programmer, but input files are not and `panic` is a very problematic thing when you're reading a bunch of parquet files that you don't control and might be malformed.

In order to keep all interfaces the same, this PR moves those `panic` to be an `error` **on first read**. This way `NewReader | NewGenericReader` don't need to start returning an error.