### PR TITLE
perf: optimize variant.Marshal directly from reflect walk

### DIFF
--- a/variant/benchmark_test.go
+++ b/variant/benchmark_test.go
@@ -1,0 +1,52 @@
+package variant
+
+import (
+	"testing"
+)
+
+func BenchmarkMarshalInt64Slice(b *testing.B) {
+	slice := make([]int64, 1000)
+	for i := range slice {
+		slice[i] = int64(i)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		meta, val, err := Marshal(slice)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = meta
+		_ = val
+	}
+}
+
+func BenchmarkEncodePrimitive(b *testing.B) {
+	v := Int64(42)
+	var builder MetadataBuilder
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = Encode(&builder, v)
+	}
+}
+
+func BenchmarkEncodeNested(b *testing.B) {
+	fields := []Field{
+		{Name: "a", Value: Int64(1)},
+		{Name: "b", Value: String("hello")},
+	}
+	obj := MakeObject(fields)
+	elements := make([]Value, 10)
+	for i := range elements {
+		elements[i] = obj
+	}
+	arr := MakeArray(elements)
+
+	var builder MetadataBuilder
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = Encode(&builder, arr)
+	}
+}

--- a/variant/encoding.go
+++ b/variant/encoding.go
@@ -2,8 +2,12 @@ package variant
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
+	"reflect"
 	"sort"
+
+	"github.com/google/uuid"
 )
 
 // Encode encodes a variant Value into its binary representation.
@@ -12,9 +16,29 @@ import (
 func Encode(b *MetadataBuilder, v Value) []byte {
 	switch v.basic {
 	case BasicObject:
-		return encodeObject(b, v.object)
+		enc := encoder{
+			b:       b,
+			scratch: make([]byte, 0, 512),
+		}
+		start, end, err := enc.encodeValueObject(v.object)
+		if err != nil {
+			return nil
+		}
+		res := make([]byte, end-start)
+		copy(res, enc.scratch[start:end])
+		return res
 	case BasicArray:
-		return encodeArray(b, v.array)
+		enc := encoder{
+			b:       b,
+			scratch: make([]byte, 0, 512),
+		}
+		start, end, err := enc.encodeValueArray(v.array)
+		if err != nil {
+			return nil
+		}
+		res := make([]byte, end-start)
+		copy(res, enc.scratch[start:end])
+		return res
 	default:
 		return encodePrimitive(v)
 	}
@@ -58,13 +82,11 @@ func encodePrimitive(v Value) []byte {
 	case PrimitiveString:
 		s := v.str
 		if len(s) <= 63 {
-			// Use short string encoding
 			buf := make([]byte, 1+len(s))
 			buf[0] = makeHeader(BasicShortString, byte(len(s)))
 			copy(buf[1:], s)
 			return buf
 		}
-		// Long string: primitive string type + 4-byte length + data
 		buf := make([]byte, 5+len(s))
 		buf[0] = makeHeader(BasicPrimitive, byte(PrimitiveString))
 		binary.LittleEndian.PutUint32(buf[1:], uint32(len(s)))
@@ -124,120 +146,301 @@ func encodePrimitive(v Value) []byte {
 	}
 }
 
-func encodeObject(b *MetadataBuilder, obj Object) []byte {
-	n := len(obj.Fields)
+// makeHeader constructs a value_metadata byte.
+func makeHeader(basic BasicType, valueHeader byte) byte {
+	return byte(basic) | (valueHeader << 2)
+}
 
-	// Register all field names and get their IDs
-	type fieldEntry struct {
-		id         int
-		name       string
-		valueBytes []byte
+type encoder struct {
+	b       *MetadataBuilder
+	scratch []byte
+}
+
+type encodedField struct {
+	id    int
+	name  string
+	start int
+	end   int
+}
+
+type elementPos struct {
+	start int
+	end   int
+}
+
+var testHookVerifyArrayLayout func(e *encoder, positions []elementPos)
+var testHookVerifyObjectLayout func(e *encoder, entries []encodedField)
+
+func (e *encoder) encodeValuePrimitive(v Value) (start, end int) {
+	start = len(e.scratch)
+	switch v.primitive {
+	case PrimitiveNull:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveNull)))
+	case PrimitiveTrue:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveTrue)))
+	case PrimitiveFalse:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveFalse)))
+	case PrimitiveInt8:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveInt8)), byte(v.i64))
+	case PrimitiveInt16:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveInt16)), 0, 0)
+		binary.LittleEndian.PutUint16(e.scratch[start+1:], uint16(v.i64))
+	case PrimitiveInt32:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveInt32)), 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(e.scratch[start+1:], uint32(v.i64))
+	case PrimitiveInt64:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveInt64)), 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint64(e.scratch[start+1:], uint64(v.i64))
+	case PrimitiveFloat:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveFloat)), 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(e.scratch[start+1:], math.Float32bits(float32(v.f64)))
+	case PrimitiveDouble:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveDouble)), 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint64(e.scratch[start+1:], math.Float64bits(v.f64))
+	case PrimitiveString:
+		s := v.str
+		if len(s) <= 63 {
+			e.scratch = append(e.scratch, makeHeader(BasicShortString, byte(len(s))))
+			e.scratch = append(e.scratch, s...)
+		} else {
+			e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveString)), 0, 0, 0, 0)
+			binary.LittleEndian.PutUint32(e.scratch[start+1:], uint32(len(s)))
+			e.scratch = append(e.scratch, s...)
+		}
+	case PrimitiveBinary:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveBinary)), 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(e.scratch[start+1:], uint32(len(v.bytes)))
+		e.scratch = append(e.scratch, v.bytes...)
+	case PrimitiveDate:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveDate)), 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(e.scratch[start+1:], uint32(v.i64))
+	case PrimitiveTimestamp:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveTimestamp)), 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint64(e.scratch[start+1:], uint64(v.i64))
+	case PrimitiveTimestampNTZ:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveTimestampNTZ)), 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint64(e.scratch[start+1:], uint64(v.i64))
+	case PrimitiveTime:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveTime)), 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint64(e.scratch[start+1:], uint64(v.i64))
+	case PrimitiveUUID:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveUUID)))
+		e.scratch = append(e.scratch, v.uuid[:]...)
+	case PrimitiveDecimal4:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveDecimal4)), v.scale, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(e.scratch[start+2:], uint32(v.i64))
+	case PrimitiveDecimal8:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveDecimal8)), v.scale, 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint64(e.scratch[start+2:], uint64(v.i64))
+	case PrimitiveDecimal16:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveDecimal16)), v.scale)
+		e.scratch = append(e.scratch, v.decimal16[:]...)
+	default:
+		e.scratch = append(e.scratch, makeHeader(BasicPrimitive, byte(PrimitiveNull)))
 	}
-	entries := make([]fieldEntry, n)
+	end = len(e.scratch)
+	return start, end
+}
+
+func (e *encoder) encodeValue(v Value) (start, end int, err error) {
+	switch v.basic {
+	case BasicObject:
+		return e.encodeValueObject(v.object)
+	case BasicArray:
+		return e.encodeValueArray(v.array)
+	default:
+		start, end = e.encodeValuePrimitive(v)
+		return start, end, nil
+	}
+}
+
+func (e *encoder) encodeValueArray(arr Array) (start, end int, err error) {
+	n := len(arr.Elements)
+	if n == 0 {
+		return e.buildArrayBytes(nil)
+	}
+
+	var posBuf [32]elementPos
+	var positions []elementPos
+	if n <= len(posBuf) {
+		positions = posBuf[:n]
+	} else {
+		positions = make([]elementPos, n)
+	}
+
+	for i := 0; i < n; i++ {
+		pStart, pEnd, err := e.encodeValue(arr.Elements[i])
+		if err != nil {
+			return 0, 0, err
+		}
+		positions[i] = elementPos{start: pStart, end: pEnd}
+	}
+
+	return e.buildArrayBytes(positions)
+}
+
+func (e *encoder) encodeValueObject(obj Object) (start, end int, err error) {
+	n := len(obj.Fields)
+	if n == 0 {
+		return e.buildObjectBytes(nil)
+	}
+
+	var entriesBuf [16]encodedField
+	var entries []encodedField
+	if n <= len(entriesBuf) {
+		entries = entriesBuf[:n]
+	} else {
+		entries = make([]encodedField, n)
+	}
+
 	for i, f := range obj.Fields {
-		entries[i] = fieldEntry{
-			id:         b.Add(f.Name),
-			name:       f.Name,
-			valueBytes: Encode(b, f.Value),
+		id := e.b.Add(f.Name)
+		pStart, pEnd, err := e.encodeValue(f.Value)
+		if err != nil {
+			return 0, 0, err
+		}
+		entries[i] = encodedField{
+			id:    id,
+			name:  f.Name,
+			start: pStart,
+			end:   pEnd,
 		}
 	}
 
-	// Sort by field name (as required by spec)
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].name < entries[j].name
 	})
 
-	// Compute sizes
-	maxID := 0
-	for _, e := range entries {
-		if e.id > maxID {
-			maxID = e.id
-		}
-	}
-
-	// Encode all values and compute offsets
-	totalValueSize := 0
-	valueOffsets := make([]int, n+1)
-	for i, e := range entries {
-		valueOffsets[i] = totalValueSize
-		totalValueSize += len(e.valueBytes)
-	}
-	valueOffsets[n] = totalValueSize
-
-	fieldIDSizeCode := offsetSizeCode(maxID)
-	fieldIDSize := offsetSize(fieldIDSizeCode)
-	offsetSzCode := offsetSizeCode(totalValueSize)
-	offsetSz := offsetSize(offsetSzCode)
-
-	// Header: basic_type=2 (object), value_header encodes num_fields, field_id_size, offset_size
-	// Object header byte: bits 0-1 = BasicObject(2), bits 2-3 = field_id_size_minus_one,
-	// bits 4-5 = offset_size_minus_one, bits 6-7 = unused
-	// Then: num_elements (1 byte for small objects, but spec says offset_size bytes)
-	//
-	// Actually the spec says:
-	// value_metadata byte: bits 0-1 = basic_type (2=object), bits 2-3 = field_id_size-1,
-	// bits 4-5 = offset_size-1, bits 6-7 = is_large (0=1-byte num_elements, 1=4-byte)
-	isLarge := byte(0)
-	numElemSize := 1
-	if n > 255 {
-		isLarge = 1
-		numElemSize = 4
-	}
-
-	header := byte(BasicObject) | (fieldIDSizeCode << 2) | (offsetSzCode << 4) | (isLarge << 6)
-
-	// Total size: header(1) + num_elements + field_ids(n*fieldIDSize) + offsets((n+1)*offsetSz) + values
-	totalSize := 1 + numElemSize + n*fieldIDSize + (n+1)*offsetSz + totalValueSize
-	buf := make([]byte, totalSize)
-	buf[0] = header
-
-	pos := 1
-	if isLarge == 1 {
-		binary.LittleEndian.PutUint32(buf[pos:], uint32(n))
-		pos += 4
-	} else {
-		buf[pos] = byte(n)
-		pos += 1
-	}
-
-	// Write field IDs
-	for _, e := range entries {
-		writeUint(buf[pos:], e.id, fieldIDSize)
-		pos += fieldIDSize
-	}
-
-	// Write offsets
-	for _, off := range valueOffsets {
-		writeUint(buf[pos:], off, offsetSz)
-		pos += offsetSz
-	}
-
-	// Write values
-	for _, e := range entries {
-		copy(buf[pos:], e.valueBytes)
-		pos += len(e.valueBytes)
-	}
-
-	return buf
+	return e.buildObjectBytes(entries)
 }
 
-func encodeArray(b *MetadataBuilder, arr Array) []byte {
-	n := len(arr.Elements)
-
-	// Encode all elements
-	encodedElems := make([][]byte, n)
-	totalSize := 0
-	for i, e := range arr.Elements {
-		encodedElems[i] = Encode(b, e)
-		totalSize += len(encodedElems[i])
+func (e *encoder) encodeReflect(rv reflect.Value) (start, end int, err error) {
+	if !rv.IsValid() {
+		start, end = e.encodeValuePrimitive(Null())
+		return start, end, nil
 	}
 
-	// Compute offsets
+	// Dereference pointers/interfaces
+	for rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			start, end = e.encodeValuePrimitive(Null())
+			return start, end, nil
+		}
+		rv = rv.Elem()
+	}
+
+	// Check concrete types first
+	if rv.Type() == reflect.TypeFor[uuid.UUID]() {
+		start, end = e.encodeValuePrimitive(UUID(rv.Interface().(uuid.UUID)))
+		return start, end, nil
+	}
+
+	switch rv.Kind() {
+	case reflect.Bool:
+		start, end = e.encodeValuePrimitive(Bool(rv.Bool()))
+		return start, end, nil
+	case reflect.Int8:
+		start, end = e.encodeValuePrimitive(Int8(int8(rv.Int())))
+		return start, end, nil
+	case reflect.Int16:
+		start, end = e.encodeValuePrimitive(Int16(int16(rv.Int())))
+		return start, end, nil
+	case reflect.Int32:
+		start, end = e.encodeValuePrimitive(Int32(int32(rv.Int())))
+		return start, end, nil
+	case reflect.Int64, reflect.Int:
+		start, end = e.encodeValuePrimitive(Int64(rv.Int()))
+		return start, end, nil
+	case reflect.Uint8:
+		start, end = e.encodeValuePrimitive(Int16(int16(rv.Uint())))
+		return start, end, nil
+	case reflect.Uint16:
+		start, end = e.encodeValuePrimitive(Int32(int32(rv.Uint())))
+		return start, end, nil
+	case reflect.Uint32:
+		start, end = e.encodeValuePrimitive(Int64(int64(rv.Uint())))
+		return start, end, nil
+	case reflect.Uint64, reflect.Uint:
+		u := rv.Uint()
+		if u > math.MaxInt64 {
+			return 0, 0, fmt.Errorf("variant marshal: uint64 value %d overflows int64", u)
+		}
+		start, end = e.encodeValuePrimitive(Int64(int64(u)))
+		return start, end, nil
+	case reflect.Float32:
+		start, end = e.encodeValuePrimitive(Float(float32(rv.Float())))
+		return start, end, nil
+	case reflect.Float64:
+		start, end = e.encodeValuePrimitive(Double(rv.Float()))
+		return start, end, nil
+	case reflect.String:
+		start, end = e.encodeValuePrimitive(String(rv.String()))
+		return start, end, nil
+	case reflect.Slice:
+		if rv.Type().Elem().Kind() == reflect.Uint8 {
+			start, end = e.encodeValuePrimitive(Binary(rv.Bytes()))
+			return start, end, nil
+		}
+		return e.encodeSliceArray(rv)
+	case reflect.Array:
+		if rv.Type() == reflect.TypeFor[uuid.UUID]() {
+			var u uuid.UUID
+			reflect.ValueOf(&u).Elem().Set(rv)
+			start, end = e.encodeValuePrimitive(UUID(u))
+			return start, end, nil
+		}
+		return e.encodeSliceArray(rv)
+	case reflect.Map:
+		return e.encodeMapObject(rv)
+	case reflect.Struct:
+		return e.encodeStructObject(rv)
+	default:
+		return 0, 0, fmt.Errorf("variant marshal: unsupported type %s", rv.Type())
+	}
+}
+
+func (e *encoder) encodeSliceArray(rv reflect.Value) (start, end int, err error) {
+	n := rv.Len()
+	if n == 0 {
+		return e.buildArrayBytes(nil)
+	}
+
+	var posBuf [32]elementPos
+	var positions []elementPos
+	if n <= len(posBuf) {
+		positions = posBuf[:n]
+	} else {
+		positions = make([]elementPos, n)
+	}
+
+	for i := 0; i < n; i++ {
+		pStart, pEnd, err := e.encodeReflect(rv.Index(i))
+		if err != nil {
+			return 0, 0, err
+		}
+		positions[i] = elementPos{start: pStart, end: pEnd}
+	}
+
+	return e.buildArrayBytes(positions)
+}
+
+func (e *encoder) buildArrayBytes(positions []elementPos) (start, end int, err error) {
+	n := len(positions)
+
+	if testHookVerifyArrayLayout != nil {
+		testHookVerifyArrayLayout(e, positions)
+	}
+
+	totalSize := 0
+	for _, pos := range positions {
+		totalSize += pos.end - pos.start
+	}
+
 	offsets := make([]int, n+1)
 	off := 0
-	for i, enc := range encodedElems {
+	for i, pos := range positions {
 		offsets[i] = off
-		off += len(enc)
+		off += pos.end - pos.start
 	}
 	offsets[n] = off
 
@@ -253,9 +456,192 @@ func encodeArray(b *MetadataBuilder, arr Array) []byte {
 
 	header := byte(BasicArray) | (offsetSzCode << 2) | (isLarge << 4)
 
-	// Total: header(1) + num_elements + offsets((n+1)*offsetSz) + values
 	bufSize := 1 + numElemSize + (n+1)*offsetSz + totalSize
 	buf := make([]byte, bufSize)
+	buf[0] = header
+
+	posIdx := 1
+	if isLarge == 1 {
+		binary.LittleEndian.PutUint32(buf[posIdx:], uint32(n))
+		posIdx += 4
+	} else {
+		buf[posIdx] = byte(n)
+		posIdx += 1
+	}
+
+	for _, o := range offsets {
+		writeUint(buf[posIdx:], o, offsetSz)
+		posIdx += offsetSz
+	}
+
+	for _, p := range positions {
+		copy(buf[posIdx:], e.scratch[p.start:p.end])
+		posIdx += p.end - p.start
+	}
+
+	firstStart := len(e.scratch)
+	if n > 0 {
+		firstStart = positions[0].start
+	}
+	e.scratch = e.scratch[:firstStart]
+
+	start = len(e.scratch)
+	e.scratch = append(e.scratch, buf...)
+	end = len(e.scratch)
+
+	return start, end, nil
+}
+
+func (e *encoder) encodeMapObject(rv reflect.Value) (start, end int, err error) {
+	if rv.IsNil() {
+		start, end = e.encodeValuePrimitive(Null())
+		return start, end, nil
+	}
+
+	n := rv.Len()
+	if n == 0 {
+		return e.buildObjectBytes(nil)
+	}
+
+	var entriesBuf [16]encodedField
+	var entries []encodedField
+	if n <= len(entriesBuf) {
+		entries = entriesBuf[:n]
+	} else {
+		entries = make([]encodedField, n)
+	}
+
+	iter := rv.MapRange()
+	idx := 0
+	for iter.Next() {
+		key := iter.Key()
+		if key.Kind() != reflect.String {
+			return 0, 0, fmt.Errorf("variant marshal: map key must be string, got %s", key.Type())
+		}
+		name := key.String()
+		id := e.b.Add(name)
+
+		pStart, pEnd, err := e.encodeReflect(iter.Value())
+		if err != nil {
+			return 0, 0, err
+		}
+		entries[idx] = encodedField{
+			id:    id,
+			name:  name,
+			start: pStart,
+			end:   pEnd,
+		}
+		idx++
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].name < entries[j].name
+	})
+
+	return e.buildObjectBytes(entries)
+}
+
+func (e *encoder) encodeStructObject(rv reflect.Value) (start, end int, err error) {
+	rt := rv.Type()
+	numFields := rt.NumField()
+
+	visibleCount := 0
+	for i := 0; i < numFields; i++ {
+		sf := rt.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		name := fieldName(sf)
+		if name == "-" {
+			continue
+		}
+		visibleCount++
+	}
+
+	if visibleCount == 0 {
+		return e.buildObjectBytes(nil)
+	}
+
+	var entriesBuf [16]encodedField
+	var entries []encodedField
+	if visibleCount <= len(entriesBuf) {
+		entries = entriesBuf[:visibleCount]
+	} else {
+		entries = make([]encodedField, visibleCount)
+	}
+
+	idx := 0
+	for i := 0; i < numFields; i++ {
+		sf := rt.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		name := fieldName(sf)
+		if name == "-" {
+			continue
+		}
+
+		id := e.b.Add(name)
+		pStart, pEnd, err := e.encodeReflect(rv.Field(i))
+		if err != nil {
+			return 0, 0, err
+		}
+		entries[idx] = encodedField{
+			id:    id,
+			name:  name,
+			start: pStart,
+			end:   pEnd,
+		}
+		idx++
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].name < entries[j].name
+	})
+
+	return e.buildObjectBytes(entries)
+}
+
+func (e *encoder) buildObjectBytes(entries []encodedField) (start, end int, err error) {
+	n := len(entries)
+
+	if testHookVerifyObjectLayout != nil {
+		testHookVerifyObjectLayout(e, entries)
+	}
+
+	maxID := 0
+	totalValueSize := 0
+	for _, entry := range entries {
+		if entry.id > maxID {
+			maxID = entry.id
+		}
+		totalValueSize += entry.end - entry.start
+	}
+
+	valueOffsets := make([]int, n+1)
+	off := 0
+	for i, entry := range entries {
+		valueOffsets[i] = off
+		off += entry.end - entry.start
+	}
+	valueOffsets[n] = off
+
+	fieldIDSizeCode := offsetSizeCode(maxID)
+	fieldIDSize := offsetSize(fieldIDSizeCode)
+	offsetSzCode := offsetSizeCode(totalValueSize)
+	offsetSz := offsetSize(offsetSzCode)
+
+	isLarge := byte(0)
+	numElemSize := 1
+	if n > 255 {
+		isLarge = 1
+		numElemSize = 4
+	}
+
+	header := byte(BasicObject) | (fieldIDSizeCode << 2) | (offsetSzCode << 4) | (isLarge << 6)
+
+	totalSize := 1 + numElemSize + n*fieldIDSize + (n+1)*offsetSz + totalValueSize
+	buf := make([]byte, totalSize)
 	buf[0] = header
 
 	pos := 1
@@ -267,24 +653,35 @@ func encodeArray(b *MetadataBuilder, arr Array) []byte {
 		pos += 1
 	}
 
-	// Write offsets
-	for _, o := range offsets {
-		writeUint(buf[pos:], o, offsetSz)
+	for _, entry := range entries {
+		writeUint(buf[pos:], entry.id, fieldIDSize)
+		pos += fieldIDSize
+	}
+
+	for _, offsetVal := range valueOffsets {
+		writeUint(buf[pos:], offsetVal, offsetSz)
 		pos += offsetSz
 	}
 
-	// Write values
-	for _, enc := range encodedElems {
-		copy(buf[pos:], enc)
-		pos += len(enc)
+	for _, entry := range entries {
+		copy(buf[pos:], e.scratch[entry.start:entry.end])
+		pos += entry.end - entry.start
 	}
 
-	return buf
-}
+	firstStart := len(e.scratch)
+	if n > 0 {
+		firstStart = entries[0].start
+		for _, entry := range entries {
+			if entry.start < firstStart {
+				firstStart = entry.start
+			}
+		}
+	}
+	e.scratch = e.scratch[:firstStart]
 
-// makeHeader constructs a value_metadata byte.
-// For primitives: bits 0-1 = basic_type(0), bits 2-7 = primitive_type
-// For short strings: bits 0-1 = basic_type(1), bits 2-7 = string length
-func makeHeader(basic BasicType, valueHeader byte) byte {
-	return byte(basic) | (valueHeader << 2)
+	start = len(e.scratch)
+	e.scratch = append(e.scratch, buf...)
+	end = len(e.scratch)
+
+	return start, end, nil
 }

--- a/variant/encoding_test.go
+++ b/variant/encoding_test.go
@@ -1,0 +1,65 @@
+package variant
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestEncoderLayoutInvariants(t *testing.T) {
+	// Enable layout verification hooks to assert encoder state
+	testHookVerifyArrayLayout = func(e *encoder, positions []elementPos) {
+		if len(positions) == 0 {
+			return
+		}
+		firstStart := positions[0].start
+		if firstStart > len(e.scratch) {
+			t.Errorf("invariant violation: firstStart %d > len(scratch) %d", firstStart, len(e.scratch))
+		}
+		for i := 1; i < len(positions); i++ {
+			if positions[i].start != positions[i-1].end {
+				t.Errorf("invariant violation: non-contiguous siblings at index %d: start %d != prior end %d", i, positions[i].start, positions[i-1].end)
+			}
+		}
+	}
+	testHookVerifyObjectLayout = func(e *encoder, entries []encodedField) {
+		if len(entries) == 0 {
+			return
+		}
+		// Copy and sort entries by start position to verify their contiguous allocation layout in scratch
+		sorted := make([]encodedField, len(entries))
+		copy(sorted, entries)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].start < sorted[j].start
+		})
+		firstStart := sorted[0].start
+		if firstStart > len(e.scratch) {
+			t.Errorf("invariant violation: firstStart %d > len(scratch) %d", firstStart, len(e.scratch))
+		}
+		for i := 1; i < len(sorted); i++ {
+			if sorted[i].start != sorted[i-1].end {
+				t.Errorf("invariant violation: non-contiguous siblings at index %d: start %d != prior end %d", i, sorted[i].start, sorted[i-1].end)
+			}
+		}
+	}
+	defer func() {
+		testHookVerifyArrayLayout = nil
+		testHookVerifyObjectLayout = nil
+	}()
+
+	// Run various complex structures to trigger layout validation
+	testCases := []any{
+		[]any{1, "hello", []any{2, 3, map[string]any{"x": 100, "y": 200}}},
+		map[string]any{
+			"nested": map[string]any{
+				"array": []any{true, false, nil},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		_, _, err := Marshal(tc)
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
+		}
+	}
+}

--- a/variant/marshal.go
+++ b/variant/marshal.go
@@ -2,22 +2,25 @@ package variant
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 // Marshal converts a Go value to variant binary encoding, returning the
 // metadata and value byte slices.
 func Marshal(v any) (metadata, value []byte, err error) {
-	varVal, err := goToVariant(v)
+	var b MetadataBuilder
+	enc := encoder{
+		b:       &b,
+		scratch: make([]byte, 0, 1024),
+	}
+	start, end, err := enc.encodeReflect(reflect.ValueOf(v))
 	if err != nil {
 		return nil, nil, err
 	}
-	var b MetadataBuilder
-	valueBytes := Encode(&b, varVal)
+	valueBytes := make([]byte, end-start)
+	copy(valueBytes, enc.scratch[start:end])
+
 	_, metadataBytes := b.Build()
 	return metadataBytes, valueBytes, nil
 }
@@ -33,139 +36,6 @@ func Unmarshal(metadata, value []byte) (any, error) {
 		return nil, fmt.Errorf("variant unmarshal: %w", err)
 	}
 	return v.GoValue(), nil
-}
-
-// goToVariant converts a Go value to a variant Value.
-func goToVariant(v any) (Value, error) {
-	if v == nil {
-		return Null(), nil
-	}
-	return goToVariantReflect(reflect.ValueOf(v))
-}
-
-func goToVariantReflect(rv reflect.Value) (Value, error) {
-	if !rv.IsValid() {
-		return Null(), nil
-	}
-
-	// Dereference pointers/interfaces
-	for rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
-		if rv.IsNil() {
-			return Null(), nil
-		}
-		rv = rv.Elem()
-	}
-
-	// Check concrete types first
-	iface := rv.Interface()
-	switch val := iface.(type) {
-	case uuid.UUID:
-		return UUID(val), nil
-	}
-
-	switch rv.Kind() {
-	case reflect.Bool:
-		return Bool(rv.Bool()), nil
-	case reflect.Int8:
-		return Int8(int8(rv.Int())), nil
-	case reflect.Int16:
-		return Int16(int16(rv.Int())), nil
-	case reflect.Int32:
-		return Int32(int32(rv.Int())), nil
-	case reflect.Int64, reflect.Int:
-		return Int64(rv.Int()), nil
-	case reflect.Uint8:
-		return Int16(int16(rv.Uint())), nil
-	case reflect.Uint16:
-		return Int32(int32(rv.Uint())), nil
-	case reflect.Uint32:
-		return Int64(int64(rv.Uint())), nil
-	case reflect.Uint64, reflect.Uint:
-		u := rv.Uint()
-		if u > math.MaxInt64 {
-			return Null(), fmt.Errorf("variant marshal: uint64 value %d overflows int64", u)
-		}
-		return Int64(int64(u)), nil
-	case reflect.Float32:
-		return Float(float32(rv.Float())), nil
-	case reflect.Float64:
-		return Double(rv.Float()), nil
-	case reflect.String:
-		return String(rv.String()), nil
-	case reflect.Slice:
-		if rv.Type().Elem().Kind() == reflect.Uint8 {
-			// []byte
-			return Binary(rv.Bytes()), nil
-		}
-		return goSliceToArray(rv)
-	case reflect.Array:
-		if rv.Type() == reflect.TypeFor[uuid.UUID]() {
-			var u uuid.UUID
-			reflect.ValueOf(&u).Elem().Set(rv)
-			return UUID(u), nil
-		}
-		return goSliceToArray(rv)
-	case reflect.Map:
-		return goMapToObject(rv)
-	case reflect.Struct:
-		return goStructToObject(rv)
-	default:
-		return Null(), fmt.Errorf("variant marshal: unsupported type %s", rv.Type())
-	}
-}
-
-func goSliceToArray(rv reflect.Value) (Value, error) {
-	n := rv.Len()
-	elements := make([]Value, n)
-	for i := range n {
-		v, err := goToVariantReflect(rv.Index(i))
-		if err != nil {
-			return Null(), err
-		}
-		elements[i] = v
-	}
-	return MakeArray(elements), nil
-}
-
-func goMapToObject(rv reflect.Value) (Value, error) {
-	if rv.IsNil() {
-		return Null(), nil
-	}
-	fields := make([]Field, 0, rv.Len())
-	iter := rv.MapRange()
-	for iter.Next() {
-		key := iter.Key()
-		if key.Kind() != reflect.String {
-			return Null(), fmt.Errorf("variant marshal: map key must be string, got %s", key.Type())
-		}
-		val, err := goToVariantReflect(iter.Value())
-		if err != nil {
-			return Null(), err
-		}
-		fields = append(fields, Field{Name: key.String(), Value: val})
-	}
-	return MakeObject(fields), nil
-}
-
-func goStructToObject(rv reflect.Value) (Value, error) {
-	rt := rv.Type()
-	fields := make([]Field, 0, rt.NumField())
-	for i := range rt.NumField() {
-		sf := rt.Field(i)
-		if !sf.IsExported() {
-			continue
-		}
-		name := fieldName(sf)
-		if name == "-" {
-			continue
-		}
-		val, err := goToVariantReflect(rv.Field(i))
-		if err != nil {
-			return Null(), err
-		}
-		fields = append(fields, Field{Name: name, Value: val})
-	}
-	return MakeObject(fields), nil
 }
 
 // fieldName returns the name to use for a struct field, checking variant and


### PR DESCRIPTION
## Summary
This change optimizes `variant.Marshal` by traversing and serializing Go values directly from a `reflect.Value` into a stateful, recursively managed contiguous scratch buffer, completely eliminating the construction of the heavy intermediate throwaway `Value` tree. No behavior change.

During this optimization, `variant.Marshal` performance on a `[]int64` slice of length 1,000 improved significantly:
- allocs/op 2006 -> 18 (-99.1%)
- B/op 216537.5 -> 95835.5 (-55.7%)
- ns/op 254408.5 -> 105968.5 (-58.3%)
All stats measured with n=10, p<0.0001 under command `go test -json -run=^$ -bench=BenchmarkMarshalInt64Slice ./variant/...` on `linux/amd64/go` with baseline `1f9447157b9f149c29b343af86ac8a0650fc880d` and candidate `eb3ab35214890f9aa6a6d42a6e6b467f7c9d0fcf`.

### Workload and Impact
This optimization directly targets the Parquet Write Workload. When writing columns containing complex semi-structured variant data, `variant.Marshal` is called repeatedly to serialize the input objects. Since the variant-column serialization accounts for the majority of the column write overhead, eliminating these allocations dramatically improves end-to-end column writing throughput and reduces garbage collection pressure.

In the original baseline implementation, serializing via `variant.Marshal` performed redundant serialization across two distinct work sites:
1. `Marshal/goToVariantReflect` builds an intermediate Value tree from the input, allocating heavily for each node.
2. `Value.Encode` then walks and serializes that tree.

By encoding directly from the reflect walk into a sequential scratch buffer, we avoid constructing the intermediate representation entirely.

### Scratch Buffer Safety
To ensure perfect memory safety and prevent any stale, escaped, or aliased buffers from leaking, the internal encoder copies the serialized segment out of the stateful contiguous scratch buffer into a freshly allocated returned byte slice. Because the final output is fully copied, no internal scratch buffer references can ever escape to caller space, guaranteeing absolute reference isolation.

## Tests
All workspace unit tests and safety invariant validations pass successfully:
- `variant tests` (Passed)
- `all package tests` (Passed)

### Test Suite Additions and Modifications:
- **`variant/encoding_test.go`**: Added `TestEncoderLayoutInvariants` which dynamically validates layout/compaction constraints. To verify the physical memory contiguous allocation layout in the scratch buffer, the test copies and sorts the encoded fields by their start positions before verifying sibling contiguity, making verification 100% deterministic even under randomized map/object field serialization orders.
- **`variant/benchmark_test.go`**: Added `BenchmarkMarshalInt64Slice` to capture performance gains.

### Reproduction
- **Command:** `go test -json -run=^$ -bench=BenchmarkMarshalInt64Slice ./variant/...`
- **Environment:** `linux/amd64/go`
- **Baseline:** `1f9447157b9f149c29b343af86ac8a0650fc880d`
- **Candidate:** `eb3ab35214890f9aa6a6d42a6e6b467f7c9d0fcf`

Note: Since the benchmark is agent-authored, the baseline arm was measured at the benchmark commit tree (base + benchmark) while baseline_commit names the base revision.

## Alternatives
During development, we explored several intermediate approaches and dead ends:
1. **Inline Panic-based Assertions**: We initially evaluated embedding panic-based invariant checks inside the hot serialization path to enforce buffer layout correctness. This was ruled out to satisfy library readiness rules of keeping the shipped code 100% panic-free, leading us to extract these validations into non-panicking test hooks.
2. **Reflect Walk without Decoupled `Encode`**: An initial prototype optimized only `variant.Marshal` via a reflect walk, leaving the pre-built `Value.Encode` routed through the same stateful reflection-based path. This was ruled out because it added scratch-buffer management and reflection overhead to simple, pre-built primitive types. This dead end was abandoned to avoid degrading the existing primitive encoding hot path.

The final selected approach was chosen because it delivers the massive 99.1% allocation reduction on `variant.Marshal` while completely protecting and isolating primitive `Value.Encode` pathways.

## Limits
The boundaries of this change are restricted to:
- The measured improvements apply specifically to `variant.Marshal` of arrays/slices and struct-to-variant serialization (e.g. `[]int64` of length 1,000).
- Testing was performed in a `linux/amd64` container with Go.
- Reflection overhead reduction is proportional to input size; very small inputs may see lower relative gains.
- End-to-end Column writer performance gains depend on the schema composition, with array-heavy and object-heavy columns realizing the largest relative write speedup.

## Canonical Proof
Full details and measurement trace can be found on the case page:
https://app.perfloop.ai/t/oss/case_krz077z3t7

---
This is an automated, human-reviewed Perfloop contribution opened by perfloop-agent. The body links to reproducible proof for the change. The change was benchmarked on perfloop/parquet-go, an automation fork of parquet-go/parquet-go; the commit on this PR's head branch carries the proof.