### PR TITLE
perf: specialize single-column row comparator to bypass interface dispatch

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -1,6 +1,7 @@
 package parquet
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	"github.com/parquet-go/parquet-go/deprecated"
@@ -226,12 +227,194 @@ func compareRowsFuncOfIndexColumns(compareFuncs []func(Row, Row) int) func(Row, 
 
 //go:noinline
 func compareRowsFuncOfIndexAscending(columnIndex uint16, typ Type) func(Row, Row) int {
-	return func(row1, row2 Row) int { return typ.Compare(row1[columnIndex], row2[columnIndex]) }
+	switch t := typ.(type) {
+	case int32Type:
+		return func(row1, row2 Row) int {
+			return compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+		}
+	case uint32Type:
+		return func(row1, row2 Row) int {
+			return compareUint32(row1[columnIndex].uint32(), row2[columnIndex].uint32())
+		}
+	case int64Type:
+		return func(row1, row2 Row) int {
+			return compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+		}
+	case uint64Type:
+		return func(row1, row2 Row) int {
+			return compareUint64(row1[columnIndex].uint64(), row2[columnIndex].uint64())
+		}
+	case floatType:
+		return func(row1, row2 Row) int {
+			return compareFloat32(row1[columnIndex].float(), row2[columnIndex].float())
+		}
+	case doubleType:
+		return func(row1, row2 Row) int {
+			return compareFloat64(row1[columnIndex].double(), row2[columnIndex].double())
+		}
+	case booleanType:
+		return func(row1, row2 Row) int {
+			return compareBool(row1[columnIndex].boolean(), row2[columnIndex].boolean())
+		}
+	case byteArrayType, *stringType:
+		return func(row1, row2 Row) int {
+			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case fixedLenByteArrayType:
+		return func(row1, row2 Row) int {
+			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case be128Type, *uuidType:
+		return func(row1, row2 Row) int {
+			return compareBE128(row1[columnIndex].be128(), row2[columnIndex].be128())
+		}
+	case *geographyType, *bsonType, *geometryType, *jsonType:
+		return func(row1, row2 Row) int {
+			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case *enumType:
+		return func(row1, row2 Row) int {
+			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case *dateType:
+		return func(row1, row2 Row) int {
+			return compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+		}
+	case *timestampType:
+		return func(row1, row2 Row) int {
+			return compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+		}
+	case *timeType:
+		if t.useInt32() {
+			return func(row1, row2 Row) int {
+				return compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+			}
+		} else {
+			return func(row1, row2 Row) int {
+				return compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+			}
+		}
+	case *intType:
+		if t.BitWidth == 64 {
+			if t.IsSigned {
+				return func(row1, row2 Row) int {
+					return compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+				}
+			} else {
+				return func(row1, row2 Row) int {
+					return compareUint64(row1[columnIndex].uint64(), row2[columnIndex].uint64())
+				}
+			}
+		} else {
+			if t.IsSigned {
+				return func(row1, row2 Row) int {
+					return compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+				}
+			} else {
+				return func(row1, row2 Row) int {
+					return compareUint32(row1[columnIndex].uint32(), row2[columnIndex].uint32())
+				}
+			}
+		}
+	default:
+		return func(row1, row2 Row) int { return typ.Compare(row1[columnIndex], row2[columnIndex]) }
+	}
 }
 
 //go:noinline
 func compareRowsFuncOfIndexDescending(columnIndex uint16, typ Type) func(Row, Row) int {
-	return func(row1, row2 Row) int { return -typ.Compare(row1[columnIndex], row2[columnIndex]) }
+	switch t := typ.(type) {
+	case int32Type:
+		return func(row1, row2 Row) int {
+			return -compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+		}
+	case uint32Type:
+		return func(row1, row2 Row) int {
+			return -compareUint32(row1[columnIndex].uint32(), row2[columnIndex].uint32())
+		}
+	case int64Type:
+		return func(row1, row2 Row) int {
+			return -compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+		}
+	case uint64Type:
+		return func(row1, row2 Row) int {
+			return -compareUint64(row1[columnIndex].uint64(), row2[columnIndex].uint64())
+		}
+	case floatType:
+		return func(row1, row2 Row) int {
+			return -compareFloat32(row1[columnIndex].float(), row2[columnIndex].float())
+		}
+	case doubleType:
+		return func(row1, row2 Row) int {
+			return -compareFloat64(row1[columnIndex].double(), row2[columnIndex].double())
+		}
+	case booleanType:
+		return func(row1, row2 Row) int {
+			return -compareBool(row1[columnIndex].boolean(), row2[columnIndex].boolean())
+		}
+	case byteArrayType, *stringType:
+		return func(row1, row2 Row) int {
+			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case fixedLenByteArrayType:
+		return func(row1, row2 Row) int {
+			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case be128Type, *uuidType:
+		return func(row1, row2 Row) int {
+			return -compareBE128(row1[columnIndex].be128(), row2[columnIndex].be128())
+		}
+	case *geographyType, *bsonType, *geometryType, *jsonType:
+		return func(row1, row2 Row) int {
+			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case *enumType:
+		return func(row1, row2 Row) int {
+			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
+		}
+	case *dateType:
+		return func(row1, row2 Row) int {
+			return -compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+		}
+	case *timestampType:
+		return func(row1, row2 Row) int {
+			return -compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+		}
+	case *timeType:
+		if t.useInt32() {
+			return func(row1, row2 Row) int {
+				return -compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+			}
+		} else {
+			return func(row1, row2 Row) int {
+				return -compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+			}
+		}
+	case *intType:
+		if t.BitWidth == 64 {
+			if t.IsSigned {
+				return func(row1, row2 Row) int {
+					return -compareInt64(row1[columnIndex].int64(), row2[columnIndex].int64())
+				}
+			} else {
+				return func(row1, row2 Row) int {
+					return -compareUint64(row1[columnIndex].uint64(), row2[columnIndex].uint64())
+				}
+			}
+		} else {
+			if t.IsSigned {
+				return func(row1, row2 Row) int {
+					return -compareInt32(row1[columnIndex].int32(), row2[columnIndex].int32())
+				}
+			} else {
+				return func(row1, row2 Row) int {
+					return -compareUint32(row1[columnIndex].uint32(), row2[columnIndex].uint32())
+				}
+			}
+		}
+	default:
+		return func(row1, row2 Row) int { return -typ.Compare(row1[columnIndex], row2[columnIndex]) }
+	}
 }
 
 //go:noinline

--- a/compare.go
+++ b/compare.go
@@ -256,25 +256,13 @@ func compareRowsFuncOfIndexAscending(columnIndex uint16, typ Type) func(Row, Row
 		return func(row1, row2 Row) int {
 			return compareBool(row1[columnIndex].boolean(), row2[columnIndex].boolean())
 		}
-	case byteArrayType, *stringType:
-		return func(row1, row2 Row) int {
-			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
-		}
-	case fixedLenByteArrayType:
+	case byteArrayType, *stringType, fixedLenByteArrayType, *enumType, *geographyType, *bsonType, *geometryType, *jsonType:
 		return func(row1, row2 Row) int {
 			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
 		}
 	case be128Type, *uuidType:
 		return func(row1, row2 Row) int {
 			return compareBE128(row1[columnIndex].be128(), row2[columnIndex].be128())
-		}
-	case *geographyType, *bsonType, *geometryType, *jsonType:
-		return func(row1, row2 Row) int {
-			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
-		}
-	case *enumType:
-		return func(row1, row2 Row) int {
-			return bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
 		}
 	case *dateType:
 		return func(row1, row2 Row) int {
@@ -352,25 +340,13 @@ func compareRowsFuncOfIndexDescending(columnIndex uint16, typ Type) func(Row, Ro
 		return func(row1, row2 Row) int {
 			return -compareBool(row1[columnIndex].boolean(), row2[columnIndex].boolean())
 		}
-	case byteArrayType, *stringType:
-		return func(row1, row2 Row) int {
-			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
-		}
-	case fixedLenByteArrayType:
+	case byteArrayType, *stringType, fixedLenByteArrayType, *enumType, *geographyType, *bsonType, *geometryType, *jsonType:
 		return func(row1, row2 Row) int {
 			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
 		}
 	case be128Type, *uuidType:
 		return func(row1, row2 Row) int {
 			return -compareBE128(row1[columnIndex].be128(), row2[columnIndex].be128())
-		}
-	case *geographyType, *bsonType, *geometryType, *jsonType:
-		return func(row1, row2 Row) int {
-			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
-		}
-	case *enumType:
-		return func(row1, row2 Row) int {
-			return -bytes.Compare(row1[columnIndex].byteArray(), row2[columnIndex].byteArray())
 		}
 	case *dateType:
 		return func(row1, row2 Row) int {

--- a/compare_test.go
+++ b/compare_test.go
@@ -24,6 +24,30 @@ func TestCompareNullsLast(t *testing.T) {
 	assertCompare(t, ValueOf(int32(0)), ValueOf(int32(1)), cmp, -1)
 }
 
+func TestCompareRowsTimeNanosecond(t *testing.T) {
+	typ := &timeNanoAdjustedToUTC
+
+	cmpAsc := compareRowsFuncOfIndexAscending(0, typ)
+	cmpDesc := compareRowsFuncOfIndexDescending(0, typ)
+
+	// 10,000,000 ns (10 ms)
+	row1 := Row{ValueOf(int64(10000000))}
+	// 3,000,000,000,000 ns (3000 seconds = 50 minutes).
+	// If compared as a signed 32-bit int, 3,000,000,000,000 wraps around or truncates.
+	// Specifically, int32(3000000000000) = -1305411584
+	row2 := Row{ValueOf(int64(3000000000000))}
+
+	// Ascending: row1 should be less than row2 (returns -1)
+	if got := cmpAsc(row1, row2); got >= 0 {
+		t.Errorf("Ascending: 10ms should be less than 50min, got %d", got)
+	}
+
+	// Descending: row1 should be greater than row2 (returns +1)
+	if got := cmpDesc(row1, row2); got <= 0 {
+		t.Errorf("Descending: 10ms should be greater than 50min, got %d", got)
+	}
+}
+
 func BenchmarkCompareBE128(b *testing.B) {
 	v1 := [16]byte{}
 	v2 := [16]byte{}


### PR DESCRIPTION
## Summary
This pull request introduces a major performance optimization to the single-column row comparison closures returned by `compareRowsFuncOfIndexAscending` and `compareRowsFuncOfIndexDescending`.

### Headline Win
* **BenchmarkMergeRowBuffers**: `316,297,418 ns/op` -> `190,214,661 ns/op` (**39.86% reduction in timing**, p-value = 1.08e-5, n=10)
* No behavior changes.

### Why It Matters
On Parquet row group sorting and merging workloads, row comparator functions are invoked inside tight loops $O(N \log N)$ times. Previously, the closure performed a generic interface call `typ.Compare(row1[columnIndex], row2[columnIndex])`, which incurred virtual dispatch overhead and copied two 24-byte `Value` structures per comparison. 

By resolving the concrete column type once during closure construction using a type switch, we return specialized, monomorphic closures. This avoids interface dispatch entirely. Furthermore, accessing `row1[columnIndex]` on a slice returns an addressable reference, which allows Go to call internal pointer-receiver methods (such as `int64()`, `int32()`, etc.) directly, avoiding `Value` copying.

### Reproduction
To reproduce and verify the performance improvements:
```bash
go test -json -run=^$ -bench=BenchmarkMergeRowBuffers -benchmem ./... | perfloop-go-bench-json BenchmarkMergeRowBuffers ns/op
```
* **Baseline Commit**: `1f9447157b9f149c29b343af86ac8a0650fc880d`
* **Candidate Commit**: `2d97e09b54af03d7a8663a21e5acc33e7ca29828`
* **Environment**: Linux / amd64 / Go (go1.26.4)

### Alternatives Considered
No other alternative changes or dead ends were tried, as this targeted monomorphization was highly successful and validated on its initial attempt.

### Limits
This optimization is scoped to single-column row comparisons during sorting and merging. Multi-column comparisons construct multiple single-column comparators and compare them sequentially, which benefits from the monomorphization of each column, but still executes sequentially. Non-sorting and non-merging workloads (such as regular reading or writing) are out of scope and remain unaffected.

### Full Proof
The canonical case-page with all interleaved runs, benchmarks, and statistical analysis is available at: https://app.perfloop.ai/t/oss/case_42cpb9gsx5

## Test plan
- [x] All package tests pass (`go test ./...`)
- [x] Race detector passes on targeted comparison tests (`go test -race -short -run=TestCompare .`)

---
This is an automated, human-reviewed Perfloop contribution opened by perfloop-agent. The body links to reproducible proof for the change. The change was benchmarked on perfloop/parquet-go, an automation fork of parquet-go/parquet-go; the commit on this PR's head branch carries the proof.
