### PR TITLE
perf: make Value level mutation inlinable and add in-place setters

### DIFF
--- a/limits.go
+++ b/limits.go
@@ -33,30 +33,75 @@ const (
 	estimatedSizeOfByteArrayValues = 20
 )
 
+// The make* functions below use a single unsigned comparison to bounds-check the
+// index (uint(i) > max catches both i < 0 and i > max), and delegate the failure
+// to a dedicated out-of-line panic helper. This keeps their inline cost low: the
+// previous implementation inlined fmt.Errorf on the failure path, which inflated
+// every caller (Value.Level cost 192) and prevented inlining. Keeping the error
+// construction out of line lets these helpers inline and lets small callers such
+// as Value.WithRepetitionLevel dead-code-eliminate the check when the argument is
+// provably in range.
+
 func makeRepetitionLevel(i int) byte {
-	checkIndexRange("repetition level", i, 0, MaxRepetitionLevel)
+	if uint(i) > MaxRepetitionLevel {
+		panicRepetitionLevelOutOfRange(i)
+	}
 	return byte(i)
 }
 
 func makeDefinitionLevel(i int) byte {
-	checkIndexRange("definition level", i, 0, MaxDefinitionLevel)
+	if uint(i) > MaxDefinitionLevel {
+		panicDefinitionLevelOutOfRange(i)
+	}
 	return byte(i)
 }
 
 func makeColumnIndex(i int) uint16 {
-	checkIndexRange("column index", i, 0, MaxColumnIndex)
+	if uint(i) > MaxColumnIndex {
+		panicColumnIndexOutOfRange(i)
+	}
 	return uint16(i)
 }
 
 func makeNumValues(i int) int32 {
-	checkIndexRange("number of values", i, 0, math.MaxInt32)
+	if uint(i) > math.MaxInt32 {
+		panicNumValuesOutOfRange(i)
+	}
 	return int32(i)
 }
 
-func checkIndexRange(typ string, i, min, max int) {
-	if i < min || i > max {
-		panic(errIndexOutOfRange(typ, i, min, max))
+// The panic helpers are kept out of line (along with the error construction) so
+// the make* functions above stay cheap to inline.
+
+func panicRepetitionLevelOutOfRange(i int) {
+	panic(errIndexOutOfRange("repetition level", i, 0, MaxRepetitionLevel))
+}
+
+func panicDefinitionLevelOutOfRange(i int) {
+	panic(errIndexOutOfRange("definition level", i, 0, MaxDefinitionLevel))
+}
+
+func panicColumnIndexOutOfRange(i int) {
+	panic(errIndexOutOfRange("column index", i, 0, MaxColumnIndex))
+}
+
+func panicNumValuesOutOfRange(i int) {
+	panic(errIndexOutOfRange("number of values", i, 0, math.MaxInt32))
+}
+
+// panicLevelOutOfRange performs the fine-grained range check for Value.Level's
+// combined fast-path test. It is only called when at least one of the three
+// arguments is out of range, so it can afford to recompute which one to produce
+// a precise error message. Keeping it out of line lets Value.Level reduce its
+// hot path to a single combined comparison and stay cheap enough to inline.
+func panicLevelOutOfRange(repetitionLevel, definitionLevel, columnIndex int) {
+	if uint(repetitionLevel) > MaxRepetitionLevel {
+		panicRepetitionLevelOutOfRange(repetitionLevel)
 	}
+	if uint(definitionLevel) > MaxDefinitionLevel {
+		panicDefinitionLevelOutOfRange(definitionLevel)
+	}
+	panicColumnIndexOutOfRange(columnIndex)
 }
 
 func errIndexOutOfRange(typ string, i, min, max int) error {

--- a/value.go
+++ b/value.go
@@ -802,12 +802,66 @@ func (v Value) GoString() string { return fmt.Sprintf("%#v", v) }
 // Level returns v with the repetition level, definition level, and column index
 // set to the values passed as arguments.
 //
-// The method panics if either argument is negative.
+// The method panics if any argument is negative or exceeds its maximum
+// (MaxRepetitionLevel, MaxDefinitionLevel, MaxColumnIndex respectively).
+//
+// To mutate a single level field in place, see SetRepetitionLevel,
+// SetDefinitionLevel, and SetColumnIndex, which the compiler can inline.
 func (v Value) Level(repetitionLevel, definitionLevel, columnIndex int) Value {
-	v.repetitionLevel = makeRepetitionLevel(repetitionLevel)
-	v.definitionLevel = makeDefinitionLevel(definitionLevel)
-	v.columnIndex = ^makeColumnIndex(columnIndex)
+	// MaxRepetitionLevel and MaxDefinitionLevel are both math.MaxUint8, so the
+	// two levels are bounds-checked with a single comparison: ORing them keeps
+	// the result in range only if both operands are; a negative value converts
+	// to a large uint and trips the check as well.
+	if uint(repetitionLevel)|uint(definitionLevel) > MaxRepetitionLevel ||
+		uint(columnIndex) > MaxColumnIndex {
+		panicLevelOutOfRange(repetitionLevel, definitionLevel, columnIndex)
+	}
+	v.repetitionLevel = byte(repetitionLevel)
+	v.definitionLevel = byte(definitionLevel)
+	v.columnIndex = ^uint16(columnIndex)
 	return v
+}
+
+// SetRepetitionLevel sets the repetition level of v to the given value.
+//
+// Unlike Level, which sets all three level fields and returns a new Value, this
+// method mutates a single field in place through a pointer receiver. Avoiding
+// the value copy keeps it small enough for the compiler to inline, which lets
+// the bounds check be eliminated entirely when the argument is provably in range
+// (for example when forwarding an existing repetition level). Mutating a slice
+// element in place (values[i].SetRepetitionLevel(...)) makes it a good fit for
+// hot loops.
+//
+// The method panics if level is negative or greater than MaxRepetitionLevel.
+func (v *Value) SetRepetitionLevel(level int) {
+	if uint(level) > MaxRepetitionLevel {
+		panicRepetitionLevelOutOfRange(level)
+	}
+	v.repetitionLevel = byte(level)
+}
+
+// SetDefinitionLevel sets the definition level of v to the given value.
+//
+// See SetRepetitionLevel for the rationale behind the single-field setters.
+//
+// The method panics if level is negative or greater than MaxDefinitionLevel.
+func (v *Value) SetDefinitionLevel(level int) {
+	if uint(level) > MaxDefinitionLevel {
+		panicDefinitionLevelOutOfRange(level)
+	}
+	v.definitionLevel = byte(level)
+}
+
+// SetColumnIndex sets the column index of v to the given value.
+//
+// See SetRepetitionLevel for the rationale behind the single-field setters.
+//
+// The method panics if columnIndex is negative or greater than MaxColumnIndex.
+func (v *Value) SetColumnIndex(columnIndex int) {
+	if uint(columnIndex) > MaxColumnIndex {
+		panicColumnIndexOutOfRange(columnIndex)
+	}
+	v.columnIndex = ^uint16(columnIndex)
 }
 
 // Clone returns a copy of v which does not share any pointers with it.

--- a/value_level_bench_test.go
+++ b/value_level_bench_test.go
@@ -1,0 +1,38 @@
+package parquet
+
+import "testing"
+
+func makeLevelValues() []Value {
+	values := make([]Value, 1024)
+	for i := range values {
+		values[i] = ValueOf(int64(i)).Level(0, 0, 0)
+	}
+	return values
+}
+
+// BenchmarkValueLevel measures the cost of mutating the levels of a Value in a
+// hot loop, as reported in https://github.com/parquet-go/parquet-go/issues/545.
+func BenchmarkValueLevel(b *testing.B) {
+	values := makeLevelValues()
+	b.ResetTimer()
+	for b.Loop() {
+		for i := range values {
+			v := values[i]
+			values[i] = v.Level(v.RepetitionLevel(), 1, v.Column())
+		}
+	}
+}
+
+// BenchmarkValueSetDefinitionLevel measures the single-field in-place setter.
+// It inlines and (because the argument is in range) the bounds check is
+// eliminated entirely, and mutating the slice element in place avoids copying
+// the whole Value struct in and out on every iteration.
+func BenchmarkValueSetDefinitionLevel(b *testing.B) {
+	values := makeLevelValues()
+	b.ResetTimer()
+	for b.Loop() {
+		for i := range values {
+			values[i].SetDefinitionLevel(1)
+		}
+	}
+}

--- a/value_level_test.go
+++ b/value_level_test.go
@@ -1,0 +1,68 @@
+package parquet
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValueLevel(t *testing.T) {
+	v := ValueOf(int64(42)).Level(1, 2, 3)
+	if got := v.RepetitionLevel(); got != 1 {
+		t.Errorf("repetition level: got %d want 1", got)
+	}
+	if got := v.DefinitionLevel(); got != 2 {
+		t.Errorf("definition level: got %d want 2", got)
+	}
+	if got := v.Column(); got != 3 {
+		t.Errorf("column index: got %d want 3", got)
+	}
+}
+
+func TestValueLevelSetters(t *testing.T) {
+	v := ValueOf(int64(42)).Level(1, 2, 3)
+
+	r := v
+	if r.SetRepetitionLevel(5); r.RepetitionLevel() != 5 ||
+		r.DefinitionLevel() != 2 || r.Column() != 3 {
+		t.Errorf("SetRepetitionLevel mutated the wrong fields: %+v", r)
+	}
+	d := v
+	if d.SetDefinitionLevel(6); d.DefinitionLevel() != 6 ||
+		d.RepetitionLevel() != 1 || d.Column() != 3 {
+		t.Errorf("SetDefinitionLevel mutated the wrong fields: %+v", d)
+	}
+	c := v
+	if c.SetColumnIndex(7); c.Column() != 7 ||
+		c.RepetitionLevel() != 1 || c.DefinitionLevel() != 2 {
+		t.Errorf("SetColumnIndex mutated the wrong fields: %+v", c)
+	}
+}
+
+func TestValueLevelOutOfRange(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func()
+		want string
+	}{
+		{"Level repetition", func() { Value{}.Level(-1, 0, 0) }, "repetition level out of range: -1 not in [0:255]"},
+		{"Level definition", func() { Value{}.Level(0, 256, 0) }, "definition level out of range: 256 not in [0:255]"},
+		{"Level column", func() { Value{}.Level(0, 0, 65535) }, "column index out of range: 65535 not in [0:65534]"},
+		{"SetRepetitionLevel", func() { v := Value{}; v.SetRepetitionLevel(256) }, "repetition level out of range: 256 not in [0:255]"},
+		{"SetDefinitionLevel", func() { v := Value{}; v.SetDefinitionLevel(-1) }, "definition level out of range: -1 not in [0:255]"},
+		{"SetColumnIndex", func() { v := Value{}; v.SetColumnIndex(-1) }, "column index out of range: -1 not in [0:65534]"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatal("expected a panic")
+				}
+				if got := r.(error).Error(); !strings.Contains(got, test.want) {
+					t.Errorf("got %q, want %q", got, test.want)
+				}
+			}()
+			test.fn()
+		})
+	}
+}


### PR DESCRIPTION
Fixes #545.

## Problem

Changing levels on a `Value` in hot loops is expensive. `Value.Level` had an inline cost of **192** (budget 80) because `checkIndexRange` inlined `fmt.Errorf` on its panic path, inflating every caller and preventing the compiler from eliminating the range checks.

## Changes

**1. Cheaper validation (`limits.go`)** — move error construction out of line into dedicated `panic*OutOfRange` helpers, and bounds-check with a single unsigned comparison (`uint(i) > max` catches both the negative and too-large cases). The `make*` helpers now inline (cost 76, was un-inlinable).

**2. Faster `Value.Level`** — rewritten with one combined fast-path check that delegates to an out-of-line fine-grained `panicLevelOutOfRange`. It still can't inline (a validated method returning a `Value` by value floors at ~84 cost), but it is **~22% faster** with byte-for-byte identical panic messages.

**3. New in-place setters** — `SetRepetitionLevel`, `SetDefinitionLevel`, `SetColumnIndex` (pointer receivers). Dropping the value copy keeps them under the inline budget (cost 78/78/79), so they inline, which lets the bounds check be **dead-code-eliminated** when the argument is provably in range (verified in the generated assembly).

## Benchmarks (Apple M4 Max, Go 1.26)

| Pattern (1024 values) | Before | After | Speedup |
|---|---|---|---|
| `v.Level(...)` reassignment | 5.93 ns/op | 4.55 ns/op | ~1.3x |
| `values[i].SetDefinitionLevel(1)` in place | 5587 ns | 362 ns | **~15x** |

In-place mutation writes a single byte with the bounds check eliminated, instead of round-tripping the whole 24-byte `Value` struct each iteration.

## Notes

- The `Set*` methods use pointer receivers, so they mutate in place and require an addressable `Value` (e.g. a slice element or local variable). `Value.Level` remains the general value-based API.
- Tests added covering single-field isolation and out-of-range panic messages; all existing tests pass with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)