### PR TITLE
fix(bloomfilter): correct offset calculation for section reads

### DIFF
--- a/file.go
+++ b/file.go
@@ -1030,9 +1030,10 @@ func (c *FileColumnChunk) readBloomFilter(reader io.ReaderAt) (*FileBloomFilter,
 		if err := decoder.Decode(&header); err != nil {
 			return nil, fmt.Errorf("decoding bloom filter header: %w", err)
 		}
-		offset, _ = section.Seek(0, io.SeekCurrent)
+		sectionPos, _ := section.Seek(0, io.SeekCurrent)
+		dataOffset := offset + sectionPos - int64(rbuf.Buffered())
 		var err error
-		filter, err = newBloomFilter(reader, offset, &header)
+		filter, err = newBloomFilter(reader, dataOffset, &header)
 		if err != nil {
 			return nil, fmt.Errorf("reading bloom filter: %w", err)
 		}

--- a/file_test.go
+++ b/file_test.go
@@ -369,6 +369,73 @@ func TestOpenFileOptimisticReadWithPrefetchBloomFilters(t *testing.T) {
 	}
 }
 
+// Verifies that lazily loading a bloom filter (SkipBloomFilters(true)) issues
+// read calls within the bloom filter's section in the file. Before the fix,
+// readBloomFilter passed a section-relative offset to newBloomFilter as if it
+// were an absolute file offset, so the underlying reads happened near byte 0 of
+// the file instead of inside the bloom filter section, resulting in always
+// returning false negative matches.
+func TestBloomFilterMatchesWhenLoadedOnOpenOrLazyLoad(t *testing.T) {
+	type Row struct {
+		Name string `parquet:"name"`
+	}
+
+	// Write enough rows to push offset past the 1024-byte bufio buffer used by
+	// readBloomFilter.
+	rows := make([]Row, 600)
+	for range 200 {
+		rows = append(rows,
+			Row{Name: "alice"},
+			Row{Name: "bob"},
+			Row{Name: "charlie"},
+		)
+	}
+
+	buf := new(bytes.Buffer)
+	w := parquet.NewGenericWriter[Row](buf,
+		parquet.BloomFilters(parquet.SplitBlockFilter(12, "name")),
+	)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data := buf.Bytes()
+	size := int64(len(data))
+
+	for _, tt := range []struct {
+		skipBloomFilters bool
+	}{
+		{skipBloomFilters: false},
+		{skipBloomFilters: true},
+	} {
+		t.Run(fmt.Sprintf("skipBloomFilters=%t", tt.skipBloomFilters), func(t *testing.T) {
+			pf, err := parquet.OpenFile(bytes.NewReader(data), size,
+				parquet.SkipBloomFilters(tt.skipBloomFilters),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bf := pf.RowGroups()[0].ColumnChunks()[0].BloomFilter()
+			if bf == nil {
+				t.Fatal("expected bloom filter on 'name' column")
+			}
+			if maybeMatch, err := bf.Check(parquet.ValueOf("charlie")); err != nil {
+				t.Fatal(err)
+			} else if !maybeMatch {
+				t.Errorf("bloom filter should have matched 'charlie' but didn't")
+			}
+			if maybeMatch, err := bf.Check(parquet.ValueOf("james")); err != nil {
+				t.Fatal(err)
+			} else if maybeMatch {
+				t.Errorf("bloom filter should not match 'james' but did")
+			}
+		})
+	}
+}
+
 func TestIssue229(t *testing.T) {
 	// https://github.com/grafana/tempo/blob/5cae77c9cf8da51e0db7c5556b19d305130ea9c4/tempodb/encoding/vparquet2/schema.go
 	type Attribute struct {


### PR DESCRIPTION
I wanted to test lazy loading bloom filters using `parquet.SkipBloomFilters(true)` to avoid the buffer allocation (as I already have this cached externally), and found the offset calculation on the lazy-load path was incorrect. 

Prior to this PR, the calculation was offset from the start of the file; as a result I saw random reads and always false negatives. The updated calculation now matches the eager load path in `OpenFile`.