### PR TITLE
feat(variant): streaming columnar writer for variant columns

### DIFF
--- a/variant/builder.go
+++ b/variant/builder.go
@@ -1,0 +1,608 @@
+package variant
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// ValueWriter is a streaming event sink for variant values. Callers describe
+// a value as a sequence of events — scalars, or containers bracketed by
+// Begin/End calls — and implementations consume the events without ever
+// materializing the value as a tree.
+//
+// Exactly one value must be written: a single scalar event, or a single
+// balanced container. Inside an object, every value must be preceded by a
+// Field call naming it, and field names must be unique within their object
+// (duplicates are an error). Errors (both misuse of the event sequence and
+// implementation-specific failures) are sticky and reported by Err; events
+// after an error are ignored.
+//
+// ValueWriter is implemented by Builder, which encodes the events to variant
+// binary, and by parquet.VariantColumnWriter, which shreds the events
+// directly into parquet column buffers.
+type ValueWriter interface {
+	Null()
+	Bool(v bool)
+	Int8(v int8)
+	Int16(v int16)
+	Int32(v int32)
+	Int64(v int64)
+	Float(v float32)
+	Double(v float64)
+	String(v string)
+	Binary(v []byte)
+	Date(days int32)
+	Time(micros int64)
+	Timestamp(micros int64)
+	TimestampNTZ(micros int64)
+	TimestampNanos(nanos int64)
+	TimestampNTZNanos(nanos int64)
+	UUID(v uuid.UUID)
+	Decimal4(unscaled int32, scale byte)
+	Decimal8(unscaled int64, scale byte)
+	Decimal16(unscaled [16]byte, scale byte)
+
+	// BeginObject starts an object value. Calls until the matching EndObject
+	// must alternate Field and value events.
+	BeginObject()
+
+	// Field names the next value written as a field of the innermost open
+	// object.
+	Field(name string)
+
+	// EndObject closes the innermost open object.
+	EndObject()
+
+	// BeginArray starts an array value. Every value written until the
+	// matching EndArray is one element.
+	BeginArray()
+
+	// EndArray closes the innermost open array.
+	EndArray()
+
+	// Err returns the first error encountered, or nil.
+	Err() error
+}
+
+// Write replays the value as a sequence of events on w. It is the bridge
+// from the tree representation to any ValueWriter.
+func (v Value) Write(w ValueWriter) {
+	switch v.basic {
+	case BasicObject:
+		w.BeginObject()
+		for _, f := range v.object.Fields {
+			w.Field(f.Name)
+			f.Value.Write(w)
+		}
+		w.EndObject()
+	case BasicArray:
+		w.BeginArray()
+		for _, e := range v.array.Elements {
+			e.Write(w)
+		}
+		w.EndArray()
+	case BasicShortString:
+		w.String(v.str)
+	default:
+		switch v.primitive {
+		case PrimitiveNull:
+			w.Null()
+		case PrimitiveTrue:
+			w.Bool(true)
+		case PrimitiveFalse:
+			w.Bool(false)
+		case PrimitiveInt8:
+			w.Int8(int8(v.i64))
+		case PrimitiveInt16:
+			w.Int16(int16(v.i64))
+		case PrimitiveInt32:
+			w.Int32(int32(v.i64))
+		case PrimitiveInt64:
+			w.Int64(v.i64)
+		case PrimitiveFloat:
+			w.Float(float32(v.f64))
+		case PrimitiveDouble:
+			w.Double(v.f64)
+		case PrimitiveString:
+			w.String(v.str)
+		case PrimitiveBinary:
+			w.Binary(v.bytes)
+		case PrimitiveDate:
+			w.Date(int32(v.i64))
+		case PrimitiveTime:
+			w.Time(v.i64)
+		case PrimitiveTimestamp:
+			w.Timestamp(v.i64)
+		case PrimitiveTimestampNTZ:
+			w.TimestampNTZ(v.i64)
+		case PrimitiveTimestampNanos:
+			w.TimestampNanos(v.i64)
+		case PrimitiveTimestampNTZNanos:
+			w.TimestampNTZNanos(v.i64)
+		case PrimitiveUUID:
+			w.UUID(v.uuid)
+		case PrimitiveDecimal4:
+			w.Decimal4(int32(v.i64), v.scale)
+		case PrimitiveDecimal8:
+			w.Decimal8(v.i64, v.scale)
+		case PrimitiveDecimal16:
+			w.Decimal16(v.decimal16, v.scale)
+		default:
+			w.Null()
+		}
+	}
+}
+
+// Builder is a streaming encoder for variant values: a ValueWriter that
+// encodes events directly to the variant binary format in a single growing
+// buffer, without building a Value tree.
+//
+// Values are encoded as their events arrive. When a container closes, its
+// header (field IDs, offsets) is spliced in front of the already-encoded
+// children with one memmove, so encoding is a single pass with no per-value
+// allocations beyond buffer growth. Object field values are kept in event
+// order and only the header entries are sorted by field name, which the
+// encoding permits (field IDs must be sorted, field offsets need not be
+// monotonic).
+//
+// The zero value is ready to use and owns its metadata dictionary; Finish
+// returns both the metadata and the value. NewBuilderWithMetadata creates a
+// builder that interns field names into a shared, caller-owned dictionary,
+// which is how multiple values (e.g. all residuals of one shredded row)
+// share one dictionary.
+//
+// A Builder may be reused after Reset. Reset retains internal buffers, so a
+// long-lived Builder encodes a stream of values with amortized zero
+// allocation. A Builder must not be copied after first use.
+type Builder struct {
+	meta    *MetadataBuilder
+	ownMeta MetadataBuilder
+
+	buf     []byte
+	scratch []byte
+
+	frames []builderFrame
+	fields []builderField // arena shared by all open object frames
+	elems  []int          // arena shared by all open array frames
+
+	pendingField bool // inside an object, a Field awaits its value
+	complete     bool // one complete top-level value has been written
+	err          error
+}
+
+type builderFrame struct {
+	isObject   bool
+	start      int // buf offset where the container's first child begins
+	fieldsBase int // objects: base of this frame's entries in the fields arena
+	elemsBase  int // arrays: base of this frame's element starts in the elems arena
+}
+
+type builderField struct {
+	id    int
+	start int // buf offset where the field's value begins
+}
+
+// NewBuilderWithMetadata returns a Builder that interns object field names
+// into the given shared metadata dictionary instead of an internal one.
+// Finish builds the shared dictionary; callers encoding multiple values
+// against one dictionary typically use Bytes and build the metadata
+// themselves once.
+func NewBuilderWithMetadata(meta *MetadataBuilder) *Builder {
+	return &Builder{meta: meta}
+}
+
+func (b *Builder) metadata() *MetadataBuilder {
+	if b.meta == nil {
+		b.meta = &b.ownMeta
+	}
+	return b.meta
+}
+
+// Err returns the first error encountered, or nil.
+func (b *Builder) Err() error { return b.err }
+
+func (b *Builder) fail(format string, args ...any) {
+	if b.err == nil {
+		b.err = fmt.Errorf("variant builder: "+format, args...)
+	}
+}
+
+// Reset clears the builder for reuse, retaining internal buffers. If the
+// builder owns its metadata dictionary the dictionary is cleared too; a
+// shared dictionary (NewBuilderWithMetadata) is left untouched.
+func (b *Builder) Reset() {
+	if b.meta == &b.ownMeta {
+		b.ownMeta.Reset()
+	}
+	b.buf = b.buf[:0]
+	b.frames = b.frames[:0]
+	b.fields = b.fields[:0]
+	b.elems = b.elems[:0]
+	b.pendingField = false
+	b.complete = false
+	b.err = nil
+}
+
+// Finish returns the encoded metadata and value. It fails if no value or an
+// incomplete value has been written. The value slice aliases the builder's
+// internal buffer and is invalidated by Reset or further writes, the same
+// as Bytes; the metadata slice is freshly allocated.
+func (b *Builder) Finish() (metadata, value []byte, err error) {
+	value, err = b.Bytes()
+	if err != nil {
+		return nil, nil, err
+	}
+	metadata = b.metadata().AppendTo(nil)
+	return metadata, value, nil
+}
+
+// Bytes returns the encoded value bytes without building the metadata. The
+// returned slice aliases the builder's internal buffer and is invalidated by
+// Reset or further writes.
+func (b *Builder) Bytes() ([]byte, error) {
+	switch {
+	case b.err != nil:
+		return nil, b.err
+	case len(b.frames) > 0:
+		return nil, errors.New("variant builder: unclosed object or array")
+	case !b.complete:
+		return nil, errors.New("variant builder: no value written")
+	}
+	return b.buf, nil
+}
+
+// beginValue validates that a value event is legal in the current state and
+// records array element boundaries. It reports whether to proceed.
+func (b *Builder) beginValue() bool {
+	if b.err != nil {
+		return false
+	}
+	if n := len(b.frames); n == 0 {
+		if b.complete {
+			b.fail("more than one top-level value")
+			return false
+		}
+	} else if f := &b.frames[n-1]; f.isObject {
+		if !b.pendingField {
+			b.fail("value written inside an object without a Field call")
+			return false
+		}
+		b.pendingField = false
+	} else {
+		b.elems = append(b.elems, len(b.buf))
+	}
+	return true
+}
+
+func (b *Builder) endValue() {
+	if len(b.frames) == 0 {
+		b.complete = true
+	}
+}
+
+func (b *Builder) appendScalar(data ...byte) {
+	if b.beginValue() {
+		b.buf = append(b.buf, data...)
+		b.endValue()
+	}
+}
+
+func (b *Builder) Null() { b.appendScalar(makeHeader(BasicPrimitive, byte(PrimitiveNull))) }
+
+func (b *Builder) Bool(v bool) {
+	p := PrimitiveFalse
+	if v {
+		p = PrimitiveTrue
+	}
+	b.appendScalar(makeHeader(BasicPrimitive, byte(p)))
+}
+
+func (b *Builder) Int8(v int8) {
+	b.appendScalar(makeHeader(BasicPrimitive, byte(PrimitiveInt8)), byte(v))
+}
+
+func (b *Builder) Int16(v int16) { b.scalar16(PrimitiveInt16, uint16(v)) }
+
+func (b *Builder) Int32(v int32) { b.scalar32(PrimitiveInt32, uint32(v)) }
+
+func (b *Builder) Int64(v int64) { b.scalar64(PrimitiveInt64, uint64(v)) }
+
+func (b *Builder) Float(v float32) { b.scalar32(PrimitiveFloat, math.Float32bits(v)) }
+
+func (b *Builder) Double(v float64) { b.scalar64(PrimitiveDouble, math.Float64bits(v)) }
+
+func (b *Builder) String(v string) {
+	if !b.beginValue() {
+		return
+	}
+	if len(v) <= 63 {
+		b.buf = append(b.buf, makeHeader(BasicShortString, byte(len(v))))
+	} else {
+		b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(PrimitiveString)), 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(b.buf[len(b.buf)-4:], uint32(len(v)))
+	}
+	b.buf = append(b.buf, v...)
+	b.endValue()
+}
+
+func (b *Builder) Binary(v []byte) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(PrimitiveBinary)), 0, 0, 0, 0)
+	binary.LittleEndian.PutUint32(b.buf[len(b.buf)-4:], uint32(len(v)))
+	b.buf = append(b.buf, v...)
+	b.endValue()
+}
+
+func (b *Builder) Date(days int32) { b.scalar32(PrimitiveDate, uint32(days)) }
+
+func (b *Builder) Time(micros int64) { b.scalar64(PrimitiveTime, uint64(micros)) }
+
+func (b *Builder) Timestamp(micros int64) { b.scalar64(PrimitiveTimestamp, uint64(micros)) }
+
+func (b *Builder) TimestampNTZ(micros int64) { b.scalar64(PrimitiveTimestampNTZ, uint64(micros)) }
+
+func (b *Builder) TimestampNanos(nanos int64) { b.scalar64(PrimitiveTimestampNanos, uint64(nanos)) }
+
+func (b *Builder) TimestampNTZNanos(nanos int64) {
+	b.scalar64(PrimitiveTimestampNTZNanos, uint64(nanos))
+}
+
+func (b *Builder) UUID(v uuid.UUID) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(PrimitiveUUID)))
+	b.buf = append(b.buf, v[:]...)
+	b.endValue()
+}
+
+func (b *Builder) Decimal4(unscaled int32, scale byte) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(PrimitiveDecimal4)), scale, 0, 0, 0, 0)
+	binary.LittleEndian.PutUint32(b.buf[len(b.buf)-4:], uint32(unscaled))
+	b.endValue()
+}
+
+func (b *Builder) Decimal8(unscaled int64, scale byte) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(PrimitiveDecimal8)), scale, 0, 0, 0, 0, 0, 0, 0, 0)
+	binary.LittleEndian.PutUint64(b.buf[len(b.buf)-8:], uint64(unscaled))
+	b.endValue()
+}
+
+func (b *Builder) Decimal16(unscaled [16]byte, scale byte) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(PrimitiveDecimal16)), scale)
+	b.buf = append(b.buf, unscaled[:]...)
+	b.endValue()
+}
+
+func (b *Builder) scalar16(p PrimitiveType, v uint16) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(p)), 0, 0)
+	binary.LittleEndian.PutUint16(b.buf[len(b.buf)-2:], v)
+	b.endValue()
+}
+
+func (b *Builder) scalar32(p PrimitiveType, v uint32) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(p)), 0, 0, 0, 0)
+	binary.LittleEndian.PutUint32(b.buf[len(b.buf)-4:], v)
+	b.endValue()
+}
+
+func (b *Builder) scalar64(p PrimitiveType, v uint64) {
+	if !b.beginValue() {
+		return
+	}
+	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(p)), 0, 0, 0, 0, 0, 0, 0, 0)
+	binary.LittleEndian.PutUint64(b.buf[len(b.buf)-8:], v)
+	b.endValue()
+}
+
+func (b *Builder) BeginObject() {
+	if !b.beginValue() {
+		return
+	}
+	b.frames = append(b.frames, builderFrame{
+		isObject:   true,
+		start:      len(b.buf),
+		fieldsBase: len(b.fields),
+	})
+}
+
+func (b *Builder) Field(name string) {
+	if b.err != nil {
+		return
+	}
+	n := len(b.frames)
+	if n == 0 || !b.frames[n-1].isObject {
+		b.fail("Field %q outside of an object", name)
+		return
+	}
+	if b.pendingField {
+		b.fail("Field %q: previous field has no value", name)
+		return
+	}
+	id := b.metadata().Add(name)
+	b.fields = append(b.fields, builderField{
+		id:    id,
+		start: len(b.buf),
+	})
+	b.pendingField = true
+}
+
+func (b *Builder) EndObject() {
+	if b.err != nil {
+		return
+	}
+	n := len(b.frames)
+	if n == 0 || !b.frames[n-1].isObject {
+		b.fail("EndObject without matching BeginObject")
+		return
+	}
+	meta := b.metadata()
+	if b.pendingField {
+		b.fail("EndObject: field %q has no value", meta.stringAt(b.fields[len(b.fields)-1].id))
+		return
+	}
+	f := b.frames[n-1]
+	entries := b.fields[f.fieldsBase:]
+
+	// The encoding requires field IDs sorted lexicographically by name;
+	// field values stay where they were written, offsets need not be
+	// monotonic. Names are resolved from the metadata slab at close time
+	// so Field does not retain views that a later Add could invalidate.
+	slices.SortFunc(entries, func(a, c builderField) int {
+		return strings.Compare(meta.stringAt(a.id), meta.stringAt(c.id))
+	})
+	for i := 1; i < len(entries); i++ {
+		if entries[i].id == entries[i-1].id || meta.stringAt(entries[i].id) == meta.stringAt(entries[i-1].id) {
+			b.fail("duplicate object field %q", meta.stringAt(entries[i].id))
+			return
+		}
+	}
+
+	numFields := len(entries)
+	contentSize := len(b.buf) - f.start
+	maxID := 0
+	for i := range entries {
+		if entries[i].id > maxID {
+			maxID = entries[i].id
+		}
+	}
+
+	fieldIDSzCode := offsetSizeCode(maxID)
+	fieldIDSz := offsetSize(fieldIDSzCode)
+	offsetSzCode := offsetSizeCode(contentSize)
+	offsetSz := offsetSize(offsetSzCode)
+
+	isLarge := byte(0)
+	numElemSize := 1
+	if numFields > 255 {
+		isLarge = 1
+		numElemSize = 4
+	}
+
+	headerSize := 1 + numElemSize + numFields*fieldIDSz + (numFields+1)*offsetSz
+	h := b.header(headerSize)
+	h[0] = byte(BasicObject) | (offsetSzCode << 2) | (fieldIDSzCode << 4) | (isLarge << 6)
+	pos := 1
+	if isLarge == 1 {
+		binary.LittleEndian.PutUint32(h[pos:], uint32(numFields))
+		pos += 4
+	} else {
+		h[pos] = byte(numFields)
+		pos++
+	}
+	for i := range entries {
+		writeUint(h[pos:], entries[i].id, fieldIDSz)
+		pos += fieldIDSz
+	}
+	for i := range entries {
+		writeUint(h[pos:], entries[i].start-f.start, offsetSz)
+		pos += offsetSz
+	}
+	writeUint(h[pos:], contentSize, offsetSz)
+
+	b.splice(f.start, h)
+	b.fields = b.fields[:f.fieldsBase]
+	b.frames = b.frames[:n-1]
+	b.endValue()
+}
+
+func (b *Builder) BeginArray() {
+	if !b.beginValue() {
+		return
+	}
+	b.frames = append(b.frames, builderFrame{
+		start:     len(b.buf),
+		elemsBase: len(b.elems),
+	})
+}
+
+func (b *Builder) EndArray() {
+	if b.err != nil {
+		return
+	}
+	n := len(b.frames)
+	if n == 0 || b.frames[n-1].isObject {
+		b.fail("EndArray without matching BeginArray")
+		return
+	}
+	f := b.frames[n-1]
+	starts := b.elems[f.elemsBase:]
+
+	numElems := len(starts)
+	contentSize := len(b.buf) - f.start
+
+	offsetSzCode := offsetSizeCode(contentSize)
+	offsetSz := offsetSize(offsetSzCode)
+
+	isLarge := byte(0)
+	numElemSize := 1
+	if numElems > 255 {
+		isLarge = 1
+		numElemSize = 4
+	}
+
+	headerSize := 1 + numElemSize + (numElems+1)*offsetSz
+	h := b.header(headerSize)
+	h[0] = byte(BasicArray) | (offsetSzCode << 2) | (isLarge << 4)
+	pos := 1
+	if isLarge == 1 {
+		binary.LittleEndian.PutUint32(h[pos:], uint32(numElems))
+		pos += 4
+	} else {
+		h[pos] = byte(numElems)
+		pos++
+	}
+	for _, start := range starts {
+		writeUint(h[pos:], start-f.start, offsetSz)
+		pos += offsetSz
+	}
+	writeUint(h[pos:], contentSize, offsetSz)
+
+	b.splice(f.start, h)
+	b.elems = b.elems[:f.elemsBase]
+	b.frames = b.frames[:n-1]
+	b.endValue()
+}
+
+// header returns a zeroed scratch slice of the given size for building a
+// container header.
+func (b *Builder) header(size int) []byte {
+	if cap(b.scratch) < size {
+		b.scratch = make([]byte, size)
+	}
+	h := b.scratch[:size]
+	clear(h)
+	return h
+}
+
+// splice inserts header at position start, shifting the container's encoded
+// children right by one memmove.
+func (b *Builder) splice(start int, header []byte) {
+	n := len(header)
+	b.buf = append(b.buf, header...)
+	copy(b.buf[start+n:], b.buf[start:len(b.buf)-n])
+	copy(b.buf[start:], header)
+}

--- a/variant/builder.go
+++ b/variant/builder.go
@@ -238,7 +238,13 @@ func (b *Builder) Finish() (metadata, value []byte, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	metadata = b.metadata().AppendTo(nil)
+	meta := b.metadata()
+	// Dictionary offsets are at most 4 bytes wide; MetadataBuilder.AppendTo
+	// would silently truncate a larger dictionary.
+	if uint64(meta.Size()) > math.MaxUint32 {
+		return nil, nil, fmt.Errorf("variant builder: metadata dictionary of %d bytes exceeds the variant format's 4 GiB limit", meta.Size())
+	}
+	metadata = meta.AppendTo(nil)
 	return metadata, value, nil
 }
 
@@ -321,6 +327,10 @@ func (b *Builder) String(v string) {
 	if !b.beginValue() {
 		return
 	}
+	if uint64(len(v)) > math.MaxUint32 {
+		b.fail("string of %d bytes exceeds the variant format's 4 GiB limit", len(v))
+		return
+	}
 	if len(v) <= 63 {
 		b.buf = append(b.buf, makeHeader(BasicShortString, byte(len(v))))
 	} else {
@@ -333,6 +343,10 @@ func (b *Builder) String(v string) {
 
 func (b *Builder) Binary(v []byte) {
 	if !b.beginValue() {
+		return
+	}
+	if uint64(len(v)) > math.MaxUint32 {
+		b.fail("binary value of %d bytes exceeds the variant format's 4 GiB limit", len(v))
 		return
 	}
 	b.buf = append(b.buf, makeHeader(BasicPrimitive, byte(PrimitiveBinary)), 0, 0, 0, 0)
@@ -483,6 +497,14 @@ func (b *Builder) EndObject() {
 
 	numFields := len(entries)
 	contentSize := len(b.buf) - f.start
+	// Offsets are at most 4 bytes wide, so a container whose encoded
+	// children exceed math.MaxUint32 bytes is unrepresentable; failing
+	// beats the silent truncation of writeUint. Field offsets and counts
+	// are bounded by contentSize, so this one check covers them too.
+	if uint64(contentSize) > math.MaxUint32 {
+		b.fail("object content of %d bytes exceeds the variant format's 4 GiB limit", contentSize)
+		return
+	}
 	maxID := 0
 	for i := range entries {
 		if entries[i].id > maxID {
@@ -553,6 +575,11 @@ func (b *Builder) EndArray() {
 
 	numElems := len(starts)
 	contentSize := len(b.buf) - f.start
+	// See the matching check in EndObject.
+	if uint64(contentSize) > math.MaxUint32 {
+		b.fail("array content of %d bytes exceeds the variant format's 4 GiB limit", contentSize)
+		return
+	}
 
 	offsetSzCode := offsetSizeCode(contentSize)
 	offsetSz := offsetSize(offsetSzCode)

--- a/variant/builder.go
+++ b/variant/builder.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// ValueWriter is a streaming event sink for variant values. Callers describe
+// ValueBuilder is a streaming event sink for variant values. Callers describe
 // a value as a sequence of events — scalars, or containers bracketed by
 // Begin/End calls — and implementations consume the events without ever
 // materializing the value as a tree.
@@ -23,10 +23,10 @@ import (
 // implementation-specific failures) are sticky and reported by Err; events
 // after an error are ignored.
 //
-// ValueWriter is implemented by Builder, which encodes the events to variant
+// ValueBuilder is implemented by Builder, which encodes the events to variant
 // binary, and by parquet.VariantColumnWriter, which shreds the events
 // directly into parquet column buffers.
-type ValueWriter interface {
+type ValueBuilder interface {
 	Null()
 	Bool(v bool)
 	Int8(v int8)
@@ -71,8 +71,8 @@ type ValueWriter interface {
 }
 
 // Write replays the value as a sequence of events on w. It is the bridge
-// from the tree representation to any ValueWriter.
-func (v Value) Write(w ValueWriter) {
+// from the tree representation to any ValueBuilder.
+func (v Value) Write(w ValueBuilder) {
 	switch v.basic {
 	case BasicObject:
 		w.BeginObject()
@@ -139,7 +139,7 @@ func (v Value) Write(w ValueWriter) {
 	}
 }
 
-// Builder is a streaming encoder for variant values: a ValueWriter that
+// Builder is a streaming encoder for variant values: a ValueBuilder that
 // encodes events directly to the variant binary format in a single growing
 // buffer, without building a Value tree.
 //

--- a/variant/builder.go
+++ b/variant/builder.go
@@ -489,7 +489,8 @@ func (b *Builder) EndObject() {
 		return strings.Compare(meta.stringAt(a.id), meta.stringAt(c.id))
 	})
 	for i := 1; i < len(entries); i++ {
-		if entries[i].id == entries[i-1].id || meta.stringAt(entries[i].id) == meta.stringAt(entries[i-1].id) {
+		// Names are interned, so equal names always share one id.
+		if entries[i].id == entries[i-1].id {
 			b.fail("duplicate object field %q", meta.stringAt(entries[i].id))
 			return
 		}

--- a/variant/builder_test.go
+++ b/variant/builder_test.go
@@ -1,0 +1,611 @@
+package variant
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/google/uuid"
+)
+
+// builderTestValues is a pool of values covering every primitive type,
+// nesting, empty containers, the short-string boundary, and out-of-order
+// object fields (the builder keeps values in event order while sorting
+// header entries by name).
+func builderTestValues() []Value {
+	long := bytes.Repeat([]byte("x"), 100)
+	return []Value{
+		Null(),
+		Bool(true),
+		Bool(false),
+		Int8(-5),
+		Int16(1234),
+		Int32(-123456),
+		Int64(1 << 40),
+		Float(1.5),
+		Double(-2.75),
+		String("short"),
+		String(string(long)),
+		Binary([]byte{0, 1, 2, 255}),
+		Date(20000),
+		Time(86399_000_000),
+		Timestamp(1700000000_000_000),
+		TimestampNTZ(1700000000_000_000),
+		TimestampNanos(1700000000_000_000_000),
+		TimestampNTZNanos(1700000000_000_000_000),
+		UUID(uuid.MustParse("00112233-4455-6677-8899-aabbccddeeff")),
+		Decimal4(1234, 2),
+		Decimal8(-123456789, 5),
+		Decimal16([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, 10),
+		MakeObject(nil),
+		MakeArray(nil),
+		MakeObject([]Field{
+			// Deliberately not in name order.
+			{Name: "z", Value: Int32(1)},
+			{Name: "a", Value: String("v")},
+			{Name: "m", Value: MakeArray([]Value{Null(), Bool(true)})},
+		}),
+		MakeArray([]Value{
+			MakeObject([]Field{{Name: "nested", Value: MakeArray([]Value{Int64(9)})}}),
+			String("elem"),
+			MakeObject(nil),
+		}),
+	}
+}
+
+// TestBuilderDifferential checks that streaming a value through Builder
+// produces bytes that decode back to the original value, and that the
+// builder's metadata dictionary is compatible with the tree encoder's.
+func TestBuilderDifferential(t *testing.T) {
+	values := builderTestValues()
+
+	// A few random values on top of the fixed pool.
+	r := rand.New(rand.NewPCG(7, 13))
+	for range 50 {
+		values = append(values, randomBuilderValue(r, 0))
+	}
+
+	for i, v := range values {
+		t.Run(fmt.Sprintf("value_%02d", i), func(t *testing.T) {
+			var b Builder
+			v.Write(&b)
+			metadata, value, err := b.Finish()
+			if err != nil {
+				t.Fatalf("Finish: %v", err)
+			}
+			m, err := DecodeMetadata(metadata)
+			if err != nil {
+				t.Fatalf("decoding metadata: %v", err)
+			}
+			got, err := Decode(m, value)
+			if err != nil {
+				t.Fatalf("decoding value: %v", err)
+			}
+			if !got.Equal(v) {
+				t.Fatalf("round trip mismatch:\n got: %#v\nwant: %#v", got.GoValue(), v.GoValue())
+			}
+		})
+	}
+}
+
+// TestBuilderMatchesEncode asserts the streaming builder produces exactly
+// the bytes of the tree encoder for the same value when object fields
+// arrive in sorted order. (For unsorted arrival the builder keeps values in
+// event order with non-monotonic offsets — spec-valid but not canonical —
+// so values are canonicalized before comparing.) This pins layout, size
+// selection, and metadata dictionary contents to the tree encoder's.
+func TestBuilderMatchesEncode(t *testing.T) {
+	values := builderTestValues()
+	r := rand.New(rand.NewPCG(21, 42))
+	for range 50 {
+		values = append(values, randomBuilderValue(r, 0))
+	}
+
+	for i, v := range values {
+		v := sortObjectFields(v)
+		t.Run(fmt.Sprintf("value_%02d", i), func(t *testing.T) {
+			var b Builder
+			v.Write(&b)
+			gotMeta, gotValue, err := b.Finish()
+			if err != nil {
+				t.Fatalf("Finish: %v", err)
+			}
+
+			var mb MetadataBuilder
+			wantValue := Encode(&mb, v)
+			wantMeta := mb.AppendTo(nil)
+
+			if !bytes.Equal(gotValue, wantValue) {
+				t.Errorf("value bytes mismatch:\n got: %x\nwant: %x", gotValue, wantValue)
+			}
+			if !bytes.Equal(gotMeta, wantMeta) {
+				t.Errorf("metadata bytes mismatch:\n got: %x\nwant: %x", gotMeta, wantMeta)
+			}
+		})
+	}
+}
+
+// TestBuilderBoundaries pins the builder's size selection at the exact
+// is_large and offset-width transitions by byte-comparing against the tree
+// encoder: 255/256 container elements (1- vs 4-byte counts) and content
+// sizes crossing the 1-, 2-, and 3-byte offset widths.
+func TestBuilderBoundaries(t *testing.T) {
+	object := func(n int) Value {
+		fields := make([]Field, n)
+		for i := range fields {
+			fields[i] = Field{Name: fmt.Sprintf("f%04d", i), Value: Int64(int64(i))}
+		}
+		return MakeObject(fields)
+	}
+	array := func(n int) Value {
+		elems := make([]Value, n)
+		for i := range elems {
+			elems[i] = Int64(int64(i))
+		}
+		return MakeArray(elems)
+	}
+	// One string element of the given length dominates the array's content
+	// size, driving the offset width.
+	sized := func(contentLen int) Value {
+		return MakeArray([]Value{String(strings.Repeat("x", contentLen))})
+	}
+
+	tests := []struct {
+		name  string
+		value Value
+	}{
+		{name: "object_255_fields", value: object(255)},
+		{name: "object_256_fields", value: object(256)},
+		{name: "array_255_elements", value: array(255)},
+		{name: "array_256_elements", value: array(256)},
+		{name: "offsets_1_byte_max", value: sized(250)},
+		{name: "offsets_2_bytes", value: sized(300)},
+		{name: "offsets_2_bytes_max", value: sized(65500)},
+		{name: "offsets_3_bytes", value: sized(65600)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var b Builder
+			test.value.Write(&b)
+			gotMeta, gotValue, err := b.Finish()
+			if err != nil {
+				t.Fatalf("Finish: %v", err)
+			}
+
+			var mb MetadataBuilder
+			wantValue := Encode(&mb, test.value)
+			wantMeta := mb.AppendTo(nil)
+
+			if !bytes.Equal(gotValue, wantValue) {
+				t.Errorf("value bytes mismatch (%d vs %d bytes)", len(gotValue), len(wantValue))
+			}
+			if !bytes.Equal(gotMeta, wantMeta) {
+				t.Errorf("metadata bytes mismatch (%d vs %d bytes)", len(gotMeta), len(wantMeta))
+			}
+
+			// And the bytes must round-trip.
+			m, err := DecodeMetadata(gotMeta)
+			if err != nil {
+				t.Fatalf("decoding metadata: %v", err)
+			}
+			got, err := Decode(m, gotValue)
+			if err != nil {
+				t.Fatalf("decoding value: %v", err)
+			}
+			if !got.Equal(test.value) {
+				t.Fatal("round trip mismatch")
+			}
+		})
+	}
+}
+
+// TestMetadataBuilderSlabGrowth forces the dictionary slab to reallocate
+// while entries already exist, verifying that lookups and encoding still
+// see the original strings after the backing array moves.
+func TestMetadataBuilderSlabGrowth(t *testing.T) {
+	var b MetadataBuilder
+	const n = 2000
+	for i := range n {
+		name := fmt.Sprintf("k%04d", i)
+		if got := b.Add(name); got != i {
+			t.Fatalf("Add(%q) = %d, want %d", name, got, i)
+		}
+	}
+	for i := range n {
+		name := fmt.Sprintf("k%04d", i)
+		if got := b.Add(name); got != i {
+			t.Fatalf("re-Add(%q) = %d, want %d (slab reindex lost the entry)", name, got, i)
+		}
+	}
+	meta, encoded := b.Build()
+	if len(meta.Strings) != n {
+		t.Fatalf("Build: %d strings, want %d", len(meta.Strings), n)
+	}
+	for i := range n {
+		want := fmt.Sprintf("k%04d", i)
+		if meta.Strings[i] != want {
+			t.Fatalf("Build string %d = %q, want %q", i, meta.Strings[i], want)
+		}
+	}
+	m, err := DecodeMetadata(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Strings) != n {
+		t.Fatalf("decoded %d strings, want %d", len(m.Strings), n)
+	}
+	for i := range n {
+		want := fmt.Sprintf("k%04d", i)
+		if m.Strings[i] != want {
+			t.Fatalf("decoded string %d = %q, want %q", i, m.Strings[i], want)
+		}
+	}
+}
+
+// TestBuilderFieldCopiesName verifies Field copies the name argument so a
+// caller can reuse a scratch buffer (the JSON-transcoder pattern) without
+// corrupting the metadata dictionary or the object's field-id sort.
+func TestBuilderFieldCopiesName(t *testing.T) {
+	var b Builder
+	b.BeginObject()
+	buf := []byte("name")
+	b.Field(unsafeString(buf))
+	copy(buf, "xxxx") // mutate the scratch after Field returns
+	b.String("alice")
+	b.EndObject()
+	metadata, value, err := b.Finish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := DecodeMetadata(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Decode(m, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := MakeObject([]Field{{Name: "name", Value: String("alice")}})
+	if !got.Equal(want) {
+		t.Fatalf("got %#v, want %#v (field name was corrupted by scratch reuse)", got.GoValue(), want.GoValue())
+	}
+	if !slices.Contains(m.Strings, "name") {
+		t.Errorf("metadata dictionary %q missing original field name", m.Strings)
+	}
+	if slices.Contains(m.Strings, "xxxx") {
+		t.Errorf("metadata dictionary retained the mutated scratch: %q", m.Strings)
+	}
+}
+
+func unsafeString(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
+// TestBuilderSparseFieldIDs encodes a small object against a shared
+// dictionary already holding 300 names, forcing 2-byte field IDs for an
+// object whose own field count would fit 1-byte IDs. The field-ID width is
+// selected from the maximum ID, not the field count — exactly the shape a
+// shredded-row residual takes when the row dictionary is wide.
+func TestBuilderSparseFieldIDs(t *testing.T) {
+	var meta MetadataBuilder
+	for i := range 300 {
+		meta.Add(fmt.Sprintf("name%03d", i))
+	}
+
+	b := NewBuilderWithMetadata(&meta)
+	want := MakeObject([]Field{{Name: "name299", Value: Int64(1)}, {Name: "wide", Value: String("x")}})
+	want.Write(b)
+	value, err := b.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+
+	m, err := DecodeMetadata(meta.AppendTo(nil))
+	if err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+	got, err := Decode(m, value)
+	if err != nil {
+		t.Fatalf("decoding value: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("round trip mismatch:\n got: %#v\nwant: %#v", got.GoValue(), want.GoValue())
+	}
+
+	// field_id_size must be 2 bytes: header info bits (offset_size_minus_one
+	// at bits 2-3, field_id_size_minus_one at bits 4-5).
+	if fieldIDSize := int(value[0]>>4)&0x03 + 1; fieldIDSize != 2 {
+		t.Errorf("field_id_size = %d, want 2 (max field id 300)", fieldIDSize)
+	}
+}
+
+// sortObjectFields returns a copy of v with all object fields recursively
+// sorted by name, the canonical layout the tree encoder emits.
+func sortObjectFields(v Value) Value {
+	switch v.basic {
+	case BasicObject:
+		fields := slices.Clone(v.object.Fields)
+		for i := range fields {
+			fields[i].Value = sortObjectFields(fields[i].Value)
+		}
+		slices.SortFunc(fields, func(a, b Field) int { return strings.Compare(a.Name, b.Name) })
+		return MakeObject(fields)
+	case BasicArray:
+		elems := slices.Clone(v.array.Elements)
+		for i := range elems {
+			elems[i] = sortObjectFields(elems[i])
+		}
+		return MakeArray(elems)
+	default:
+		return v
+	}
+}
+
+func randomBuilderValue(r *rand.Rand, depth int) Value {
+	if depth < 3 && r.IntN(3) == 0 {
+		if r.IntN(2) == 0 {
+			n := r.IntN(5)
+			fields := make([]Field, 0, n)
+			for i := range n {
+				fields = append(fields, Field{
+					Name:  fmt.Sprintf("f%d", (i*7+r.IntN(3))%11),
+					Value: randomBuilderValue(r, depth+1),
+				})
+			}
+			// Deduplicate names (objects require unique field names).
+			seen := map[string]bool{}
+			uniq := fields[:0]
+			for _, f := range fields {
+				if !seen[f.Name] {
+					seen[f.Name] = true
+					uniq = append(uniq, f)
+				}
+			}
+			return MakeObject(uniq)
+		}
+		n := r.IntN(5)
+		elems := make([]Value, n)
+		for i := range elems {
+			elems[i] = randomBuilderValue(r, depth+1)
+		}
+		return MakeArray(elems)
+	}
+	switch r.IntN(8) {
+	case 0:
+		return Null()
+	case 1:
+		return Bool(r.IntN(2) == 0)
+	case 2:
+		return Int64(int64(r.Uint64()))
+	case 3:
+		return Double(r.NormFloat64())
+	case 4:
+		return String(string(bytes.Repeat([]byte("s"), r.IntN(80))))
+	case 5:
+		return Decimal8(int64(r.Uint64()), byte(r.IntN(20)))
+	case 6:
+		return Date(int32(r.IntN(40000)))
+	default:
+		return Binary([]byte{byte(r.Uint32())})
+	}
+}
+
+// TestBuilderLargeContainers exercises the is_large header paths (more than
+// 255 fields / elements) and multi-byte offsets.
+func TestBuilderLargeContainers(t *testing.T) {
+	var b Builder
+	b.BeginObject()
+	want := make([]Field, 300)
+	for i := range want {
+		name := fmt.Sprintf("field_%03d", i)
+		b.Field(name)
+		b.String(fmt.Sprintf("value_%03d", i))
+		want[i] = Field{Name: name, Value: String(fmt.Sprintf("value_%03d", i))}
+	}
+	b.EndObject()
+	metadata, value, err := b.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	m, err := DecodeMetadata(metadata)
+	if err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+	got, err := Decode(m, value)
+	if err != nil {
+		t.Fatalf("decoding value: %v", err)
+	}
+	if !got.Equal(MakeObject(want)) {
+		t.Fatal("large object round trip mismatch")
+	}
+
+	b.Reset()
+	b.BeginArray()
+	elems := make([]Value, 400)
+	for i := range elems {
+		elems[i] = Int32(int32(i))
+		b.Int32(int32(i))
+	}
+	b.EndArray()
+	metadata, value, err = b.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	m, err = DecodeMetadata(metadata)
+	if err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+	got, err = Decode(m, value)
+	if err != nil {
+		t.Fatalf("decoding value: %v", err)
+	}
+	if !got.Equal(MakeArray(elems)) {
+		t.Fatal("large array round trip mismatch")
+	}
+}
+
+// TestBuilderSharedMetadata checks that multiple builders interning into one
+// shared dictionary produce values decodable against the single dictionary.
+func TestBuilderSharedMetadata(t *testing.T) {
+	var meta MetadataBuilder
+	b1 := NewBuilderWithMetadata(&meta)
+	b2 := NewBuilderWithMetadata(&meta)
+
+	MakeObject([]Field{{Name: "shared", Value: Int32(1)}, {Name: "one", Value: Null()}}).Write(b1)
+	MakeObject([]Field{{Name: "shared", Value: Int32(2)}, {Name: "two", Value: Null()}}).Write(b2)
+
+	v1, err := b1.Bytes()
+	if err != nil {
+		t.Fatalf("b1.Bytes: %v", err)
+	}
+	v2, err := b2.Bytes()
+	if err != nil {
+		t.Fatalf("b2.Bytes: %v", err)
+	}
+	m, err := DecodeMetadata(meta.AppendTo(nil))
+	if err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+	got1, err := Decode(m, v1)
+	if err != nil {
+		t.Fatalf("decoding v1: %v", err)
+	}
+	got2, err := Decode(m, v2)
+	if err != nil {
+		t.Fatalf("decoding v2: %v", err)
+	}
+	if !got1.Equal(MakeObject([]Field{{Name: "shared", Value: Int32(1)}, {Name: "one", Value: Null()}})) {
+		t.Errorf("v1 mismatch: %#v", got1.GoValue())
+	}
+	if !got2.Equal(MakeObject([]Field{{Name: "shared", Value: Int32(2)}, {Name: "two", Value: Null()}})) {
+		t.Errorf("v2 mismatch: %#v", got2.GoValue())
+	}
+
+	// Resetting a shared-metadata builder must not clear the shared
+	// dictionary.
+	b1.Reset()
+	if len(meta.offs) == 0 {
+		t.Error("Reset cleared the shared metadata dictionary")
+	}
+}
+
+// TestBuilderMisuse checks that malformed event sequences produce sticky
+// errors instead of corrupt output.
+func TestBuilderMisuse(t *testing.T) {
+	tests := []struct {
+		name  string
+		drive func(b *Builder)
+	}{
+		{"two top-level values", func(b *Builder) { b.Int32(1); b.Int32(2) }},
+		{"value without Field", func(b *Builder) { b.BeginObject(); b.Int32(1) }},
+		{"Field outside object", func(b *Builder) { b.Field("x") }},
+		{"Field in array", func(b *Builder) { b.BeginArray(); b.Field("x") }},
+		{"double Field", func(b *Builder) { b.BeginObject(); b.Field("x"); b.Field("y") }},
+		{"EndObject with pending field", func(b *Builder) { b.BeginObject(); b.Field("x"); b.EndObject() }},
+		{"EndObject without Begin", func(b *Builder) { b.EndObject() }},
+		{"EndArray without Begin", func(b *Builder) { b.EndArray() }},
+		{"EndArray closes object", func(b *Builder) { b.BeginObject(); b.EndArray() }},
+		{"EndObject closes array", func(b *Builder) { b.BeginArray(); b.EndObject() }},
+		{"duplicate field name", func(b *Builder) {
+			b.BeginObject()
+			b.Field("x")
+			b.Int32(1)
+			b.Field("x")
+			b.Int32(2)
+			b.EndObject()
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var b Builder
+			tc.drive(&b)
+			if b.Err() == nil {
+				// Errors like unclosed containers only surface at Finish.
+				if _, _, err := b.Finish(); err == nil {
+					t.Fatal("expected an error")
+				}
+			}
+			// Sticky: further events must not clear it.
+			b.Int32(3)
+			if _, _, err := b.Finish(); err == nil {
+				t.Fatal("expected the error to be sticky")
+			}
+		})
+	}
+
+	t.Run("unclosed container", func(t *testing.T) {
+		var b Builder
+		b.BeginArray()
+		if _, _, err := b.Finish(); err == nil {
+			t.Fatal("expected an error for unclosed array")
+		}
+	})
+	t.Run("no value", func(t *testing.T) {
+		var b Builder
+		if _, _, err := b.Finish(); err == nil {
+			t.Fatal("expected an error for empty builder")
+		}
+	})
+}
+
+// TestBuilderReset checks that a reused builder produces clean output with
+// no residue from the previous value.
+func TestBuilderReset(t *testing.T) {
+	var b Builder
+	MakeObject([]Field{{Name: "first", Value: Int32(1)}}).Write(&b)
+	if _, _, err := b.Finish(); err != nil {
+		t.Fatalf("first Finish: %v", err)
+	}
+
+	b.Reset()
+	MakeArray([]Value{String("second")}).Write(&b)
+	metadata, value, err := b.Finish()
+	if err != nil {
+		t.Fatalf("second Finish: %v", err)
+	}
+	m, err := DecodeMetadata(metadata)
+	if err != nil {
+		t.Fatalf("decoding metadata: %v", err)
+	}
+	if len(m.Strings) != 0 {
+		t.Errorf("metadata after Reset contains stale strings: %v", m.Strings)
+	}
+	got, err := Decode(m, value)
+	if err != nil {
+		t.Fatalf("decoding value: %v", err)
+	}
+	if !got.Equal(MakeArray([]Value{String("second")})) {
+		t.Errorf("mismatch after Reset: %#v", got.GoValue())
+	}
+}
+
+// TestBuilderAllocations checks that a warmed-up builder encodes values with
+// zero allocations.
+func TestBuilderAllocations(t *testing.T) {
+	v := MakeObject([]Field{
+		{Name: "a", Value: Int64(1)},
+		{Name: "b", Value: MakeArray([]Value{String("x"), String("y")})},
+	})
+	var b Builder
+	v.Write(&b)
+	if _, _, err := b.Finish(); err != nil {
+		t.Fatal(err)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		b.Reset()
+		v.Write(&b)
+		if _, err := b.Bytes(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	// Reset clears the owned dictionary, so each run re-interns the two
+	// field names; map writes may allocate. Everything else must not.
+	if allocs > 2 {
+		t.Errorf("allocations per encode: %v, want <= 2", allocs)
+	}
+}

--- a/variant/metadata.go
+++ b/variant/metadata.go
@@ -105,9 +105,10 @@ func (m Metadata) Lookup(id int) (string, error) {
 // interned into a single contiguous byte buffer so a high-cardinality key
 // set pays for buffer growth rather than a heap string per key.
 type MetadataBuilder struct {
-	buf   []byte // concatenated dictionary strings
-	offs  []int  // start offset of each string in buf; end is offs[i+1] or len(buf)
-	index map[string]int
+	buf      []byte // concatenated dictionary strings
+	offs     []int  // start offset of each string in buf; end is offs[i+1] or len(buf)
+	index    map[string]int
+	unsorted bool // some entry compares below its predecessor
 }
 
 // Add interns s into the dictionary and returns its stable index. The
@@ -119,6 +120,9 @@ func (b *MetadataBuilder) Add(s string) int {
 	}
 	if idx, ok := b.index[s]; ok {
 		return idx
+	}
+	if n := len(b.offs); n > 0 && !b.unsorted && b.stringAt(n-1) > s {
+		b.unsorted = true
 	}
 	start := len(b.buf)
 	old := unsafe.SliceData(b.buf)
@@ -215,19 +219,20 @@ func (b *MetadataBuilder) AppendTo(dst []byte) []byte {
 }
 
 // sorted reports whether the dictionary strings are in lexicographic order.
+// The order is tracked incrementally by Add, so building the binary
+// representation of a large dictionary need not re-compare every entry.
 func (b *MetadataBuilder) sorted() bool {
-	for i := 1; i < len(b.offs); i++ {
-		if b.stringAt(i-1) > b.stringAt(i) {
-			return false
-		}
-	}
-	return true
+	return !b.unsorted
 }
+
+// Size returns the total number of bytes of interned dictionary strings.
+func (b *MetadataBuilder) Size() int { return len(b.buf) }
 
 // Reset clears the builder for reuse, retaining the string buffer's capacity.
 func (b *MetadataBuilder) Reset() {
 	b.buf = b.buf[:0]
 	b.offs = b.offs[:0]
+	b.unsorted = false
 	clear(b.index)
 }
 

--- a/variant/metadata.go
+++ b/variant/metadata.go
@@ -180,6 +180,11 @@ func (b *MetadataBuilder) Build() (Metadata, []byte) {
 // dst and returns the extended slice. The dictionary indices in the output
 // match those returned by Add, so encoded values referencing those indices
 // remain valid.
+//
+// The variant format encodes dictionary offsets in at most 4 bytes, so the
+// interned names must total at most math.MaxUint32 bytes; callers growing
+// the dictionary without bound must check Size before encoding (as
+// Builder.Finish and parquet.VariantColumnWriter do).
 func (b *MetadataBuilder) AppendTo(dst []byte) []byte {
 	n := len(b.offs)
 	totalLen := len(b.buf)

--- a/variant/metadata.go
+++ b/variant/metadata.go
@@ -4,11 +4,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"sort"
 	"unicode/utf8"
+	"unsafe"
 )
 
 // Metadata holds the decoded metadata dictionary for a variant value.
+// Sorted reports whether the dictionary strings were stored in
+// lexicographic order (the sorted_strings header bit).
 type Metadata struct {
 	Strings []string
 	Sorted  bool
@@ -60,7 +62,6 @@ func DecodeMetadata(data []byte) (Metadata, error) {
 		return Metadata{}, fmt.Errorf("variant metadata: dictionary size %d exceeds data", dictSize)
 	}
 
-	// Read (dictSize+1) offsets
 	offsets := make([]int, dictSize+1)
 	for i := range offsets {
 		v, n, err := readUint(data[pos:], offsetSz)
@@ -100,14 +101,18 @@ func (m Metadata) Lookup(id int) (string, error) {
 	return m.Strings[id], nil
 }
 
-// MetadataBuilder builds a variant metadata dictionary.
+// MetadataBuilder builds a variant metadata dictionary. Field names are
+// interned into a single contiguous byte buffer so a high-cardinality key
+// set pays for buffer growth rather than a heap string per key.
 type MetadataBuilder struct {
-	strings []string
-	index   map[string]int
+	buf   []byte // concatenated dictionary strings
+	offs  []int  // start offset of each string in buf; end is offs[i+1] or len(buf)
+	index map[string]int
 }
 
-// Add adds a string to the dictionary and returns its index.
-// If the string already exists, the existing index is returned.
+// Add interns s into the dictionary and returns its stable index. The
+// string is copied into the builder's buffer, so callers may reuse the
+// argument's backing memory after Add returns.
 func (b *MetadataBuilder) Add(s string) int {
 	if b.index == nil {
 		b.index = make(map[string]int)
@@ -115,71 +120,115 @@ func (b *MetadataBuilder) Add(s string) int {
 	if idx, ok := b.index[s]; ok {
 		return idx
 	}
-	idx := len(b.strings)
-	b.strings = append(b.strings, s)
-	b.index[s] = idx
+	start := len(b.buf)
+	old := unsafe.SliceData(b.buf)
+	b.buf = append(b.buf, s...)
+	idx := len(b.offs)
+	// Record the new start before any reindex so stringAt can bound the
+	// previous last entry (and this one) correctly against the grown slab.
+	b.offs = append(b.offs, start)
+	if idx > 0 && unsafe.SliceData(b.buf) != old {
+		b.reindex()
+	} else {
+		b.index[b.stringAt(idx)] = idx
+	}
 	return idx
+}
+
+// stringAt returns a view of dictionary entry i into the slab. The view is
+// only valid until the next Add that grows the buffer, or Reset.
+func (b *MetadataBuilder) stringAt(i int) string {
+	start := b.offs[i]
+	end := len(b.buf)
+	if i+1 < len(b.offs) {
+		end = b.offs[i+1]
+	}
+	if end == start {
+		return ""
+	}
+	return unsafe.String(unsafe.SliceData(b.buf[start:end]), end-start)
+}
+
+// reindex rebuilds the lookup map after the slab has been reallocated.
+func (b *MetadataBuilder) reindex() {
+	clear(b.index)
+	if b.index == nil {
+		b.index = make(map[string]int, len(b.offs))
+	}
+	for i := range b.offs {
+		b.index[b.stringAt(i)] = i
+	}
 }
 
 // Build returns the decoded Metadata and the encoded binary representation.
 // The dictionary indices in the output match those returned by Add, so
-// encoded values referencing those indices remain valid.
+// encoded values referencing those indices remain valid. The returned
+// Metadata owns its strings and remains valid after Reset.
 func (b *MetadataBuilder) Build() (Metadata, []byte) {
-	n := len(b.strings)
-
-	// Check if the strings happen to be sorted
-	sorted := sort.StringsAreSorted(b.strings)
-
-	// Compute string data and offsets
-	offsets := make([]int, n+1)
-	totalLen := 0
-	for i, s := range b.strings {
-		offsets[i] = totalLen
-		totalLen += len(s)
+	strs := make([]string, len(b.offs))
+	for i := range b.offs {
+		strs[i] = string(b.stringAt(i)) // detach from the slab so Reset cannot invalidate
 	}
-	offsets[n] = totalLen
+	return Metadata{Strings: strs, Sorted: b.sorted()}, b.AppendTo(nil)
+}
 
-	// Determine offset size
+// AppendTo appends the encoded binary representation of the dictionary to
+// dst and returns the extended slice. The dictionary indices in the output
+// match those returned by Add, so encoded values referencing those indices
+// remain valid.
+func (b *MetadataBuilder) AppendTo(dst []byte) []byte {
+	n := len(b.offs)
+	totalLen := len(b.buf)
+	sortedBit := byte(0)
+	if b.sorted() {
+		sortedBit = 1
+	}
+
 	maxOffset := max(totalLen, n)
 	osc := offsetSizeCode(maxOffset)
 	offsetSz := offsetSize(osc)
 
-	// Build the binary blob
-	// header(1) + dict_size(offsetSz) + offsets((n+1)*offsetSz) + string_data(totalLen)
+	// Layout: header(1) + dict_size(offsetSz) + offsets((n+1)*offsetSz) +
+	// string_data(totalLen).
 	size := 1 + offsetSz + (n+1)*offsetSz + totalLen
-	buf := make([]byte, size)
+	base := len(dst)
+	dst = append(dst, make([]byte, size)...)
+	out := dst[base:]
 
 	// Header: version=1, sorted_strings flag at bit 4, offset_size_minus_one
 	// at bits 6-7 (per the spec's metadata encoding grammar).
-	sortedBit := byte(0)
-	if sorted {
-		sortedBit = 1
-	}
-	buf[0] = 1 | (sortedBit << 4) | (osc << 6)
+	out[0] = 1 | (sortedBit << 4) | (osc << 6)
 
 	pos := 1
-	writeUint(buf[pos:], n, offsetSz)
+	writeUint(out[pos:], n, offsetSz)
 	pos += offsetSz
 
-	for _, off := range offsets {
-		writeUint(buf[pos:], off, offsetSz)
+	for _, off := range b.offs {
+		writeUint(out[pos:], off, offsetSz)
 		pos += offsetSz
 	}
+	writeUint(out[pos:], totalLen, offsetSz)
+	pos += offsetSz
 
-	for _, s := range b.strings {
-		copy(buf[pos:], s)
-		pos += len(s)
-	}
-
-	return Metadata{Strings: b.strings, Sorted: sorted}, buf
+	copy(out[pos:], b.buf)
+	return dst
 }
 
-// Reset clears the builder for reuse.
-func (b *MetadataBuilder) Reset() {
-	b.strings = b.strings[:0]
-	for k := range b.index {
-		delete(b.index, k)
+// sorted reports whether the dictionary strings are in lexicographic order.
+func (b *MetadataBuilder) sorted() bool {
+	for i := 1; i < len(b.offs); i++ {
+		if b.stringAt(i-1) > b.stringAt(i) {
+			return false
+		}
 	}
+	return true
+}
+
+// Reset clears the builder for reuse, retaining the string buffer's capacity.
+func (b *MetadataBuilder) Reset() {
+	b.buf = b.buf[:0]
+	b.offs = b.offs[:0]
+	clear(b.index)
 }
 
 // readUint reads an unsigned integer of the given byte width from data. Note

--- a/variant/metadata.go
+++ b/variant/metadata.go
@@ -105,10 +105,13 @@ func (m Metadata) Lookup(id int) (string, error) {
 // interned into a single contiguous byte buffer so a high-cardinality key
 // set pays for buffer growth rather than a heap string per key.
 type MetadataBuilder struct {
-	buf      []byte // concatenated dictionary strings
-	offs     []int  // start offset of each string in buf; end is offs[i+1] or len(buf)
-	index    map[string]int
-	unsorted bool // some entry compares below its predecessor
+	buf   []byte // concatenated dictionary strings
+	offs  []int  // start offset of each string in buf; end is offs[i+1] or len(buf)
+	index map[string]int
+	// unsorted is set when some entry compares below its predecessor; it is
+	// tracked incrementally by Add so encoding a large dictionary need not
+	// re-compare every entry.
+	unsorted bool
 }
 
 // Add interns s into the dictionary and returns its stable index. The
@@ -156,9 +159,6 @@ func (b *MetadataBuilder) stringAt(i int) string {
 // reindex rebuilds the lookup map after the slab has been reallocated.
 func (b *MetadataBuilder) reindex() {
 	clear(b.index)
-	if b.index == nil {
-		b.index = make(map[string]int, len(b.offs))
-	}
 	for i := range b.offs {
 		b.index[b.stringAt(i)] = i
 	}
@@ -173,7 +173,7 @@ func (b *MetadataBuilder) Build() (Metadata, []byte) {
 	for i := range b.offs {
 		strs[i] = string(b.stringAt(i)) // detach from the slab so Reset cannot invalidate
 	}
-	return Metadata{Strings: strs, Sorted: b.sorted()}, b.AppendTo(nil)
+	return Metadata{Strings: strs, Sorted: !b.unsorted}, b.AppendTo(nil)
 }
 
 // AppendTo appends the encoded binary representation of the dictionary to
@@ -189,7 +189,7 @@ func (b *MetadataBuilder) AppendTo(dst []byte) []byte {
 	n := len(b.offs)
 	totalLen := len(b.buf)
 	sortedBit := byte(0)
-	if b.sorted() {
+	if !b.unsorted {
 		sortedBit = 1
 	}
 
@@ -221,13 +221,6 @@ func (b *MetadataBuilder) AppendTo(dst []byte) []byte {
 
 	copy(out[pos:], b.buf)
 	return dst
-}
-
-// sorted reports whether the dictionary strings are in lexicographic order.
-// The order is tracked incrementally by Add, so building the binary
-// representation of a large dictionary need not re-compare every entry.
-func (b *MetadataBuilder) sorted() bool {
-	return !b.unsorted
 }
 
 // Size returns the total number of bytes of interned dictionary strings.

--- a/variant_column_reader.go
+++ b/variant_column_reader.go
@@ -81,20 +81,19 @@ func (k VariantCursorKind) String() string {
 // created at any time; cursors created after a call to Next take effect on
 // the following call.
 type VariantReader struct {
-	rowGroup    RowGroup
-	group       *shreddedVariantGroup
-	groupDef    int // definition level at which the variant group is present
-	groupMaxDef byte
-	baseColumn  int // first leaf column of the variant group
-	numRows     int64
-	rowOffset   int64
-	leafInfo    []variantLeafInfo
-	leaves      []*variantLeafReader // lazily created, indexed by relative column
-	metaLeaf    *variantLeafReader
-	root        *VariantCursor
-	metaCache   map[string]variant.Metadata
-	leafSet     map[*variantLeafReader]struct{} // reused by Next
-	err         error
+	rowGroup   RowGroup
+	group      *shreddedVariantGroup
+	groupDef   int // definition level at which the variant group is present
+	baseColumn int // first leaf column of the variant group
+	numRows    int64
+	rowOffset  int64
+	leafInfo   []variantLeafInfo
+	leaves     []*variantLeafReader // lazily created, indexed by relative column
+	metaLeaf   *variantLeafReader
+	root       *VariantCursor
+	metaCache  map[string]variant.Metadata
+	leafSet    map[*variantLeafReader]struct{} // reused by Next
+	err        error
 
 	// rootValueRequired is set for plain unshredded variant groups, whose
 	// value field is required rather than optional.
@@ -144,22 +143,45 @@ type variantLeafInfo struct {
 	maxRep byte
 }
 
-// NewVariantReader creates a reader for the variant column at the given path
-// in the row group. The path names the variant group node in the schema
-// (e.g. "event" for a top-level column, "attrs", "v" for a nested one). The
-// column may be unshredded (metadata, value) or shredded (metadata, value,
-// typed_value) in any shape permitted by the Variant Shredding
-// specification.
-func NewVariantReader(rowGroup RowGroup, path ...string) (*VariantReader, error) {
-	if len(path) == 0 {
-		return nil, fmt.Errorf("variant: NewVariantReader requires a column path")
+// variantColumnInfo is the result of resolving a variant column path in a
+// schema, shared by NewVariantReader and NewVariantColumnWriter.
+type variantColumnInfo struct {
+	node          Node
+	group         *shreddedVariantGroup
+	valueRequired bool // plain unshredded shape (required binary value)
+	col           int  // first leaf column of the variant group
+	def           int  // definition level at which the group is present
+	optional      bool // whether the group node itself is optional
+}
+
+// variantGroupOf builds the shredding tree of a variant group node,
+// accepting both the shredded shapes (optional value) and the plain
+// unshredded shape (required value) that VariantEncoding.md declares. The
+// boolean result reports the latter.
+func variantGroupOf(node Node) (*shreddedVariantGroup, bool, error) {
+	g, err := buildShreddedVariantGroup(node, 0, 0, 0)
+	if err != nil {
+		if u, ok := unshreddedVariantGroupOf(node); ok {
+			return u, true, nil
+		}
+		return nil, false, err
 	}
-	node := Node(rowGroup.Schema())
-	def := 0
-	col := 0
+	if g.metadataCol < 0 {
+		return nil, false, fmt.Errorf("variant: variant group has no metadata field")
+	}
+	return g, false, nil
+}
+
+// resolveVariantColumn walks the schema to the variant group node named by
+// path and builds its shredding tree.
+func resolveVariantColumn(schema Node, path []string) (info variantColumnInfo, err error) {
+	if len(path) == 0 {
+		return info, fmt.Errorf("variant: a column path is required")
+	}
+	node := schema
 	for _, name := range path {
 		if node.Leaf() {
-			return nil, fmt.Errorf("variant: column %q not found: %q is a leaf", joinPath(path), name)
+			return info, fmt.Errorf("variant: column %q not found: %q is a leaf", joinPath(path), name)
 		}
 		var next Node
 		for _, f := range node.Fields() {
@@ -167,50 +189,55 @@ func NewVariantReader(rowGroup RowGroup, path ...string) (*VariantReader, error)
 				next = f
 				break
 			}
-			col += int(numLeafColumnsOf(f))
+			info.col += int(numLeafColumnsOf(f))
 		}
 		if next == nil {
-			return nil, fmt.Errorf("variant: column %q not found: no field %q", joinPath(path), name)
+			return info, fmt.Errorf("variant: column %q not found: no field %q", joinPath(path), name)
 		}
 		if next.Repeated() {
-			return nil, fmt.Errorf("variant: column %q is beneath a repeated field, which VariantReader does not support", joinPath(path))
+			return info, fmt.Errorf("variant: column %q is beneath a repeated field, which the columnar variant APIs do not support", joinPath(path))
 		}
-		if next.Optional() {
-			def++
+		info.optional = next.Optional()
+		if info.optional {
+			info.def++
 		}
 		node = next
 	}
 	if node.Leaf() {
-		return nil, fmt.Errorf("variant: column %q is not a variant group", joinPath(path))
+		return info, fmt.Errorf("variant: column %q is not a variant group", joinPath(path))
 	}
-	group, err := buildShreddedVariantGroup(node, 0, 0, 0)
-	valueRequired := false
+	info.node = node
+	info.group, info.valueRequired, err = variantGroupOf(node)
 	if err != nil {
-		// Plain unshredded variant groups declare "required binary value"
-		// (VariantEncoding.md), which the shredded-schema validation
-		// rejects; accept that shape here.
-		if g, ok := unshreddedVariantGroupOf(node); ok {
-			group, valueRequired, err = g, true, nil
-		} else {
-			return nil, err
-		}
+		return info, fmt.Errorf("variant: column %q: %w", joinPath(path), err)
 	}
-	if group.metadataCol < 0 {
-		return nil, fmt.Errorf("variant: column %q has no metadata field", joinPath(path))
+	return info, nil
+}
+
+// NewVariantReader creates a reader for the variant column at the given path
+// in the row group. The path names the variant group node in the schema
+// (e.g. "event" for a top-level column, "attrs", "v" for a nested one). The
+// column may be unshredded (metadata, value) or shredded (metadata, value,
+// typed_value) in any shape permitted by the Variant Shredding
+// specification.
+func NewVariantReader(rowGroup RowGroup, path ...string) (*VariantReader, error) {
+	info, err := resolveVariantColumn(rowGroup.Schema(), path)
+	if err != nil {
+		return nil, err
 	}
+	group, node := info.group, info.node
 
 	r := &VariantReader{
-		rowGroup:    rowGroup,
-		group:       group,
-		groupDef:    def,
-		groupMaxDef: byte(def),
-		baseColumn:  col,
-		numRows:     rowGroup.NumRows(),
-		leafInfo:    make([]variantLeafInfo, group.numCols),
-		leaves:      make([]*variantLeafReader, group.numCols),
-		metaCache:   make(map[string]variant.Metadata),
+		rowGroup:   rowGroup,
+		group:      group,
+		groupDef:   info.def,
+		baseColumn: info.col,
+		numRows:    rowGroup.NumRows(),
+		leafInfo:   make([]variantLeafInfo, group.numCols),
+		leaves:     make([]*variantLeafReader, group.numCols),
+		metaCache:  make(map[string]variant.Metadata),
 
-		rootValueRequired: valueRequired,
+		rootValueRequired: info.valueRequired,
 	}
 
 	// Types in leaf order; the traversal order matches the column numbering
@@ -227,11 +254,11 @@ func NewVariantReader(rowGroup RowGroup, path ...string) (*VariantReader, error)
 	}
 	r.fillLeafLevels(group)
 
-	for _, info := range r.leafInfo {
-		switch info.typ.Kind() {
+	for _, li := range r.leafInfo {
+		switch li.typ.Kind() {
 		case Boolean, Int32, Int64, Float, Double, ByteArray, FixedLenByteArray:
 		default:
-			return nil, fmt.Errorf("variant: unsupported leaf type %s in shredded variant group", info.typ)
+			return nil, fmt.Errorf("variant: unsupported leaf type %s in shredded variant group", li.typ)
 		}
 	}
 
@@ -881,11 +908,11 @@ func (c *VariantCursor) processRoot(n int) error {
 	}
 	for row := range n {
 		e := c.appendEntry(int32(row), int32(row))
-		if mw.defs[row] < c.reader.groupMaxDef {
+		if mw.defs[row] < byte(c.reader.groupDef) {
 			c.locs[e] = variant.LocMissing
-			continue
+		} else {
+			c.computeOwn(e, int32(row), variant.LocNull)
 		}
-		c.computeOwn(e, int32(row), variant.LocNull)
 	}
 	return nil
 }

--- a/variant_column_writer.go
+++ b/variant_column_writer.go
@@ -1,0 +1,884 @@
+package parquet
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/parquet-go/parquet-go/variant"
+)
+
+// This file implements a columnar, streaming writer for VARIANT columns.
+//
+// Unlike the row-based write path (column_buffer_variant.go) — which decodes
+// each row into a variant.Value tree and shreds the tree — VariantColumnWriter
+// consumes variant.ValueWriter events and shreds them as they arrive: values
+// matching the shredded type are appended directly to the typed_value column
+// buffers, and everything else is encoded to variant binary residuals with a
+// streaming variant.Builder, sharing one metadata dictionary per row. No
+// intermediate tree, map, or []parquet.Value is ever built, so transcoding
+// e.g. JSON into a shredded variant column runs allocation-free per row once
+// the writer's buffers are warm.
+//
+// The shredding semantics are identical to the row path (both follow the
+// case tables of the Variant Shredding specification and share
+// variantToParquetValue and the shreddedVariantGroup tree):
+//
+//   - Scalars that exactly match the shredded type go into typed_value with
+//     a null value column; mismatches are encoded into the value column.
+//   - Objects shred field-wise when the position is shredded as an object:
+//     shredded fields descend, missing shredded fields write nulls,
+//     non-shredded fields stream into a partial-object residual.
+//   - Arrays shred element-wise through the 3-level LIST structure when the
+//     position is shredded as a list.
+//   - All object field names of the row, shredded or not, are interned into
+//     the row's metadata dictionary (as VariantShredding.md requires).
+
+// VariantColumnWriter writes one VARIANT column of a parquet file in
+// streaming, columnar form. It implements variant.ValueWriter: each row is
+// bracketed by BeginRow and EndRow, and the row's value is described by the
+// event methods in between, following the event-sequence rules documented
+// on variant.ValueWriter. WriteValue and WriteNullRow are row-level
+// conveniences. String and []byte event arguments, and Field names, are
+// copied; callers may reuse their backing memory after the call returns.
+//
+// The writer appends to the column buffers of the ColumnWriters backing the
+// variant column's leaf columns and flushes full pages at row boundaries,
+// like ColumnWriter.WriteRowValues. Other columns of the file must be
+// written separately (e.g. through Writer.ColumnWriters) with the same
+// number of rows, and the parent writer must be closed (or its row group
+// committed) as usual to flush buffered sub-page data to the file.
+//
+// Errors are sticky: the first misuse or write failure is retained,
+// subsequent events are ignored, and the error is reported by Err, EndRow,
+// and row-level methods. After an error the underlying columns may hold a
+// partial row, so the parent writer's current row group is inconsistent and
+// must be abandoned as a whole, including the other columns' writers: for a
+// ConcurrentRowGroupWriter target, do not Commit; for a Writer or
+// GenericWriter target, discard the output.
+//
+// A VariantColumnWriter is not safe for concurrent use, and the parent
+// writer must not be flushed, reset, or closed between BeginRow and EndRow
+// (rows cannot span pages or row groups).
+type VariantColumnWriter struct {
+	group    *shreddedVariantGroup
+	groupDef int  // definition level at which the variant group is present
+	optional bool // whether the variant group node itself is optional
+	columns  []*ColumnWriter
+	types    []Type // leaf types, indexed by relative column
+
+	// rootValueRequired is set for plain unshredded variant groups, whose
+	// value field is required rather than optional.
+	rootValueRequired bool
+
+	meta     variant.MetadataBuilder
+	metaBuf  []byte
+	builders map[*shreddedVariantGroup]*variant.Builder
+
+	// Row state. cur is the shredded node awaiting a value event, nil when
+	// no value is expected (inside an object before a Field call, or after
+	// the row's value completed). frames tracks open shredded containers,
+	// residual an active residual stream.
+	inRow       bool
+	rowHasValue bool
+	cur         *shreddedVariantGroup
+	curLevels   shredLevels
+	frames      []variantWriterFrame
+	residual    variantResidualState
+	err         error
+}
+
+// variantWriterFrame is one open shredded container (an object or list
+// being shredded field-wise or element-wise).
+type variantWriterFrame struct {
+	node    *shreddedVariantGroup
+	isList  bool
+	levels  shredLevels // level context of this container occurrence
+	seen    []bool      // objects: shredded fields that received a value
+	partial *variant.Builder
+	elems   int // lists: elements written so far
+}
+
+// variantResidualState tracks an active residual stream: events are
+// forwarded to b until the container depth returns to base.
+type variantResidualState struct {
+	b      *variant.Builder
+	node   *shreddedVariantGroup
+	levels shredLevels
+	depth  int
+	base   int
+}
+
+// VariantWriterTarget is the writer surface VariantColumnWriter binds to;
+// it is satisfied by *Writer, *GenericWriter[T], and
+// *ConcurrentRowGroupWriter.
+type VariantWriterTarget interface {
+	Schema() *Schema
+	ColumnWriters() []*ColumnWriter
+}
+
+var (
+	_ VariantWriterTarget = (*Writer)(nil)
+	_ VariantWriterTarget = (*GenericWriter[any])(nil)
+	_ VariantWriterTarget = (*ConcurrentRowGroupWriter)(nil)
+)
+
+// NewVariantColumnWriter returns a streaming columnar writer for the VARIANT
+// column at the given path in w's schema (e.g. "event" for a top-level
+// column, "attrs", "v" for one nested in a group). The column may be
+// unshredded (metadata, value) or shredded (metadata, value, typed_value)
+// in any shape permitted by the Variant Shredding specification.
+func NewVariantColumnWriter(w VariantWriterTarget, path ...string) (*VariantColumnWriter, error) {
+	if len(path) == 0 {
+		return nil, fmt.Errorf("variant: NewVariantColumnWriter requires a column path")
+	}
+	schema := w.Schema()
+	if schema == nil {
+		return nil, fmt.Errorf("variant: the writer has no schema configured")
+	}
+	node := Node(schema)
+	def := 0
+	col := 0
+	optional := false
+	for _, name := range path {
+		if node.Leaf() {
+			return nil, fmt.Errorf("variant: column %q not found: %q is a leaf", joinPath(path), name)
+		}
+		var next Node
+		for _, f := range node.Fields() {
+			if f.Name() == name {
+				next = f
+				break
+			}
+			col += int(numLeafColumnsOf(f))
+		}
+		if next == nil {
+			return nil, fmt.Errorf("variant: column %q not found: no field %q", joinPath(path), name)
+		}
+		if next.Repeated() {
+			return nil, fmt.Errorf("variant: column %q is beneath a repeated field, which VariantColumnWriter does not support", joinPath(path))
+		}
+		optional = next.Optional()
+		if optional {
+			def++
+		}
+		node = next
+	}
+	if node.Leaf() {
+		return nil, fmt.Errorf("variant: column %q is not a variant group", joinPath(path))
+	}
+
+	group, err := buildShreddedVariantGroup(node, 0, 0, 0)
+	valueRequired := false
+	if err != nil {
+		// Plain unshredded variant groups declare "required binary value"
+		// (VariantEncoding.md), which the shredded-schema validation
+		// rejects; accept that shape here.
+		if g, ok := unshreddedVariantGroupOf(node); ok {
+			group, valueRequired = g, true
+		} else {
+			return nil, err
+		}
+	}
+	if group.metadataCol < 0 {
+		return nil, fmt.Errorf("variant: column %q has no metadata field", joinPath(path))
+	}
+
+	columnWriters := w.ColumnWriters()
+	if col+group.numCols > len(columnWriters) {
+		return nil, fmt.Errorf("variant: column %q spans columns [%d, %d) but the writer has %d", joinPath(path), col, col+group.numCols, len(columnWriters))
+	}
+
+	vw := &VariantColumnWriter{
+		group:             group,
+		groupDef:          def,
+		optional:          optional,
+		columns:           columnWriters[col : col+group.numCols],
+		types:             make([]Type, group.numCols),
+		rootValueRequired: valueRequired,
+		builders:          make(map[*shreddedVariantGroup]*variant.Builder),
+	}
+	i := 0
+	forEachLeafColumnOf(node, func(leaf leafColumn) {
+		if i < len(vw.types) {
+			vw.types[i] = leaf.node.Type()
+		}
+		i++
+	})
+	return vw, nil
+}
+
+// Err returns the first error encountered, or nil.
+func (w *VariantColumnWriter) Err() error { return w.err }
+
+func (w *VariantColumnWriter) fail(format string, args ...any) {
+	if w.err == nil {
+		w.err = fmt.Errorf("variant writer: "+format, args...)
+	}
+}
+
+// BeginRow starts a new row. Exactly one value — a single scalar event, or
+// a single balanced object or array — must be written before the matching
+// EndRow.
+func (w *VariantColumnWriter) BeginRow() error {
+	if w.err != nil {
+		return w.err
+	}
+	if w.inRow {
+		w.fail("BeginRow inside a row")
+		return w.err
+	}
+	w.inRow = true
+	w.rowHasValue = false
+	w.cur = w.group
+	w.curLevels = shredLevels{baseDef: w.groupDef}
+	w.meta.Reset()
+	return nil
+}
+
+// EndRow completes the current row: it writes the row's metadata dictionary
+// and flushes any column whose buffered page reached the writer's page size.
+func (w *VariantColumnWriter) EndRow() error {
+	if w.err == nil && !w.inRow {
+		w.fail("EndRow outside of a row")
+	}
+	if w.err == nil && (w.residual.b != nil || len(w.frames) > 0) {
+		w.fail("EndRow with an unclosed object or array")
+	}
+	if w.err == nil && !w.rowHasValue {
+		w.fail("EndRow without a value; use WriteNullRow for SQL null rows")
+	}
+	if w.err != nil {
+		return w.err
+	}
+	w.metaBuf = w.meta.AppendTo(w.metaBuf[:0])
+	w.leaf(w.group.metadataCol).writeByteArray(w.levels(byte(w.groupDef), 0), w.metaBuf)
+	w.inRow = false
+	w.cur = nil
+	return w.flush()
+}
+
+// WriteNullRow writes a row where the variant column itself is null (a SQL
+// null, distinct from the variant null value). The variant group must be
+// optional. Any optional ancestors of the variant group are written as
+// present; the writer cannot express a row where an ancestor group is null.
+func (w *VariantColumnWriter) WriteNullRow() error {
+	if w.err != nil {
+		return w.err
+	}
+	if w.inRow {
+		w.fail("WriteNullRow inside a row")
+		return w.err
+	}
+	if !w.optional {
+		w.fail("WriteNullRow on a required variant column")
+		return w.err
+	}
+	lv := w.levels(byte(w.groupDef-1), 0)
+	for col := range w.columns {
+		w.leaf(col).writeNull(lv)
+	}
+	return w.flush()
+}
+
+// WriteValue writes one row holding the given variant value: it brackets
+// v.Write(w) with BeginRow and EndRow and reports any error either raised.
+func (w *VariantColumnWriter) WriteValue(v variant.Value) error {
+	if err := w.BeginRow(); err != nil {
+		return err
+	}
+	v.Write(w)
+	return w.EndRow()
+}
+
+// leaf returns the column buffer of the relative leaf column, creating it on
+// first use like ColumnWriter.WriteRowValues does.
+func (w *VariantColumnWriter) leaf(col int) ColumnBuffer {
+	c := w.columns[col]
+	if c.columnBuffer == nil {
+		c.columnBuffer = c.newColumnBuffer()
+		if c.originalColumnBuffer == nil {
+			c.originalColumnBuffer = c.columnBuffer
+		}
+	}
+	return c.columnBuffer
+}
+
+func (w *VariantColumnWriter) levels(def, rep byte) columnLevels {
+	return columnLevels{definitionLevel: def, repetitionLevel: rep}
+}
+
+// flush flushes any column whose buffer reached the configured page size.
+// It only runs at row boundaries, since a row cannot span two pages.
+func (w *VariantColumnWriter) flush() error {
+	for _, c := range w.columns {
+		if c.columnBuffer != nil && c.columnBuffer.Size() >= int64(c.bufferSize) {
+			if err := c.Flush(); err != nil {
+				w.err = err
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// builder returns the residual builder of a shredded node, sharing the
+// row's metadata dictionary.
+func (w *VariantColumnWriter) builder(node *shreddedVariantGroup) *variant.Builder {
+	b := w.builders[node]
+	if b == nil {
+		b = variant.NewBuilderWithMetadata(&w.meta)
+		w.builders[node] = b
+	}
+	b.Reset()
+	return b
+}
+
+// writeNulls writes one null to every leaf column in [startCol, endCol).
+func (w *VariantColumnWriter) writeNulls(startCol, endCol int, def, rep byte) {
+	lv := w.levels(def, rep)
+	for col := startCol; col < endCol; col++ {
+		w.leaf(col).writeNull(lv)
+	}
+}
+
+// writeMissing writes a missing occurrence of a shredded node (both value
+// and typed_value null), which is how absent object fields are represented.
+func (w *VariantColumnWriter) writeMissing(g *shreddedVariantGroup, l shredLevels) {
+	if g.valueCol >= 0 {
+		w.leaf(g.valueCol).writeNull(w.levels(l.def(g.defLevel), l.rep))
+	}
+	if g.typed != nil {
+		w.writeNulls(g.typed.startCol, g.typed.startCol+g.typed.numCols, l.def(g.defLevel), l.rep)
+	}
+}
+
+// writeResidualBytes writes encoded variant bytes to the node's value
+// column.
+func (w *VariantColumnWriter) writeResidualBytes(g *shreddedVariantGroup, l shredLevels, data []byte) {
+	if g.valueCol < 0 {
+		w.fail("value does not match the shredded type and the schema has no value column to fall back to")
+		return
+	}
+	def := l.def(g.defLevel) + 1
+	if g == w.group && w.rootValueRequired {
+		def = byte(w.groupDef)
+	}
+	w.leaf(g.valueCol).writeByteArray(w.levels(def, l.rep), data)
+}
+
+// writeTyped writes a matched scalar to the node's typed_value column.
+func (w *VariantColumnWriter) writeTyped(col int, pv Value, def, rep byte) {
+	buf := w.leaf(col)
+	lv := w.levels(def, rep)
+	switch pv.Kind() {
+	case Boolean:
+		buf.writeBoolean(lv, pv.Boolean())
+	case Int32:
+		buf.writeInt32(lv, pv.Int32())
+	case Int64:
+		buf.writeInt64(lv, pv.Int64())
+	case Float:
+		buf.writeFloat(lv, pv.Float())
+	case Double:
+		buf.writeDouble(lv, pv.Double())
+	default:
+		buf.writeByteArray(lv, pv.ByteArray())
+	}
+}
+
+// valueDone advances the row state after one value completed at node level:
+// back to the row, to the enclosing object (awaiting the next Field), or to
+// the next element of the enclosing list.
+func (w *VariantColumnWriter) valueDone() {
+	w.cur = nil
+	if n := len(w.frames); n > 0 {
+		f := &w.frames[n-1]
+		if f.isList {
+			f.elems++
+			w.cur = f.node.typed.element
+			w.curLevels = f.levels
+			w.curLevels.rep = byte(f.levels.baseRep + f.node.typed.element.repDepth)
+		}
+	} else {
+		w.rowHasValue = true
+	}
+}
+
+// forward reports whether events must stream into an active residual.
+func (w *VariantColumnWriter) forward() bool {
+	return w.err == nil && w.residual.b != nil
+}
+
+// residualDone finalizes a completed residual stream.
+func (w *VariantColumnWriter) residualDone() {
+	r := w.residual
+	w.residual = variantResidualState{}
+	if r.base > 0 {
+		// A residual field of a partial object completed; the partial
+		// object builder stays open in its frame.
+		return
+	}
+	data, err := r.b.Bytes()
+	if err != nil {
+		w.err = err
+		return
+	}
+	w.writeResidualBytes(r.node, r.levels, data)
+	w.valueDone()
+}
+
+func (w *VariantColumnWriter) afterResidualScalar() {
+	if w.residual.depth == w.residual.base {
+		w.residualDone()
+	}
+}
+
+// scalar shreds one scalar value at the current position: into typed_value
+// on an exact type match, into the value column as variant binary otherwise.
+func (w *VariantColumnWriter) scalar(v variant.Value) {
+	if w.err != nil {
+		return
+	}
+	node := w.cur
+	if node == nil {
+		w.fail("unexpected value event")
+		return
+	}
+	l := w.curLevels
+	if t := node.typed; t != nil && t.kind == shreddedTypedPrimitive {
+		if pv, ok := variantToParquetValue(v, w.types[t.startCol]); ok {
+			w.writeTyped(t.startCol, pv, l.def(t.defLevel), l.rep)
+			if node.valueCol >= 0 {
+				w.leaf(node.valueCol).writeNull(w.levels(l.def(node.defLevel), l.rep))
+			}
+			w.valueDone()
+			return
+		}
+	}
+	b := w.builder(node)
+	v.Write(b)
+	data, err := b.Bytes()
+	if err != nil {
+		w.err = err
+		return
+	}
+	w.writeResidualBytes(node, l, data)
+	if node.typed != nil {
+		w.writeNulls(node.typed.startCol, node.typed.startCol+node.typed.numCols, l.def(node.defLevel), l.rep)
+	}
+	w.valueDone()
+}
+
+// startResidual begins streaming a container that does not match the
+// shredded type into the node's residual builder, nulling the typed columns.
+func (w *VariantColumnWriter) startResidual(node *shreddedVariantGroup, l shredLevels) *variant.Builder {
+	if node.typed != nil {
+		w.writeNulls(node.typed.startCol, node.typed.startCol+node.typed.numCols, l.def(node.defLevel), l.rep)
+	}
+	b := w.builder(node)
+	w.residual = variantResidualState{b: b, node: node, levels: l}
+	return b
+}
+
+// BeginObject starts an object value at the current position. If the
+// position is shredded as an object, its fields shred individually; any
+// other shredded type is a conflict and the whole object streams into the
+// position's value column.
+func (w *VariantColumnWriter) BeginObject() {
+	if w.forward() {
+		w.residual.b.BeginObject()
+		w.residual.depth++
+		return
+	}
+	if w.err != nil {
+		return
+	}
+	node := w.cur
+	if node == nil {
+		w.fail("unexpected BeginObject event")
+		return
+	}
+	l := w.curLevels
+	if t := node.typed; t != nil && t.kind == shreddedTypedObject {
+		w.pushFrame(node, false, l)
+		w.cur = nil
+		return
+	}
+	b := w.startResidual(node, l)
+	b.BeginObject()
+	w.residual.depth = 1
+	w.cur = nil
+}
+
+// Field names the next value written as a field of the innermost open
+// object. Values of shredded fields go to the field's columns; others
+// stream into the object's partial residual.
+func (w *VariantColumnWriter) Field(name string) {
+	if w.forward() {
+		w.residual.b.Field(name)
+		return
+	}
+	if w.err != nil {
+		return
+	}
+	n := len(w.frames)
+	if n == 0 || w.frames[n-1].isList {
+		w.fail("Field %q outside of an object", name)
+		return
+	}
+	f := &w.frames[n-1]
+	if w.cur != nil {
+		w.fail("Field %q: previous field has no value", name)
+		return
+	}
+	// VariantShredding.md requires all field names, shredded or not, to be
+	// present in the metadata dictionary.
+	w.meta.Add(name)
+	node := f.node
+	for i := range node.typed.fields {
+		if node.typed.fields[i].name == name {
+			if f.seen[i] {
+				w.fail("duplicate object field %q", name)
+				return
+			}
+			f.seen[i] = true
+			w.cur = node.typed.fields[i].group
+			w.curLevels = f.levels
+			return
+		}
+	}
+	// Not a shredded field: it goes into the partial-object residual.
+	if f.partial == nil {
+		f.partial = w.builder(node)
+		f.partial.BeginObject()
+	}
+	f.partial.Field(name)
+	w.residual = variantResidualState{b: f.partial, node: node, levels: f.levels, depth: 1, base: 1}
+}
+
+// EndObject closes the innermost open object, recording shredded fields
+// that received no value as missing and committing the partial residual, if
+// any, to the object's value column.
+func (w *VariantColumnWriter) EndObject() {
+	if w.forward() {
+		w.residual.b.EndObject()
+		w.residual.depth--
+		if w.residual.depth == w.residual.base {
+			w.residualDone()
+		}
+		return
+	}
+	if w.err != nil {
+		return
+	}
+	n := len(w.frames)
+	if n == 0 || w.frames[n-1].isList {
+		w.fail("EndObject without matching BeginObject")
+		return
+	}
+	f := &w.frames[n-1]
+	if w.cur != nil {
+		w.fail("EndObject: last field has no value")
+		return
+	}
+	node, l := f.node, f.levels
+	for i := range node.typed.fields {
+		if !f.seen[i] {
+			w.writeMissing(node.typed.fields[i].group, l)
+		}
+	}
+	if f.partial != nil {
+		f.partial.EndObject()
+		data, err := f.partial.Bytes()
+		if err != nil {
+			w.err = err
+			return
+		}
+		w.writeResidualBytes(node, l, data)
+	} else if node.valueCol >= 0 {
+		w.leaf(node.valueCol).writeNull(w.levels(l.def(node.defLevel), l.rep))
+	}
+	w.frames = w.frames[:n-1]
+	w.valueDone()
+}
+
+// BeginArray starts an array value at the current position. If the position
+// is shredded as a list, every value until the matching EndArray shreds as
+// one element; any other shredded type is a conflict and the whole array
+// streams into the position's value column.
+func (w *VariantColumnWriter) BeginArray() {
+	if w.forward() {
+		w.residual.b.BeginArray()
+		w.residual.depth++
+		return
+	}
+	if w.err != nil {
+		return
+	}
+	node := w.cur
+	if node == nil {
+		w.fail("unexpected BeginArray event")
+		return
+	}
+	l := w.curLevels
+	if t := node.typed; t != nil && t.kind == shreddedTypedList {
+		w.pushFrame(node, true, l)
+		// The first element carries the enclosing occurrence's repetition
+		// level; valueDone switches to the element repetition level for
+		// subsequent elements.
+		w.cur = t.element
+		w.curLevels = l
+		return
+	}
+	b := w.startResidual(node, l)
+	b.BeginArray()
+	w.residual.depth = 1
+	w.cur = nil
+}
+
+// EndArray closes the innermost open array.
+func (w *VariantColumnWriter) EndArray() {
+	if w.forward() {
+		w.residual.b.EndArray()
+		w.residual.depth--
+		if w.residual.depth == w.residual.base {
+			w.residualDone()
+		}
+		return
+	}
+	if w.err != nil {
+		return
+	}
+	n := len(w.frames)
+	if n == 0 || !w.frames[n-1].isList {
+		w.fail("EndArray without matching BeginArray")
+		return
+	}
+	f := &w.frames[n-1]
+	node, l := f.node, f.levels
+	if f.elems == 0 {
+		// typed_value present but the list is empty: every leaf records
+		// the list's definition level.
+		t := node.typed
+		w.writeNulls(t.startCol, t.startCol+t.numCols, l.def(t.defLevel), l.rep)
+	}
+	if node.valueCol >= 0 {
+		w.leaf(node.valueCol).writeNull(w.levels(l.def(node.defLevel), l.rep))
+	}
+	w.frames = w.frames[:n-1]
+	w.valueDone()
+}
+
+func (w *VariantColumnWriter) pushFrame(node *shreddedVariantGroup, isList bool, l shredLevels) {
+	if len(w.frames) < cap(w.frames) {
+		w.frames = w.frames[:len(w.frames)+1]
+	} else {
+		w.frames = append(w.frames, variantWriterFrame{})
+	}
+	f := &w.frames[len(w.frames)-1]
+	f.node = node
+	f.isList = isList
+	f.levels = l
+	f.partial = nil
+	f.elems = 0
+	if !isList {
+		numFields := len(node.typed.fields)
+		if cap(f.seen) < numFields {
+			f.seen = make([]bool, numFields)
+		} else {
+			f.seen = f.seen[:numFields]
+			clear(f.seen)
+		}
+	}
+}
+
+// The scalar event methods below write one scalar value at the current
+// position: the row's value, the current object field, or the next array
+// element. A scalar matching the position's shredded type goes to its
+// typed_value column; any other scalar encodes into the value column.
+
+// Null writes the variant null value (distinct from a missing field and
+// from a SQL null row; see WriteNullRow). Variant null never matches a
+// shredded type: it encodes into the position's value column, or fails the
+// row when the position is shredded without one.
+func (w *VariantColumnWriter) Null() {
+	if w.forward() {
+		w.residual.b.Null()
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Null())
+}
+
+func (w *VariantColumnWriter) Bool(v bool) {
+	if w.forward() {
+		w.residual.b.Bool(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Bool(v))
+}
+
+func (w *VariantColumnWriter) Int8(v int8) {
+	if w.forward() {
+		w.residual.b.Int8(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Int8(v))
+}
+
+func (w *VariantColumnWriter) Int16(v int16) {
+	if w.forward() {
+		w.residual.b.Int16(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Int16(v))
+}
+
+func (w *VariantColumnWriter) Int32(v int32) {
+	if w.forward() {
+		w.residual.b.Int32(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Int32(v))
+}
+
+func (w *VariantColumnWriter) Int64(v int64) {
+	if w.forward() {
+		w.residual.b.Int64(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Int64(v))
+}
+
+func (w *VariantColumnWriter) Float(v float32) {
+	if w.forward() {
+		w.residual.b.Float(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Float(v))
+}
+
+func (w *VariantColumnWriter) Double(v float64) {
+	if w.forward() {
+		w.residual.b.Double(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Double(v))
+}
+
+func (w *VariantColumnWriter) String(v string) {
+	if w.forward() {
+		w.residual.b.String(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.String(v))
+}
+
+func (w *VariantColumnWriter) Binary(v []byte) {
+	if w.forward() {
+		w.residual.b.Binary(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Binary(v))
+}
+
+func (w *VariantColumnWriter) Date(days int32) {
+	if w.forward() {
+		w.residual.b.Date(days)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Date(days))
+}
+
+func (w *VariantColumnWriter) Time(micros int64) {
+	if w.forward() {
+		w.residual.b.Time(micros)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Time(micros))
+}
+
+func (w *VariantColumnWriter) Timestamp(micros int64) {
+	if w.forward() {
+		w.residual.b.Timestamp(micros)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Timestamp(micros))
+}
+
+func (w *VariantColumnWriter) TimestampNTZ(micros int64) {
+	if w.forward() {
+		w.residual.b.TimestampNTZ(micros)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.TimestampNTZ(micros))
+}
+
+func (w *VariantColumnWriter) TimestampNanos(nanos int64) {
+	if w.forward() {
+		w.residual.b.TimestampNanos(nanos)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.TimestampNanos(nanos))
+}
+
+func (w *VariantColumnWriter) TimestampNTZNanos(nanos int64) {
+	if w.forward() {
+		w.residual.b.TimestampNTZNanos(nanos)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.TimestampNTZNanos(nanos))
+}
+
+func (w *VariantColumnWriter) UUID(v uuid.UUID) {
+	if w.forward() {
+		w.residual.b.UUID(v)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.UUID(v))
+}
+
+func (w *VariantColumnWriter) Decimal4(unscaled int32, scale byte) {
+	if w.forward() {
+		w.residual.b.Decimal4(unscaled, scale)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Decimal4(unscaled, scale))
+}
+
+func (w *VariantColumnWriter) Decimal8(unscaled int64, scale byte) {
+	if w.forward() {
+		w.residual.b.Decimal8(unscaled, scale)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Decimal8(unscaled, scale))
+}
+
+func (w *VariantColumnWriter) Decimal16(unscaled [16]byte, scale byte) {
+	if w.forward() {
+		w.residual.b.Decimal16(unscaled, scale)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(variant.Decimal16(unscaled, scale))
+}
+
+var _ variant.ValueWriter = (*VariantColumnWriter)(nil)

--- a/variant_column_writer.go
+++ b/variant_column_writer.go
@@ -568,15 +568,16 @@ func (w *VariantColumnWriter) Field(name string) {
 // schema and its metadata dictionary intern, so hot ingest loops writing
 // the same fields on every row skip the per-event name hashing of Field.
 //
-// A ref belongs to the writer that created it and caches its resolution
-// against one object position at a time: use one ref per writer per field
-// name, and prefer distinct refs for identically named fields of different
-// objects.
+// A ref caches its resolution against one writer and one object position at
+// a time, so any use is correct, but for peak performance use one ref per
+// writer per field name, with distinct refs for identically named fields of
+// different objects.
 type VariantFieldRef struct {
 	name    string
 	node    *shreddedVariantGroup // object node the ref last resolved against
 	idx     int                   // field index in node, -1 when not shredded
-	metaGen uint64                // 1+dictionary generation of the cached intern
+	metaFor *VariantColumnWriter  // writer whose dictionary holds the cached intern
+	metaGen uint64                // dictionary generation of the cached intern
 }
 
 // FieldRef pre-resolves an object field name for use with FieldByRef. The
@@ -595,9 +596,10 @@ func (w *VariantColumnWriter) FieldByRef(ref *VariantFieldRef) {
 	if f == nil {
 		return
 	}
-	if ref.metaGen != w.metaGen+1 {
+	if ref.metaFor != w || ref.metaGen != w.metaGen {
 		w.meta.Add(ref.name)
-		ref.metaGen = w.metaGen + 1
+		ref.metaFor = w
+		ref.metaGen = w.metaGen
 	}
 	if ref.node != f.node {
 		ref.node = f.node

--- a/variant_column_writer.go
+++ b/variant_column_writer.go
@@ -23,19 +23,10 @@ import (
 // e.g. JSON into a shredded variant column runs allocation-free per row once
 // the writer's buffers are warm.
 //
-// The shredding semantics are identical to the row path (both follow the
-// case tables of the Variant Shredding specification and share
-// variantToParquetValue and the shreddedVariantGroup tree):
-//
-//   - Scalars that exactly match the shredded type go into typed_value with
-//     a null value column; mismatches are encoded into the value column.
-//   - Objects shred field-wise when the position is shredded as an object:
-//     shredded fields descend, missing shredded fields write nulls,
-//     non-shredded fields stream into a partial-object residual.
-//   - Arrays shred element-wise through the 3-level LIST structure when the
-//     position is shredded as a list.
-//   - All object field names of the row, shredded or not, are interned into
-//     the row's metadata dictionary (as VariantShredding.md requires).
+// The shredding semantics are identical to the row path: both follow the
+// case tables of the Variant Shredding specification (summarized at the top
+// of variant_shredded_write.go) and share variantToParquetValue and the
+// shreddedVariantGroup tree.
 
 // VariantColumnWriter writes one VARIANT column of a parquet file in
 // streaming, columnar form. It implements variant.ValueWriter: each row is
@@ -71,7 +62,6 @@ type VariantColumnWriter struct {
 	groupDef int  // definition level at which the variant group is present
 	optional bool // whether the variant group node itself is optional
 	columns  []*ColumnWriter
-	types    []Type // leaf types, indexed by relative column
 
 	// rootValueRequired is set for plain unshredded variant groups, whose
 	// value field is required rather than optional.
@@ -88,15 +78,14 @@ type VariantColumnWriter struct {
 
 	// Row state. cur is the shredded node awaiting a value event, nil when
 	// no value is expected (inside an object before a Field call, or after
-	// the row's value completed). frames tracks open shredded containers,
-	// residual an active residual stream.
-	inRow       bool
-	rowHasValue bool
-	cur         *shreddedVariantGroup
-	curLevels   shredLevels
-	frames      []variantWriterFrame
-	residual    variantResidualState
-	err         error
+	// the row's value completed). frames tracks open shredded containers;
+	// residual tracks an active residual stream.
+	inRow     bool
+	cur       *shreddedVariantGroup
+	curLevels shredLevels
+	frames    []variantWriterFrame
+	residual  variantResidualState
+	err       error
 }
 
 // variantWriterFrame is one open shredded container (an object or list
@@ -140,83 +129,29 @@ var (
 // unshredded (metadata, value) or shredded (metadata, value, typed_value)
 // in any shape permitted by the Variant Shredding specification.
 func NewVariantColumnWriter(w VariantWriterTarget, path ...string) (*VariantColumnWriter, error) {
-	if len(path) == 0 {
-		return nil, fmt.Errorf("variant: NewVariantColumnWriter requires a column path")
-	}
 	schema := w.Schema()
 	if schema == nil {
 		return nil, fmt.Errorf("variant: the writer has no schema configured")
 	}
-	node := Node(schema)
-	def := 0
-	col := 0
-	optional := false
-	for _, name := range path {
-		if node.Leaf() {
-			return nil, fmt.Errorf("variant: column %q not found: %q is a leaf", joinPath(path), name)
-		}
-		var next Node
-		for _, f := range node.Fields() {
-			if f.Name() == name {
-				next = f
-				break
-			}
-			col += int(numLeafColumnsOf(f))
-		}
-		if next == nil {
-			return nil, fmt.Errorf("variant: column %q not found: no field %q", joinPath(path), name)
-		}
-		if next.Repeated() {
-			return nil, fmt.Errorf("variant: column %q is beneath a repeated field, which VariantColumnWriter does not support", joinPath(path))
-		}
-		optional = next.Optional()
-		if optional {
-			def++
-		}
-		node = next
-	}
-	if node.Leaf() {
-		return nil, fmt.Errorf("variant: column %q is not a variant group", joinPath(path))
-	}
-
-	group, err := buildShreddedVariantGroup(node, 0, 0, 0)
-	valueRequired := false
+	info, err := resolveVariantColumn(schema, path)
 	if err != nil {
-		// Plain unshredded variant groups declare "required binary value"
-		// (VariantEncoding.md), which the shredded-schema validation
-		// rejects; accept that shape here.
-		if g, ok := unshreddedVariantGroupOf(node); ok {
-			group, valueRequired = g, true
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
-	if group.metadataCol < 0 {
-		return nil, fmt.Errorf("variant: column %q has no metadata field", joinPath(path))
-	}
+	group := info.group
 
 	columnWriters := w.ColumnWriters()
-	if col+group.numCols > len(columnWriters) {
-		return nil, fmt.Errorf("variant: column %q spans columns [%d, %d) but the writer has %d", joinPath(path), col, col+group.numCols, len(columnWriters))
+	if info.col+group.numCols > len(columnWriters) {
+		return nil, fmt.Errorf("variant: column %q spans columns [%d, %d) but the writer has %d", joinPath(path), info.col, info.col+group.numCols, len(columnWriters))
 	}
 
-	vw := &VariantColumnWriter{
+	return &VariantColumnWriter{
 		group:             group,
-		groupDef:          def,
-		optional:          optional,
-		columns:           columnWriters[col : col+group.numCols],
-		types:             make([]Type, group.numCols),
-		rootValueRequired: valueRequired,
+		groupDef:          info.def,
+		optional:          info.optional,
+		columns:           columnWriters[info.col : info.col+group.numCols],
+		rootValueRequired: info.valueRequired,
 		builders:          make(map[*shreddedVariantGroup]*variant.Builder),
-	}
-	i := 0
-	forEachLeafColumnOf(node, func(leaf leafColumn) {
-		if i < len(vw.types) {
-			vw.types[i] = leaf.node.Type()
-		}
-		i++
-	})
-	return vw, nil
+	}, nil
 }
 
 // Err returns the first error encountered, or nil.
@@ -253,7 +188,6 @@ func (w *VariantColumnWriter) BeginRow() error {
 		return w.err
 	}
 	w.inRow = true
-	w.rowHasValue = false
 	w.cur = w.group
 	w.curLevels = shredLevels{baseDef: w.groupDef}
 	if w.meta.Size() > variantMetadataResetSize {
@@ -273,7 +207,9 @@ func (w *VariantColumnWriter) EndRow() error {
 	if w.err == nil && (w.residual.b != nil || len(w.frames) > 0) {
 		w.fail("EndRow with an unclosed object or array")
 	}
-	if w.err == nil && !w.rowHasValue {
+	// With no open frames or residual, cur still set means the row's value
+	// never arrived (valueDone clears it when the value completes).
+	if w.err == nil && w.cur != nil {
 		w.fail("EndRow without a value; use WriteNullRow for SQL null rows")
 	}
 	if w.err != nil {
@@ -449,8 +385,6 @@ func (w *VariantColumnWriter) valueDone() {
 			w.curLevels = f.levels
 			w.curLevels.rep = byte(f.levels.baseRep + f.node.typed.element.repDepth)
 		}
-	} else {
-		w.rowHasValue = true
 	}
 }
 
@@ -516,7 +450,7 @@ func (w *VariantColumnWriter) scalar(v variant.Value) {
 	}
 	l := w.curLevels
 	if t := node.typed; t != nil && t.kind == shreddedTypedPrimitive {
-		if pv, ok := variantToParquetValue(v, w.types[t.startCol]); ok {
+		if pv, ok := variantToParquetValue(v, t.typ); ok {
 			w.writeTyped(t.startCol, pv, l.def(t.defLevel), l.rep)
 			if node.valueCol >= 0 {
 				w.leaf(node.valueCol).writeNull(w.levels(l.def(node.defLevel), l.rep))
@@ -607,19 +541,14 @@ func (w *VariantColumnWriter) Field(name string) {
 	w.beginField(f, name, idx)
 }
 
-// VariantFieldRef is a pre-resolved object field name for FieldByRef. In
-// steady state a ref caches both the field's position in the shredded
-// schema and its metadata dictionary intern, so hot ingest loops writing
-// the same fields on every row skip the per-event name hashing of Field.
-//
-// FieldByRef rewrites the ref's cache (which also retains the last writer
-// it resolved against), so a ref must not be used by multiple goroutines
-// concurrently: writers running in parallel, e.g. one per
-// ConcurrentRowGroupWriter goroutine, each need their own refs. Within one
-// goroutine any use is correct — the cache re-resolves whenever the writer
-// or object position changes — but for peak performance use one ref per
-// writer per field name, with distinct refs for identically named fields
-// of different objects.
+// VariantFieldRef is a pre-resolved object field name for FieldByRef: a ref
+// caches its resolution (shredded position and metadata intern) against the
+// last writer and object it was used with, so hot ingest loops writing the
+// same fields on every row skip the per-event name hashing of Field. The
+// cache re-resolves whenever the writer or object position changes, but
+// FieldByRef mutates it, so a ref must not be used by multiple goroutines
+// concurrently — for concurrency and peak performance use one ref per
+// writer per field.
 type VariantFieldRef struct {
 	name    string
 	node    *shreddedVariantGroup // object node the ref last resolved against
@@ -859,6 +788,17 @@ func (w *VariantColumnWriter) pushFrame(node *shreddedVariantGroup, isList bool,
 	}
 }
 
+// scalarEvent handles one scalar event: forwarded into an active residual
+// stream, or shredded at the current position.
+func (w *VariantColumnWriter) scalarEvent(v variant.Value) {
+	if w.forward() {
+		v.Write(w.residual.b)
+		w.afterResidualScalar()
+		return
+	}
+	w.scalar(v)
+}
+
 // The scalar event methods below write one scalar value at the current
 // position: the row's value, the current object field, or the next array
 // element. A scalar matching the position's shredded type goes to its
@@ -868,184 +808,37 @@ func (w *VariantColumnWriter) pushFrame(node *shreddedVariantGroup, isList bool,
 // from a SQL null row; see WriteNullRow). Variant null never matches a
 // shredded type: it encodes into the position's value column, or fails the
 // row when the position is shredded without one.
-func (w *VariantColumnWriter) Null() {
-	if w.forward() {
-		w.residual.b.Null()
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Null())
+func (w *VariantColumnWriter) Null()              { w.scalarEvent(variant.Null()) }
+func (w *VariantColumnWriter) Bool(v bool)        { w.scalarEvent(variant.Bool(v)) }
+func (w *VariantColumnWriter) Int8(v int8)        { w.scalarEvent(variant.Int8(v)) }
+func (w *VariantColumnWriter) Int16(v int16)      { w.scalarEvent(variant.Int16(v)) }
+func (w *VariantColumnWriter) Int32(v int32)      { w.scalarEvent(variant.Int32(v)) }
+func (w *VariantColumnWriter) Int64(v int64)      { w.scalarEvent(variant.Int64(v)) }
+func (w *VariantColumnWriter) Float(v float32)    { w.scalarEvent(variant.Float(v)) }
+func (w *VariantColumnWriter) Double(v float64)   { w.scalarEvent(variant.Double(v)) }
+func (w *VariantColumnWriter) String(v string)    { w.scalarEvent(variant.String(v)) }
+func (w *VariantColumnWriter) Binary(v []byte)    { w.scalarEvent(variant.Binary(v)) }
+func (w *VariantColumnWriter) Date(days int32)    { w.scalarEvent(variant.Date(days)) }
+func (w *VariantColumnWriter) Time(micros int64)  { w.scalarEvent(variant.Time(micros)) }
+func (w *VariantColumnWriter) UUID(v uuid.UUID)   { w.scalarEvent(variant.UUID(v)) }
+func (w *VariantColumnWriter) Timestamp(us int64) { w.scalarEvent(variant.Timestamp(us)) }
+func (w *VariantColumnWriter) TimestampNTZ(us int64) {
+	w.scalarEvent(variant.TimestampNTZ(us))
 }
-
-func (w *VariantColumnWriter) Bool(v bool) {
-	if w.forward() {
-		w.residual.b.Bool(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Bool(v))
+func (w *VariantColumnWriter) TimestampNanos(ns int64) {
+	w.scalarEvent(variant.TimestampNanos(ns))
 }
-
-func (w *VariantColumnWriter) Int8(v int8) {
-	if w.forward() {
-		w.residual.b.Int8(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Int8(v))
+func (w *VariantColumnWriter) TimestampNTZNanos(ns int64) {
+	w.scalarEvent(variant.TimestampNTZNanos(ns))
 }
-
-func (w *VariantColumnWriter) Int16(v int16) {
-	if w.forward() {
-		w.residual.b.Int16(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Int16(v))
-}
-
-func (w *VariantColumnWriter) Int32(v int32) {
-	if w.forward() {
-		w.residual.b.Int32(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Int32(v))
-}
-
-func (w *VariantColumnWriter) Int64(v int64) {
-	if w.forward() {
-		w.residual.b.Int64(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Int64(v))
-}
-
-func (w *VariantColumnWriter) Float(v float32) {
-	if w.forward() {
-		w.residual.b.Float(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Float(v))
-}
-
-func (w *VariantColumnWriter) Double(v float64) {
-	if w.forward() {
-		w.residual.b.Double(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Double(v))
-}
-
-func (w *VariantColumnWriter) String(v string) {
-	if w.forward() {
-		w.residual.b.String(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.String(v))
-}
-
-func (w *VariantColumnWriter) Binary(v []byte) {
-	if w.forward() {
-		w.residual.b.Binary(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Binary(v))
-}
-
-func (w *VariantColumnWriter) Date(days int32) {
-	if w.forward() {
-		w.residual.b.Date(days)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Date(days))
-}
-
-func (w *VariantColumnWriter) Time(micros int64) {
-	if w.forward() {
-		w.residual.b.Time(micros)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Time(micros))
-}
-
-func (w *VariantColumnWriter) Timestamp(micros int64) {
-	if w.forward() {
-		w.residual.b.Timestamp(micros)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Timestamp(micros))
-}
-
-func (w *VariantColumnWriter) TimestampNTZ(micros int64) {
-	if w.forward() {
-		w.residual.b.TimestampNTZ(micros)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.TimestampNTZ(micros))
-}
-
-func (w *VariantColumnWriter) TimestampNanos(nanos int64) {
-	if w.forward() {
-		w.residual.b.TimestampNanos(nanos)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.TimestampNanos(nanos))
-}
-
-func (w *VariantColumnWriter) TimestampNTZNanos(nanos int64) {
-	if w.forward() {
-		w.residual.b.TimestampNTZNanos(nanos)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.TimestampNTZNanos(nanos))
-}
-
-func (w *VariantColumnWriter) UUID(v uuid.UUID) {
-	if w.forward() {
-		w.residual.b.UUID(v)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.UUID(v))
-}
-
 func (w *VariantColumnWriter) Decimal4(unscaled int32, scale byte) {
-	if w.forward() {
-		w.residual.b.Decimal4(unscaled, scale)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Decimal4(unscaled, scale))
+	w.scalarEvent(variant.Decimal4(unscaled, scale))
 }
-
 func (w *VariantColumnWriter) Decimal8(unscaled int64, scale byte) {
-	if w.forward() {
-		w.residual.b.Decimal8(unscaled, scale)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Decimal8(unscaled, scale))
+	w.scalarEvent(variant.Decimal8(unscaled, scale))
 }
-
 func (w *VariantColumnWriter) Decimal16(unscaled [16]byte, scale byte) {
-	if w.forward() {
-		w.residual.b.Decimal16(unscaled, scale)
-		w.afterResidualScalar()
-		return
-	}
-	w.scalar(variant.Decimal16(unscaled, scale))
+	w.scalarEvent(variant.Decimal16(unscaled, scale))
 }
 
 var _ variant.ValueWriter = (*VariantColumnWriter)(nil)

--- a/variant_column_writer.go
+++ b/variant_column_writer.go
@@ -13,7 +13,7 @@ import (
 //
 // Unlike the row-based write path (column_buffer_variant.go) — which decodes
 // each row into a variant.Value tree and shreds the tree — VariantColumnWriter
-// consumes variant.ValueWriter events and shreds them as they arrive: values
+// consumes variant.ValueBuilder events and shreds them as they arrive: values
 // matching the shredded type are appended directly to the typed_value column
 // buffers, and everything else is encoded to variant binary residuals with a
 // streaming variant.Builder. All rows share one metadata dictionary (reset
@@ -29,10 +29,10 @@ import (
 // shreddedVariantGroup tree.
 
 // VariantColumnWriter writes one VARIANT column of a parquet file in
-// streaming, columnar form. It implements variant.ValueWriter: each row is
+// streaming, columnar form. It implements variant.ValueBuilder: each row is
 // bracketed by BeginRow and EndRow, and the row's value is described by the
 // event methods in between, following the event-sequence rules documented
-// on variant.ValueWriter. WriteValue and WriteNullRow are row-level
+// on variant.ValueBuilder. WriteValue and WriteNullRow are row-level
 // conveniences. String and []byte event arguments, and Field names, are
 // copied; callers may reuse their backing memory after the call returns.
 //
@@ -109,18 +109,18 @@ type variantResidualState struct {
 	base   int
 }
 
-// VariantWriterTarget is the writer surface VariantColumnWriter binds to;
+// WriterTarget is the writer surface VariantColumnWriter binds to;
 // it is satisfied by *Writer, *GenericWriter[T], and
 // *ConcurrentRowGroupWriter.
-type VariantWriterTarget interface {
+type WriterTarget interface {
 	Schema() *Schema
 	ColumnWriters() []*ColumnWriter
 }
 
 var (
-	_ VariantWriterTarget = (*Writer)(nil)
-	_ VariantWriterTarget = (*GenericWriter[any])(nil)
-	_ VariantWriterTarget = (*ConcurrentRowGroupWriter)(nil)
+	_ WriterTarget = (*Writer)(nil)
+	_ WriterTarget = (*GenericWriter[any])(nil)
+	_ WriterTarget = (*ConcurrentRowGroupWriter)(nil)
 )
 
 // NewVariantColumnWriter returns a streaming columnar writer for the VARIANT
@@ -128,7 +128,7 @@ var (
 // column, "attrs", "v" for one nested in a group). The column may be
 // unshredded (metadata, value) or shredded (metadata, value, typed_value)
 // in any shape permitted by the Variant Shredding specification.
-func NewVariantColumnWriter(w VariantWriterTarget, path ...string) (*VariantColumnWriter, error) {
+func NewVariantColumnWriter(w WriterTarget, path ...string) (*VariantColumnWriter, error) {
 	schema := w.Schema()
 	if schema == nil {
 		return nil, fmt.Errorf("variant: the writer has no schema configured")
@@ -841,4 +841,4 @@ func (w *VariantColumnWriter) Decimal16(unscaled [16]byte, scale byte) {
 	w.scalarEvent(variant.Decimal16(unscaled, scale))
 }
 
-var _ variant.ValueWriter = (*VariantColumnWriter)(nil)
+var _ variant.ValueBuilder = (*VariantColumnWriter)(nil)

--- a/variant_column_writer.go
+++ b/variant_column_writer.go
@@ -535,17 +535,15 @@ func (w *VariantColumnWriter) Field(name string) {
 	// present in the metadata dictionary.
 	w.meta.Add(name)
 	node := f.node
-	for i := range node.typed.fields {
-		if node.typed.fields[i].name == name {
-			if f.seen[i] {
-				w.fail("duplicate object field %q", name)
-				return
-			}
-			f.seen[i] = true
-			w.cur = node.typed.fields[i].group
-			w.curLevels = f.levels
+	if i, ok := node.typed.index[name]; ok {
+		if f.seen[i] {
+			w.fail("duplicate object field %q", name)
 			return
 		}
+		f.seen[i] = true
+		w.cur = node.typed.fields[i].group
+		w.curLevels = f.levels
+		return
 	}
 	// Not a shredded field: it goes into the partial-object residual.
 	if f.partial == nil {

--- a/variant_column_writer.go
+++ b/variant_column_writer.go
@@ -2,6 +2,7 @@ package parquet
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/google/uuid"
@@ -46,7 +47,10 @@ import (
 //
 // The writer appends to the column buffers of the ColumnWriters backing the
 // variant column's leaf columns and flushes full pages at row boundaries,
-// like ColumnWriter.WriteRowValues. Other columns of the file must be
+// like ColumnWriter.WriteRowValues. To keep row boundaries cheap the
+// page-size check is polled every few rows while the buffers are under half
+// the configured page size (and every row past that), so pages may
+// moderately overshoot the configured size. Other columns of the file must be
 // written separately (e.g. through Writer.ColumnWriters) with the same
 // number of rows, and the parent writer must be closed (or its row group
 // committed) as usual to flush buffered sub-page data to the file.
@@ -233,8 +237,8 @@ func (w *VariantColumnWriter) fail(format string, args ...any) {
 const variantMetadataResetSize = 4096
 
 // variantFlushCheckRows is how many rows may pass between page-size checks
-// of the variant group's columns. Pages can overshoot the configured buffer
-// size by up to this many rows of values.
+// of the variant group's columns while every column is under half its
+// buffer size; past half, flush checks every row.
 const variantFlushCheckRows = 16
 
 // BeginRow starts a new row. Exactly one value — a single scalar event, or
@@ -273,6 +277,14 @@ func (w *VariantColumnWriter) EndRow() error {
 		w.fail("EndRow without a value; use WriteNullRow for SQL null rows")
 	}
 	if w.err != nil {
+		return w.err
+	}
+	// Dictionary offsets are at most 4 bytes wide; AppendTo would silently
+	// truncate a larger dictionary. Only reachable when a single row
+	// interns over 4 GiB of unique field names, since BeginRow resets the
+	// dictionary at variantMetadataResetSize.
+	if uint64(w.meta.Size()) > math.MaxUint32 {
+		w.fail("metadata dictionary of %d bytes exceeds the variant format's 4 GiB limit", w.meta.Size())
 		return w.err
 	}
 	w.metaBuf = w.meta.AppendTo(w.metaBuf[:0])
@@ -333,8 +345,10 @@ func (w *VariantColumnWriter) levels(def, rep byte) columnLevels {
 }
 
 // flush flushes any column whose buffer reached the configured page size.
-// It only runs at row boundaries, since a row cannot span two pages, and
-// polls the column sizes every variantFlushCheckRows rows.
+// It only runs at row boundaries, since a row cannot span two pages. While
+// every column is under half its buffer size the poll is spaced out to
+// every variantFlushCheckRows rows; once any column crosses half, it runs
+// every row so a page cannot silently overshoot by many large rows.
 func (w *VariantColumnWriter) flush() error {
 	if w.flushCountdown > 0 {
 		w.flushCountdown--
@@ -342,11 +356,16 @@ func (w *VariantColumnWriter) flush() error {
 	}
 	w.flushCountdown = variantFlushCheckRows - 1
 	for _, c := range w.columns {
-		if c.columnBuffer != nil && c.columnBuffer.Size() >= int64(c.bufferSize) {
+		if c.columnBuffer == nil {
+			continue
+		}
+		if size := c.columnBuffer.Size(); size >= int64(c.bufferSize) {
 			if err := c.Flush(); err != nil {
 				w.err = err
 				return err
 			}
+		} else if size >= int64(c.bufferSize)/2 {
+			w.flushCountdown = 0
 		}
 	}
 	return nil
@@ -440,6 +459,20 @@ func (w *VariantColumnWriter) forward() bool {
 	return w.err == nil && w.residual.b != nil
 }
 
+// checkResidual surfaces an error the residual builder recorded from a
+// forwarded event (misuse of the event sequence, an oversized value) as the
+// writer's error, so it is reported at the offending event rather than when
+// the residual is committed. It reports whether the residual is healthy.
+func (w *VariantColumnWriter) checkResidual() bool {
+	if err := w.residual.b.Err(); err != nil {
+		if w.err == nil {
+			w.err = err
+		}
+		return false
+	}
+	return true
+}
+
 // residualDone finalizes a completed residual stream.
 func (w *VariantColumnWriter) residualDone() {
 	r := w.residual
@@ -455,10 +488,16 @@ func (w *VariantColumnWriter) residualDone() {
 		return
 	}
 	w.writeResidualBytes(r.node, r.levels, data)
+	if w.err != nil {
+		return
+	}
 	w.valueDone()
 }
 
 func (w *VariantColumnWriter) afterResidualScalar() {
+	if !w.checkResidual() {
+		return
+	}
 	if w.residual.depth == w.residual.base {
 		w.residualDone()
 	}
@@ -494,6 +533,9 @@ func (w *VariantColumnWriter) scalar(v variant.Value) {
 		return
 	}
 	w.writeResidualBytes(node, l, data)
+	if w.err != nil {
+		return
+	}
 	if node.typed != nil {
 		w.writeNulls(node.typed.startCol, node.typed.startCol+node.typed.numCols, l.def(node.defLevel), l.rep)
 	}
@@ -519,6 +561,7 @@ func (w *VariantColumnWriter) BeginObject() {
 	if w.forward() {
 		w.residual.b.BeginObject()
 		w.residual.depth++
+		w.checkResidual()
 		return
 	}
 	if w.err != nil {
@@ -547,6 +590,7 @@ func (w *VariantColumnWriter) BeginObject() {
 func (w *VariantColumnWriter) Field(name string) {
 	if w.forward() {
 		w.residual.b.Field(name)
+		w.checkResidual()
 		return
 	}
 	f := w.fieldFrame(name)
@@ -568,10 +612,14 @@ func (w *VariantColumnWriter) Field(name string) {
 // schema and its metadata dictionary intern, so hot ingest loops writing
 // the same fields on every row skip the per-event name hashing of Field.
 //
-// A ref caches its resolution against one writer and one object position at
-// a time, so any use is correct, but for peak performance use one ref per
-// writer per field name, with distinct refs for identically named fields of
-// different objects.
+// FieldByRef rewrites the ref's cache (which also retains the last writer
+// it resolved against), so a ref must not be used by multiple goroutines
+// concurrently: writers running in parallel, e.g. one per
+// ConcurrentRowGroupWriter goroutine, each need their own refs. Within one
+// goroutine any use is correct — the cache re-resolves whenever the writer
+// or object position changes — but for peak performance use one ref per
+// writer per field name, with distinct refs for identically named fields
+// of different objects.
 type VariantFieldRef struct {
 	name    string
 	node    *shreddedVariantGroup // object node the ref last resolved against
@@ -580,16 +628,19 @@ type VariantFieldRef struct {
 	metaGen uint64                // dictionary generation of the cached intern
 }
 
-// FieldRef pre-resolves an object field name for use with FieldByRef. The
-// name is copied; the caller may reuse its backing memory.
-func (w *VariantColumnWriter) FieldRef(name string) *VariantFieldRef {
+// NewVariantFieldRef pre-resolves an object field name for use with
+// VariantColumnWriter.FieldByRef. The name is copied; the caller may reuse
+// its backing memory. The ref is not bound to any writer: resolution is
+// cached lazily by FieldByRef.
+func NewVariantFieldRef(name string) *VariantFieldRef {
 	return &VariantFieldRef{name: strings.Clone(name)}
 }
 
-// FieldByRef is Field with a pre-resolved name; see FieldRef.
+// FieldByRef is Field with a pre-resolved name; see NewVariantFieldRef.
 func (w *VariantColumnWriter) FieldByRef(ref *VariantFieldRef) {
 	if w.forward() {
 		w.residual.b.Field(ref.name)
+		w.checkResidual()
 		return
 	}
 	f := w.fieldFrame(ref.name)
@@ -644,6 +695,10 @@ func (w *VariantColumnWriter) beginField(f *variantWriterFrame, name string, idx
 		return
 	}
 	// Not a shredded field: it goes into the partial-object residual.
+	if f.node.valueCol < 0 {
+		w.fail("object field %q is not in the shredded schema and the object has no value column to hold it", name)
+		return
+	}
 	if f.partial == nil {
 		f.partial = w.builder(f.node)
 		f.partial.BeginObject()
@@ -657,9 +712,17 @@ func (w *VariantColumnWriter) beginField(f *variantWriterFrame, name string, idx
 // any, to the object's value column.
 func (w *VariantColumnWriter) EndObject() {
 	if w.forward() {
+		if w.residual.depth == w.residual.base {
+			// Only reachable in a partial-object residual, right after a
+			// Field: the event tries to close the enclosing shredded
+			// object while the field's value is still pending. Fail here
+			// rather than corrupting the residual's depth tracking.
+			w.fail("EndObject: last field has no value")
+			return
+		}
 		w.residual.b.EndObject()
 		w.residual.depth--
-		if w.residual.depth == w.residual.base {
+		if w.checkResidual() && w.residual.depth == w.residual.base {
 			w.residualDone()
 		}
 		return
@@ -706,6 +769,7 @@ func (w *VariantColumnWriter) BeginArray() {
 	if w.forward() {
 		w.residual.b.BeginArray()
 		w.residual.depth++
+		w.checkResidual()
 		return
 	}
 	if w.err != nil {
@@ -735,9 +799,16 @@ func (w *VariantColumnWriter) BeginArray() {
 // EndArray closes the innermost open array.
 func (w *VariantColumnWriter) EndArray() {
 	if w.forward() {
+		if w.residual.depth == w.residual.base {
+			// See the matching guard in EndObject; here the enclosing
+			// container is an object, so the array being closed was never
+			// opened.
+			w.fail("EndArray without matching BeginArray")
+			return
+		}
 		w.residual.b.EndArray()
 		w.residual.depth--
-		if w.residual.depth == w.residual.base {
+		if w.checkResidual() && w.residual.depth == w.residual.base {
 			w.residualDone()
 		}
 		return

--- a/variant_column_writer.go
+++ b/variant_column_writer.go
@@ -2,6 +2,7 @@ package parquet
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/parquet-go/parquet-go/variant"
@@ -14,7 +15,9 @@ import (
 // consumes variant.ValueWriter events and shreds them as they arrive: values
 // matching the shredded type are appended directly to the typed_value column
 // buffers, and everything else is encoded to variant binary residuals with a
-// streaming variant.Builder, sharing one metadata dictionary per row. No
+// streaming variant.Builder. All rows share one metadata dictionary (reset
+// only when it outgrows a bound), so a stable field set interns each name
+// once and every row writes byte-identical metadata. No
 // intermediate tree, map, or []parquet.Value is ever built, so transcoding
 // e.g. JSON into a shredded variant column runs allocation-free per row once
 // the writer's buffers are warm.
@@ -71,8 +74,13 @@ type VariantColumnWriter struct {
 	rootValueRequired bool
 
 	meta     variant.MetadataBuilder
+	metaGen  uint64 // bumped when meta resets; invalidates VariantFieldRef interns
 	metaBuf  []byte
 	builders map[*shreddedVariantGroup]*variant.Builder
+
+	// flushCountdown spaces out the page-size scan of flush, which is
+	// O(columns) and dominates wide schemas when run every row.
+	flushCountdown int
 
 	// Row state. cur is the shredded node awaiting a value event, nil when
 	// no value is expected (inside an object before a Field call, or after
@@ -216,6 +224,19 @@ func (w *VariantColumnWriter) fail(format string, args ...any) {
 	}
 }
 
+// variantMetadataResetSize bounds the interned name bytes of the writer's
+// metadata dictionary. The dictionary persists across rows so that a stable
+// field set interns each name once and every row writes byte-identical
+// metadata (which encodes and compresses well); the bound keeps workloads
+// with unbounded field-name churn from bloating every row's metadata with
+// names of earlier rows.
+const variantMetadataResetSize = 4096
+
+// variantFlushCheckRows is how many rows may pass between page-size checks
+// of the variant group's columns. Pages can overshoot the configured buffer
+// size by up to this many rows of values.
+const variantFlushCheckRows = 16
+
 // BeginRow starts a new row. Exactly one value — a single scalar event, or
 // a single balanced object or array — must be written before the matching
 // EndRow.
@@ -231,12 +252,16 @@ func (w *VariantColumnWriter) BeginRow() error {
 	w.rowHasValue = false
 	w.cur = w.group
 	w.curLevels = shredLevels{baseDef: w.groupDef}
-	w.meta.Reset()
+	if w.meta.Size() > variantMetadataResetSize {
+		w.meta.Reset()
+		w.metaGen++
+	}
 	return nil
 }
 
 // EndRow completes the current row: it writes the row's metadata dictionary
-// and flushes any column whose buffered page reached the writer's page size.
+// and periodically flushes columns whose buffered page reached the writer's
+// page size.
 func (w *VariantColumnWriter) EndRow() error {
 	if w.err == nil && !w.inRow {
 		w.fail("EndRow outside of a row")
@@ -308,8 +333,14 @@ func (w *VariantColumnWriter) levels(def, rep byte) columnLevels {
 }
 
 // flush flushes any column whose buffer reached the configured page size.
-// It only runs at row boundaries, since a row cannot span two pages.
+// It only runs at row boundaries, since a row cannot span two pages, and
+// polls the column sizes every variantFlushCheckRows rows.
 func (w *VariantColumnWriter) flush() error {
+	if w.flushCountdown > 0 {
+		w.flushCountdown--
+		return nil
+	}
+	w.flushCountdown = variantFlushCheckRows - 1
 	for _, c := range w.columns {
 		if c.columnBuffer != nil && c.columnBuffer.Size() >= int64(c.bufferSize) {
 			if err := c.Flush(); err != nil {
@@ -518,40 +549,105 @@ func (w *VariantColumnWriter) Field(name string) {
 		w.residual.b.Field(name)
 		return
 	}
-	if w.err != nil {
-		return
-	}
-	n := len(w.frames)
-	if n == 0 || w.frames[n-1].isList {
-		w.fail("Field %q outside of an object", name)
-		return
-	}
-	f := &w.frames[n-1]
-	if w.cur != nil {
-		w.fail("Field %q: previous field has no value", name)
+	f := w.fieldFrame(name)
+	if f == nil {
 		return
 	}
 	// VariantShredding.md requires all field names, shredded or not, to be
 	// present in the metadata dictionary.
 	w.meta.Add(name)
-	node := f.node
-	if i, ok := node.typed.index[name]; ok {
-		if f.seen[i] {
+	idx, ok := f.node.typed.index[name]
+	if !ok {
+		idx = -1
+	}
+	w.beginField(f, name, idx)
+}
+
+// VariantFieldRef is a pre-resolved object field name for FieldByRef. In
+// steady state a ref caches both the field's position in the shredded
+// schema and its metadata dictionary intern, so hot ingest loops writing
+// the same fields on every row skip the per-event name hashing of Field.
+//
+// A ref belongs to the writer that created it and caches its resolution
+// against one object position at a time: use one ref per writer per field
+// name, and prefer distinct refs for identically named fields of different
+// objects.
+type VariantFieldRef struct {
+	name    string
+	node    *shreddedVariantGroup // object node the ref last resolved against
+	idx     int                   // field index in node, -1 when not shredded
+	metaGen uint64                // 1+dictionary generation of the cached intern
+}
+
+// FieldRef pre-resolves an object field name for use with FieldByRef. The
+// name is copied; the caller may reuse its backing memory.
+func (w *VariantColumnWriter) FieldRef(name string) *VariantFieldRef {
+	return &VariantFieldRef{name: strings.Clone(name)}
+}
+
+// FieldByRef is Field with a pre-resolved name; see FieldRef.
+func (w *VariantColumnWriter) FieldByRef(ref *VariantFieldRef) {
+	if w.forward() {
+		w.residual.b.Field(ref.name)
+		return
+	}
+	f := w.fieldFrame(ref.name)
+	if f == nil {
+		return
+	}
+	if ref.metaGen != w.metaGen+1 {
+		w.meta.Add(ref.name)
+		ref.metaGen = w.metaGen + 1
+	}
+	if ref.node != f.node {
+		ref.node = f.node
+		if i, ok := f.node.typed.index[ref.name]; ok {
+			ref.idx = i
+		} else {
+			ref.idx = -1
+		}
+	}
+	w.beginField(f, ref.name, ref.idx)
+}
+
+// fieldFrame validates that a field event is legal here and returns the
+// innermost open object frame, or nil after recording the error.
+func (w *VariantColumnWriter) fieldFrame(name string) *variantWriterFrame {
+	if w.err != nil {
+		return nil
+	}
+	n := len(w.frames)
+	if n == 0 || w.frames[n-1].isList {
+		w.fail("Field %q outside of an object", name)
+		return nil
+	}
+	if w.cur != nil {
+		w.fail("Field %q: previous field has no value", name)
+		return nil
+	}
+	return &w.frames[n-1]
+}
+
+// beginField positions the writer at shredded field idx of the open object
+// frame, or at the partial-object residual when idx is -1.
+func (w *VariantColumnWriter) beginField(f *variantWriterFrame, name string, idx int) {
+	if idx >= 0 {
+		if f.seen[idx] {
 			w.fail("duplicate object field %q", name)
 			return
 		}
-		f.seen[i] = true
-		w.cur = node.typed.fields[i].group
+		f.seen[idx] = true
+		w.cur = f.node.typed.fields[idx].group
 		w.curLevels = f.levels
 		return
 	}
 	// Not a shredded field: it goes into the partial-object residual.
 	if f.partial == nil {
-		f.partial = w.builder(node)
+		f.partial = w.builder(f.node)
 		f.partial.BeginObject()
 	}
 	f.partial.Field(name)
-	w.residual = variantResidualState{b: f.partial, node: node, levels: f.levels, depth: 1, base: 1}
+	w.residual = variantResidualState{b: f.partial, node: f.node, levels: f.levels, depth: 1, base: 1}
 }
 
 // EndObject closes the innermost open object, recording shredded fields

--- a/variant_column_writer_test.go
+++ b/variant_column_writer_test.go
@@ -554,6 +554,78 @@ func TestVariantColumnWriterFieldRef(t *testing.T) {
 	}
 }
 
+// TestVariantColumnWriterFieldRefAcrossWriters uses one ref on two writers:
+// the ref's cached metadata intern belongs to the first writer's
+// dictionary, and the second writer must not trust it — its own metadata
+// must still contain the field name (VariantShredding.md requires all field
+// names of a row, shredded or not, in the row's metadata).
+func TestVariantColumnWriterFieldRefAcrossWriters(t *testing.T) {
+	shred := parquet.Group{"a": parquet.Int(64)}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(mustShreddedVariant(t, shred)),
+	})
+
+	var buf1, buf2 bytes.Buffer
+	w1 := parquet.NewWriter(&buf1, schema)
+	w2 := parquet.NewWriter(&buf2, schema)
+	vw1, err := parquet.NewVariantColumnWriter(w1, "var")
+	if err != nil {
+		t.Fatal(err)
+	}
+	vw2, err := parquet.NewVariantColumnWriter(w2, "var")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := vw1.FieldRef("a")
+	write := func(vw *parquet.VariantColumnWriter) {
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.FieldByRef(ref)
+		vw.Int64(1)
+		vw.EndObject()
+		if err := vw.EndRow(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(vw1)
+	write(vw2) // ref now holds vw1's intern; vw2 must re-intern
+
+	if err := w1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for label, data := range map[string][]byte{"writer 1": buf1.Bytes(), "writer 2": buf2.Bytes()} {
+		f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		pages := f.RowGroups()[0].ColumnChunks()[0].Pages()
+		p, err := pages.ReadPage()
+		if err != nil {
+			t.Fatal(err)
+		}
+		vals := make([]parquet.Value, 1)
+		if _, err := p.Values().ReadValues(vals); err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		m, err := variant.DecodeMetadata(vals[0].ByteArray())
+		parquet.Release(p)
+		pages.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Contains(m.Strings, "a") {
+			t.Errorf("%s: metadata dictionary %q is missing field name %q", label, m.Strings, "a")
+		}
+	}
+}
+
 // TestVariantColumnWriterMetadataPersistent asserts that rows with the same
 // field set write byte-identical metadata (the dictionary persists across
 // rows), and that the dictionary reset under field-name churn keeps rows
@@ -627,6 +699,46 @@ func TestVariantColumnWriterMetadataPersistent(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertVariantFile(t, buf.Bytes(), churn, "metadata churn")
+
+	// The dictionary reset invalidated nameRef's cached intern mid-run;
+	// every row's metadata must still contain the shredded field name.
+	// This cannot be caught by reconstruction, which recovers shredded
+	// field names from the schema instead of the dictionary.
+	f, err = parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	metaPages := f.RowGroups()[0].ColumnChunks()[0].Pages()
+	defer metaPages.Close()
+	row := 0
+	for {
+		p, err := metaPages.ReadPage()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		metaVals := make([]parquet.Value, p.NumRows())
+		n, err := p.Values().ReadValues(metaVals)
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		for _, v := range metaVals[:n] {
+			m, err := variant.DecodeMetadata(v.ByteArray())
+			if err != nil {
+				t.Fatalf("row %d: decoding metadata: %v", row, err)
+			}
+			if !slices.Contains(m.Strings, "name") {
+				t.Errorf("row %d: metadata is missing shredded field name %q after dictionary reset", row, "name")
+			}
+			row++
+		}
+		parquet.Release(p)
+	}
+	if row != rows {
+		t.Fatalf("read %d metadata values, want %d", row, rows)
+	}
 }
 
 // TestVariantColumnWriterMultiPage writes enough rows through a small page

--- a/variant_column_writer_test.go
+++ b/variant_column_writer_test.go
@@ -936,4 +936,46 @@ func BenchmarkVariantColumnWriter(b *testing.B) {
 			}
 		}
 	})
+
+	// Wide objects exercise the per-event field lookup: with a linear scan
+	// this case is quadratic in the field count and dominated field
+	// resolution from a few dozen fields up.
+	b.Run("streaming-wide", func(b *testing.B) {
+		const numFields = 100
+		names := make([]string, numFields)
+		wideShred := parquet.Group{}
+		for j := range numFields {
+			names[j] = fmt.Sprintf("f%03d", j)
+			wideShred[names[j]] = parquet.Int(64)
+		}
+		shredded, err := parquet.ShreddedVariant(wideShred)
+		if err != nil {
+			b.Fatalf("ShreddedVariant: %v", err)
+		}
+		schema := parquet.NewSchema("table", parquet.Group{
+			"var": parquet.Optional(shredded),
+		})
+		w := parquet.NewWriter(io.Discard, schema)
+		vw, err := parquet.NewVariantColumnWriter(w, "var")
+		if err != nil {
+			b.Fatalf("NewVariantColumnWriter: %v", err)
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			for i := range rowsPerIter {
+				if err := vw.BeginRow(); err != nil {
+					b.Fatal(err)
+				}
+				vw.BeginObject()
+				for j := range numFields {
+					vw.Field(names[j])
+					vw.Int64(int64(i + j))
+				}
+				vw.EndObject()
+				if err := vw.EndRow(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
 }

--- a/variant_column_writer_test.go
+++ b/variant_column_writer_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"slices"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -498,7 +499,7 @@ func TestVariantColumnWriterFieldRef(t *testing.T) {
 			field = func(name string) {
 				ref := refs[name]
 				if ref == nil {
-					ref = vw.FieldRef(name)
+					ref = parquet.NewVariantFieldRef(name)
 					refs[name] = ref
 				}
 				vw.FieldByRef(ref)
@@ -540,7 +541,7 @@ func TestVariantColumnWriterFieldRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ref := vw.FieldRef("a")
+	ref := parquet.NewVariantFieldRef("a")
 	if err := vw.BeginRow(); err != nil {
 		t.Fatal(err)
 	}
@@ -577,7 +578,7 @@ func TestVariantColumnWriterFieldRefAcrossWriters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ref := vw1.FieldRef("a")
+	ref := parquet.NewVariantFieldRef("a")
 	write := func(vw *parquet.VariantColumnWriter) {
 		if err := vw.BeginRow(); err != nil {
 			t.Fatal(err)
@@ -673,7 +674,7 @@ func TestVariantColumnWriterMetadataPersistent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nameRef := vw.FieldRef("name")
+	nameRef := parquet.NewVariantFieldRef("name")
 	const rows = 50
 	churn := make([]*variant.Value, rows)
 	for i := range rows {
@@ -1062,6 +1063,75 @@ func TestVariantColumnWriterMisuse(t *testing.T) {
 			t.Fatal("expected an error")
 		}
 	})
+	t.Run("EndObject with pending residual field fails at the event", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("resid") // not shredded: opens the partial-object residual
+		vw.EndObject()    // closes the object while the field has no value
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error at the EndObject event")
+		}
+	})
+	t.Run("EndArray with pending residual field", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("resid")
+		vw.EndArray() // no array is open anywhere
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error at the EndArray event")
+		}
+	})
+	t.Run("mismatched end inside a residual", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginArray() // root is shredded as an object: full residual
+		vw.BeginArray()
+		vw.EndObject() // closes an array frame: builder misuse
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected the builder error to surface at the EndObject event")
+		}
+	})
+	t.Run("unshredded field without a value column", func(t *testing.T) {
+		// A shredded object group may legally omit the value column; then
+		// any field outside the shredded set is unrepresentable and must
+		// fail with a message saying so (not a type-mismatch error).
+		schema := parquet.NewSchema("table", parquet.Group{
+			"var": parquet.Group{
+				"metadata": parquet.Leaf(parquet.ByteArrayType),
+				"typed_value": parquet.Optional(parquet.Group{
+					"a": parquet.Group{
+						"value":       parquet.Optional(parquet.Leaf(parquet.ByteArrayType)),
+						"typed_value": parquet.Optional(parquet.Int(64)),
+					},
+				}),
+			},
+		})
+		w := parquet.NewWriter(io.Discard, schema)
+		vw, err := parquet.NewVariantColumnWriter(w, "var")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("extra")
+		err = vw.Err()
+		if err == nil {
+			t.Fatal("expected an error at the Field event")
+		}
+		if !strings.Contains(err.Error(), "no value column") {
+			t.Errorf("error should name the missing value column, got: %v", err)
+		}
+	})
 	t.Run("WriteNullRow inside a row", func(t *testing.T) {
 		vw := newWriter(t, true)
 		if err := vw.BeginRow(); err != nil {
@@ -1260,7 +1330,7 @@ func BenchmarkVariantColumnWriter(b *testing.B) {
 		}
 		refs := make([]*parquet.VariantFieldRef, numFields)
 		for j := range refs {
-			refs[j] = vw.FieldRef(names[j])
+			refs[j] = parquet.NewVariantFieldRef(names[j])
 		}
 		b.ReportAllocs()
 		for b.Loop() {

--- a/variant_column_writer_test.go
+++ b/variant_column_writer_test.go
@@ -471,6 +471,164 @@ func TestVariantColumnWriterMetadataInterned(t *testing.T) {
 
 func ptrTo[T any](v T) *T { return &v }
 
+// TestVariantColumnWriterFieldRef writes the same rows through Field and
+// through pre-resolved FieldByRef refs and asserts the two files are
+// byte-identical, covering shredded fields, a non-shredded (residual)
+// field, and a ref reused across two different object nodes carrying the
+// same field name.
+func TestVariantColumnWriterFieldRef(t *testing.T) {
+	shred := parquet.Group{
+		"a":      parquet.Int(64),
+		"nested": parquet.Group{"a": parquet.String()},
+	}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(mustShreddedVariant(t, shred)),
+	})
+
+	build := func(byRef bool) []byte {
+		buf := new(bytes.Buffer)
+		w := parquet.NewWriter(buf, schema)
+		vw, err := parquet.NewVariantColumnWriter(w, "var")
+		if err != nil {
+			t.Fatalf("NewVariantColumnWriter: %v", err)
+		}
+		field := vw.Field
+		if byRef {
+			refs := map[string]*parquet.VariantFieldRef{}
+			field = func(name string) {
+				ref := refs[name]
+				if ref == nil {
+					ref = vw.FieldRef(name)
+					refs[name] = ref
+				}
+				vw.FieldByRef(ref)
+			}
+		}
+		for i := range 10 {
+			if err := vw.BeginRow(); err != nil {
+				t.Fatal(err)
+			}
+			vw.BeginObject()
+			field("a") // shredded int64 at the root object
+			vw.Int64(int64(i))
+			field("nested")
+			vw.BeginObject()
+			field("a") // same name, different node: shredded string
+			vw.String("s")
+			field("extra") // not shredded: partial-object residual
+			vw.Bool(true)
+			vw.EndObject()
+			vw.EndObject()
+			if err := vw.EndRow(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+
+	plain, byRef := build(false), build(true)
+	if !bytes.Equal(plain, byRef) {
+		t.Errorf("FieldByRef produced a different file than Field (%d vs %d bytes)", len(byRef), len(plain))
+	}
+
+	// Duplicate detection must work through refs too.
+	w := parquet.NewWriter(io.Discard, schema)
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := vw.FieldRef("a")
+	if err := vw.BeginRow(); err != nil {
+		t.Fatal(err)
+	}
+	vw.BeginObject()
+	vw.FieldByRef(ref)
+	vw.Int64(1)
+	vw.FieldByRef(ref)
+	vw.Int64(2)
+	if vw.Err() == nil {
+		t.Error("duplicate field through FieldByRef did not fail")
+	}
+}
+
+// TestVariantColumnWriterMetadataPersistent asserts that rows with the same
+// field set write byte-identical metadata (the dictionary persists across
+// rows), and that the dictionary reset under field-name churn keeps rows
+// correct, including refs whose cached interns the reset invalidates.
+func TestVariantColumnWriterMetadataPersistent(t *testing.T) {
+	obj := func(fields ...variant.Field) variant.Value { return variant.MakeObject(fields) }
+	field := func(name string, v variant.Value) variant.Field { return variant.Field{Name: name, Value: v} }
+	shred := parquet.Group{"name": parquet.String(), "age": parquet.Int(64)}
+	values := []*variant.Value{
+		ptrTo(obj(field("name", variant.String("alice")), field("age", variant.Int64(30)))),
+		ptrTo(obj(field("age", variant.Int64(31)), field("name", variant.String("bob")))),
+	}
+	data := buildVariantFileStreaming(t, shred, values)
+
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Leaf column 1 of the file is the variant group's metadata column
+	// (the id column sorts first).
+	pages := f.RowGroups()[0].ColumnChunks()[1].Pages()
+	defer pages.Close()
+	p, err := pages.ReadPage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parquet.Release(p)
+	vals := make([]parquet.Value, 2)
+	if _, err := p.Values().ReadValues(vals); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(vals[0].ByteArray(), vals[1].ByteArray()) {
+		t.Errorf("rows with the same field set wrote different metadata:\n row 0: %x\n row 1: %x",
+			vals[0].ByteArray(), vals[1].ByteArray())
+	}
+
+	// Churn: every row carries unique long residual field names, forcing
+	// periodic dictionary resets, through refs that cache their interns.
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(mustShreddedVariant(t, shred)),
+	})
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf, schema)
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nameRef := vw.FieldRef("name")
+	const rows = 50
+	churn := make([]*variant.Value, rows)
+	for i := range rows {
+		uniq := fmt.Sprintf("field_with_a_rather_long_unique_name_%0150d", i)
+		churn[i] = ptrTo(obj(
+			field("name", variant.String("alice")),
+			field(uniq, variant.Int64(int64(i))),
+		))
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.FieldByRef(nameRef)
+		vw.String("alice")
+		vw.Field(uniq)
+		vw.Int64(int64(i))
+		vw.EndObject()
+		if err := vw.EndRow(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertVariantFile(t, buf.Bytes(), churn, "metadata churn")
+}
+
 // TestVariantColumnWriterMultiPage writes enough rows through a small page
 // buffer that every column flushes multiple pages, verifying flushes land
 // on row boundaries.
@@ -939,23 +1097,26 @@ func BenchmarkVariantColumnWriter(b *testing.B) {
 
 	// Wide objects exercise the per-event field lookup: with a linear scan
 	// this case is quadratic in the field count and dominated field
-	// resolution from a few dozen fields up.
+	// resolution from a few dozen fields up. The refs variant resolves
+	// each field name once through FieldRef instead of hashing it on
+	// every event.
+	const numFields = 100
+	names := make([]string, numFields)
+	wideShred := parquet.Group{}
+	for j := range numFields {
+		names[j] = fmt.Sprintf("f%03d", j)
+		wideShred[names[j]] = parquet.Int(64)
+	}
+	wideShredded, err := parquet.ShreddedVariant(wideShred)
+	if err != nil {
+		b.Fatalf("ShreddedVariant: %v", err)
+	}
+	wideSchema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(wideShredded),
+	})
+
 	b.Run("streaming-wide", func(b *testing.B) {
-		const numFields = 100
-		names := make([]string, numFields)
-		wideShred := parquet.Group{}
-		for j := range numFields {
-			names[j] = fmt.Sprintf("f%03d", j)
-			wideShred[names[j]] = parquet.Int(64)
-		}
-		shredded, err := parquet.ShreddedVariant(wideShred)
-		if err != nil {
-			b.Fatalf("ShreddedVariant: %v", err)
-		}
-		schema := parquet.NewSchema("table", parquet.Group{
-			"var": parquet.Optional(shredded),
-		})
-		w := parquet.NewWriter(io.Discard, schema)
+		w := parquet.NewWriter(io.Discard, wideSchema)
 		vw, err := parquet.NewVariantColumnWriter(w, "var")
 		if err != nil {
 			b.Fatalf("NewVariantColumnWriter: %v", err)
@@ -969,6 +1130,35 @@ func BenchmarkVariantColumnWriter(b *testing.B) {
 				vw.BeginObject()
 				for j := range numFields {
 					vw.Field(names[j])
+					vw.Int64(int64(i + j))
+				}
+				vw.EndObject()
+				if err := vw.EndRow(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+
+	b.Run("streaming-wide-refs", func(b *testing.B) {
+		w := parquet.NewWriter(io.Discard, wideSchema)
+		vw, err := parquet.NewVariantColumnWriter(w, "var")
+		if err != nil {
+			b.Fatalf("NewVariantColumnWriter: %v", err)
+		}
+		refs := make([]*parquet.VariantFieldRef, numFields)
+		for j := range refs {
+			refs[j] = vw.FieldRef(names[j])
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			for i := range rowsPerIter {
+				if err := vw.BeginRow(); err != nil {
+					b.Fatal(err)
+				}
+				vw.BeginObject()
+				for j := range numFields {
+					vw.FieldByRef(refs[j])
 					vw.Int64(int64(i + j))
 				}
 				vw.EndObject()

--- a/variant_column_writer_test.go
+++ b/variant_column_writer_test.go
@@ -1,0 +1,939 @@
+package parquet_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"slices"
+	"testing"
+	"unsafe"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/variant"
+)
+
+// The tests in this file validate the streaming columnar write path
+// (VariantColumnWriter) against the row-based write path: both write the
+// same values through the same shredding schema, and both files must read
+// back structurally equal to the originals. Schemas and values come from
+// the same randomized generators as the row-path round-trip tests, so every
+// case of the VariantShredding.md tables arises: exact matches, type
+// mismatches, partially shredded objects, missing fields, empty containers,
+// variant nulls, and nested combinations.
+
+// buildVariantFileStreaming writes values through VariantColumnWriter into
+// the same schema shape as buildVariantFile (an id column and an optional
+// variant column), driving the id column through ColumnWriter.WriteRowValues
+// the way an application writing column-by-column would. A nil value writes
+// a null variant row.
+func buildVariantFileStreaming(t *testing.T, shred parquet.Node, values []*variant.Value, options ...parquet.WriterOption) []byte {
+	t.Helper()
+	variantNode := parquet.Variant()
+	if shred != nil {
+		shredded, err := parquet.ShreddedVariant(shred)
+		if err != nil {
+			t.Fatalf("building shredded variant node: %v", err)
+		}
+		variantNode = shredded
+	}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"id":  parquet.Int(32),
+		"var": parquet.Optional(variantNode),
+	})
+	buf := new(bytes.Buffer)
+	opts := append([]parquet.WriterOption{schema}, options...)
+	w := parquet.NewWriter(buf, opts...)
+
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatalf("NewVariantColumnWriter: %v", err)
+	}
+	idColumn := w.ColumnWriters()[0]
+	idValue := make([]parquet.Value, 1)
+	for i, v := range values {
+		idValue[0] = parquet.Int32Value(int32(i)).Level(0, 0, 0)
+		if _, err := idColumn.WriteRowValues(idValue); err != nil {
+			t.Fatalf("writing id %d: %v", i, err)
+		}
+		if v == nil {
+			err = vw.WriteNullRow()
+		} else {
+			err = vw.WriteValue(*v)
+		}
+		if err != nil {
+			t.Fatalf("writing variant row %d: %v", i, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// assertVariantFile reads a written file back through the columnar reader
+// and asserts every row matches the expected values (nil = null row).
+func assertVariantFile(t *testing.T, data []byte, values []*variant.Value, context string) {
+	t.Helper()
+	got, present := readVariantColumnar(t, data, 1024, "var")
+	if len(got) != len(values) {
+		t.Fatalf("%s: read %d rows, want %d", context, len(got), len(values))
+	}
+	for i, want := range values {
+		if want == nil {
+			if present[i] {
+				t.Errorf("%s: row %d: got %#v, want null row", context, i, got[i].GoValue())
+			}
+			continue
+		}
+		if !present[i] {
+			t.Errorf("%s: row %d: got null row, want %#v", context, i, want.GoValue())
+			continue
+		}
+		if !got[i].Equal(*want) {
+			t.Errorf("%s: row %d mismatch:\n got: %#v\nwant: %#v", context, i, got[i].GoValue(), want.GoValue())
+		}
+	}
+}
+
+// TestVariantColumnWriterRandomizedDifferential runs the randomized
+// shredding schema × value matrix through both the streaming writer and the
+// row-based writer, reading each file back through the columnar reader and
+// the streaming file additionally through the row-based conversion read
+// path. A shredding bug shared symmetrically by the streaming writer and
+// the columnar reader cannot hide: the row-based writer and the conversion
+// read path check both files independently.
+func TestVariantColumnWriterRandomizedDifferential(t *testing.T) {
+	const numSchemas, rowsPerSchema = 48, 11
+	r := rand.New(rand.NewPCG(101, 202))
+	for i := range numSchemas {
+		t.Run(fmt.Sprintf("schema_%02d", i), func(t *testing.T) {
+			shred := randomShredNode(r, 0)
+			values := make([]*variant.Value, rowsPerSchema)
+			for j := range values {
+				if r.IntN(8) == 0 {
+					continue
+				}
+				v := randomVariant(r, 0)
+				values[j] = &v
+			}
+
+			data := buildVariantFileStreaming(t, shred, values)
+			assertVariantFile(t, data, values, "streaming write")
+
+			// The row-based writer must produce a file that reads back to
+			// the same values through the same columnar reader.
+			rowData := buildVariantFile(t, shred, values)
+			assertVariantFile(t, rowData, values, "row-based write")
+
+			// The row-based read path (schema conversion to an unshredded
+			// variant) is an independent check on the streaming file. Null
+			// rows read back as empty metadata/value bytes.
+			rows, err := parquet.Read[rawVariantRow](bytes.NewReader(data), int64(len(data)))
+			if err != nil {
+				t.Fatalf("row-based read: %v", err)
+			}
+			if len(rows) != len(values) {
+				t.Fatalf("row-based read: %d rows, want %d", len(rows), len(values))
+			}
+			for j, want := range values {
+				if want == nil {
+					if len(rows[j].Var.Metadata) != 0 || len(rows[j].Var.Value) != 0 {
+						t.Errorf("row-based read: row %d: got %d metadata and %d value bytes, want empty null row",
+							j, len(rows[j].Var.Metadata), len(rows[j].Var.Value))
+					}
+					continue
+				}
+				decoded, err := decodeRawVariant(rows[j].Var)
+				if err != nil {
+					t.Errorf("row-based read: row %d: %v", j, err)
+					continue
+				}
+				if !decoded.Equal(*want) {
+					t.Errorf("row-based read: row %d mismatch:\n got: %#v\nwant: %#v",
+						j, decoded.GoValue(), want.GoValue())
+				}
+			}
+		})
+	}
+}
+
+// TestVariantColumnWriterUnshredded writes through a plain unshredded
+// variant column (required binary metadata and value).
+func TestVariantColumnWriterUnshredded(t *testing.T) {
+	r := rand.New(rand.NewPCG(5, 6))
+	values := make([]*variant.Value, 20)
+	for i := range values {
+		if i%7 == 3 {
+			continue
+		}
+		v := randomVariant(r, 0)
+		values[i] = &v
+	}
+	data := buildVariantFileStreaming(t, nil, values)
+	assertVariantFile(t, data, values, "unshredded")
+
+	rows, err := parquet.Read[rawVariantRow](bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("row-based read: %v", err)
+	}
+	for i, want := range values {
+		if want == nil {
+			if len(rows[i].Var.Metadata) != 0 || len(rows[i].Var.Value) != 0 {
+				t.Errorf("row-based read: row %d: want empty null row", i)
+			}
+			continue
+		}
+		decoded, err := decodeRawVariant(rows[i].Var)
+		if err != nil {
+			t.Errorf("row-based read: row %d: %v", i, err)
+			continue
+		}
+		if !decoded.Equal(*want) {
+			t.Errorf("row-based read: row %d mismatch:\n got: %#v\nwant: %#v",
+				i, decoded.GoValue(), want.GoValue())
+		}
+	}
+}
+
+// TestVariantColumnWriterErrors exercises the constructor error paths.
+func TestVariantColumnWriterErrors(t *testing.T) {
+	schema := parquet.NewSchema("table", parquet.Group{
+		"id":   parquet.Int(32),
+		"sub":  parquet.Group{"x": parquet.Int(64)},
+		"list": parquet.Repeated(parquet.Group{"var": parquet.Optional(parquet.Variant())}),
+		"var":  parquet.Optional(parquet.Variant()),
+	})
+	w := parquet.NewWriter(new(bytes.Buffer), schema)
+
+	for _, test := range []struct {
+		name string
+		path []string
+	}{
+		{name: "no path", path: nil},
+		{name: "missing column", path: []string{"nope"}},
+		{name: "path through leaf", path: []string{"id", "x"}},
+		{name: "leaf column", path: []string{"id"}},
+		{name: "non-variant group", path: []string{"sub"}},
+		{name: "beneath repeated field", path: []string{"list", "var"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parquet.NewVariantColumnWriter(w, test.path...); err == nil {
+				t.Fatalf("NewVariantColumnWriter(%q): want error, got nil", test.path)
+			}
+		})
+	}
+
+}
+
+// TestVariantColumnWriterEvents drives the event API directly, without
+// building variant.Value trees, the way a JSON transcoder would.
+func TestVariantColumnWriterEvents(t *testing.T) {
+	shred := parquet.Group{
+		"name": parquet.String(),
+		"age":  parquet.Int(64),
+		"tags": parquet.List(parquet.String()),
+	}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(mustShreddedVariant(t, shred)),
+	})
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf, schema)
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatalf("NewVariantColumnWriter: %v", err)
+	}
+
+	// Row 0: fully shredded object with a residual field and a list.
+	if err := vw.BeginRow(); err != nil {
+		t.Fatal(err)
+	}
+	vw.BeginObject()
+	vw.Field("name")
+	vw.String("alice")
+	vw.Field("extra") // not shredded: goes into the partial-object residual
+	vw.BeginObject()
+	vw.Field("x")
+	vw.Int64(1)
+	vw.EndObject()
+	vw.Field("age")
+	vw.Int64(30)
+	vw.Field("tags")
+	vw.BeginArray()
+	vw.String("a")
+	vw.String("b")
+	vw.EndArray()
+	vw.EndObject()
+	if err := vw.EndRow(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Row 1: type conflicts everywhere: scalar at the object position.
+	if err := vw.BeginRow(); err != nil {
+		t.Fatal(err)
+	}
+	vw.Int32(42)
+	if err := vw.EndRow(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Row 2: object with a type conflict in a field and a mixed list.
+	if err := vw.BeginRow(); err != nil {
+		t.Fatal(err)
+	}
+	vw.BeginObject()
+	vw.Field("age")
+	vw.String("not a number")
+	vw.Field("tags")
+	vw.BeginArray()
+	vw.String("ok")
+	vw.Int64(7) // conflicts with the string element type
+	vw.Null()
+	vw.EndArray()
+	vw.EndObject()
+	if err := vw.EndRow(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []*variant.Value{
+		ptrTo(variant.MakeObject([]variant.Field{
+			{Name: "name", Value: variant.String("alice")},
+			{Name: "extra", Value: variant.MakeObject([]variant.Field{{Name: "x", Value: variant.Int64(1)}})},
+			{Name: "age", Value: variant.Int64(30)},
+			{Name: "tags", Value: variant.MakeArray([]variant.Value{variant.String("a"), variant.String("b")})},
+		})),
+		ptrTo(variant.Int32(42)),
+		ptrTo(variant.MakeObject([]variant.Field{
+			{Name: "age", Value: variant.String("not a number")},
+			{Name: "tags", Value: variant.MakeArray([]variant.Value{variant.String("ok"), variant.Int64(7), variant.Null()})},
+		})),
+	}
+	assertVariantFile(t, buf.Bytes(), want, "event API")
+}
+
+// TestVariantColumnWriterFieldCopiesName verifies the documented reuse
+// contract for Field: a caller may mutate the name's backing memory after
+// the call returns without corrupting the row's metadata dictionary.
+func TestVariantColumnWriterFieldCopiesName(t *testing.T) {
+	shred := parquet.Group{"age": parquet.Int(64)}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(mustShreddedVariant(t, shred)),
+	})
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf, schema)
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := vw.BeginRow(); err != nil {
+		t.Fatal(err)
+	}
+	vw.BeginObject()
+	scratch := []byte("extra")
+	vw.Field(unsafe.String(unsafe.SliceData(scratch), len(scratch)))
+	copy(scratch, "XXXXX")
+	vw.String("residual")
+	vw.Field("age")
+	vw.Int64(1)
+	vw.EndObject()
+	if err := vw.EndRow(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	want := []*variant.Value{ptrTo(variant.MakeObject([]variant.Field{
+		{Name: "extra", Value: variant.String("residual")},
+		{Name: "age", Value: variant.Int64(1)},
+	}))}
+	assertVariantFile(t, buf.Bytes(), want, "field name copy")
+}
+
+func mustShreddedVariant(t *testing.T, shred parquet.Node) parquet.Node {
+	t.Helper()
+	node, err := parquet.ShreddedVariant(shred)
+	if err != nil {
+		t.Fatalf("ShreddedVariant: %v", err)
+	}
+	return node
+}
+
+// TestVariantColumnWriterDeepNesting shreds three container levels (objects
+// inside a list inside an object) together with boolean and double typed
+// leaves. The randomized generator stops at two container levels, and its
+// value distribution does not reliably put a bool or double at a matching
+// typed position, so these shapes need a deterministic fixture.
+func TestVariantColumnWriterDeepNesting(t *testing.T) {
+	shred := parquet.Group{
+		"ok":    parquet.Leaf(parquet.BooleanType),
+		"score": parquet.Leaf(parquet.DoubleType),
+		"items": parquet.List(parquet.Group{"n": parquet.Int(64)}),
+	}
+	obj := func(fields ...variant.Field) variant.Value { return variant.MakeObject(fields) }
+	field := func(name string, v variant.Value) variant.Field { return variant.Field{Name: name, Value: v} }
+	arr := func(elems ...variant.Value) variant.Value { return variant.MakeArray(elems) }
+	item := func(n int64) variant.Value { return obj(field("n", variant.Int64(n))) }
+
+	values := []*variant.Value{
+		// Everything matches: bool, double, and a list of typed objects.
+		ptrTo(obj(
+			field("ok", variant.Bool(true)),
+			field("score", variant.Double(0.5)),
+			field("items", arr(item(1), item(2))),
+		)),
+		// Conflicts at each level: int where bool is shredded, string where
+		// double is shredded, and a list mixing typed objects, a scalar
+		// conflict, and an object with a residual field.
+		ptrTo(obj(
+			field("ok", variant.Int64(1)),
+			field("score", variant.String("high")),
+			field("items", arr(
+				item(3),
+				variant.String("loose"),
+				obj(field("n", variant.Int64(4)), field("extra", variant.Bool(false))),
+			)),
+		)),
+		// Empty list and false/zero values (not Go zero-value confusables).
+		ptrTo(obj(
+			field("ok", variant.Bool(false)),
+			field("score", variant.Double(0)),
+			field("items", arr()),
+		)),
+	}
+	data := buildVariantFileStreaming(t, shred, values)
+	assertVariantFile(t, data, values, "deep nesting")
+
+	// Independent check through the row-based conversion read path.
+	rows, err := parquet.Read[rawVariantRow](bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("row-based read: %v", err)
+	}
+	for i, want := range values {
+		decoded, err := decodeRawVariant(rows[i].Var)
+		if err != nil {
+			t.Fatalf("row-based read: row %d: %v", i, err)
+		}
+		if !decoded.Equal(*want) {
+			t.Errorf("row-based read: row %d mismatch:\n got: %#v\nwant: %#v",
+				i, decoded.GoValue(), want.GoValue())
+		}
+	}
+}
+
+// TestVariantColumnWriterMetadataInterned reads back the raw metadata
+// column of a fully shredded row and asserts every object field name is in
+// the row's dictionary. VariantShredding.md requires all field names,
+// shredded or not, to be present in the metadata; no reconstruction oracle
+// can catch a violation because readers recover shredded field names from
+// the schema.
+func TestVariantColumnWriterMetadataInterned(t *testing.T) {
+	shred := parquet.Group{"name": parquet.String(), "age": parquet.Int(64)}
+	values := []*variant.Value{
+		ptrTo(variant.MakeObject([]variant.Field{
+			{Name: "name", Value: variant.String("alice")},
+			{Name: "age", Value: variant.Int64(30)},
+			{Name: "extra", Value: variant.String("residual")}, // not shredded
+		})),
+	}
+	data := buildVariantFileStreaming(t, shred, values)
+
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The metadata column is the first leaf of the variant group; the id
+	// column sorts before var, so it is leaf column 1 of the file.
+	pages := f.RowGroups()[0].ColumnChunks()[1].Pages()
+	defer pages.Close()
+	p, err := pages.ReadPage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer parquet.Release(p)
+	vals := make([]parquet.Value, 1)
+	if _, err := p.Values().ReadValues(vals); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	m, err := variant.DecodeMetadata(vals[0].ByteArray())
+	if err != nil {
+		t.Fatalf("decoding written metadata: %v", err)
+	}
+	for _, name := range []string{"name", "age", "extra"} {
+		if !slices.Contains(m.Strings, name) {
+			t.Errorf("metadata dictionary %q is missing field name %q", m.Strings, name)
+		}
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }
+
+// TestVariantColumnWriterMultiPage writes enough rows through a small page
+// buffer that every column flushes multiple pages, verifying flushes land
+// on row boundaries.
+func TestVariantColumnWriterMultiPage(t *testing.T) {
+	shred := parquet.Group{"a": parquet.Int(64), "b": parquet.String()}
+	r := rand.New(rand.NewPCG(31, 41))
+	values := make([]*variant.Value, 300)
+	for i := range values {
+		if i%13 == 5 {
+			continue
+		}
+		v := randomVariant(r, 0)
+		values[i] = &v
+	}
+	data := buildVariantFileStreaming(t, shred, values, parquet.PageBufferSize(256))
+	assertVariantFile(t, data, values, "multi-page")
+}
+
+// TestVariantColumnWriterNestedEmptyList covers empty and conflicting
+// elements inside nested shredded lists, where the empty-list null fill and
+// element repetition levels interact.
+func TestVariantColumnWriterNestedEmptyList(t *testing.T) {
+	node := mustShreddedVariant(t, parquet.List(parquet.List(parquet.Int(64))))
+	schema := parquet.NewSchema("table", parquet.Group{"var": parquet.Optional(node)})
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf, schema)
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Row 0: [[1, 2], [], "conflict"], row 1: [].
+	if err := vw.BeginRow(); err != nil {
+		t.Fatal(err)
+	}
+	vw.BeginArray()
+	vw.BeginArray()
+	vw.Int64(1)
+	vw.Int64(2)
+	vw.EndArray()
+	vw.BeginArray()
+	vw.EndArray()
+	vw.String("conflict")
+	vw.EndArray()
+	if err := vw.EndRow(); err != nil {
+		t.Fatal(err)
+	}
+	if err := vw.BeginRow(); err != nil {
+		t.Fatal(err)
+	}
+	vw.BeginArray()
+	vw.EndArray()
+	if err := vw.EndRow(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []*variant.Value{
+		ptrTo(variant.MakeArray([]variant.Value{
+			variant.MakeArray([]variant.Value{variant.Int64(1), variant.Int64(2)}),
+			variant.MakeArray(nil),
+			variant.String("conflict"),
+		})),
+		ptrTo(variant.MakeArray(nil)),
+	}
+	assertVariantFile(t, buf.Bytes(), want, "nested empty list")
+}
+
+// TestVariantColumnWriterMultipleRowGroups verifies the writer stays bound
+// to its columns across row group flushes, which reset and swap the
+// underlying column buffers.
+func TestVariantColumnWriterMultipleRowGroups(t *testing.T) {
+	shred := parquet.Group{"a": parquet.Int(64)}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(mustShreddedVariant(t, shred)),
+	})
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf, schema)
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatalf("NewVariantColumnWriter: %v", err)
+	}
+
+	r := rand.New(rand.NewPCG(9, 9))
+	values := make([]*variant.Value, 30)
+	for i := range values {
+		v := randomVariant(r, 0)
+		values[i] = &v
+		if err := vw.WriteValue(v); err != nil {
+			t.Fatalf("writing row %d: %v", i, err)
+		}
+		if i == 9 || i == 19 {
+			if err := w.Flush(); err != nil {
+				t.Fatalf("flushing row group after row %d: %v", i, err)
+			}
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing writer: %v", err)
+	}
+
+	f, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("opening file: %v", err)
+	}
+	if got := len(f.RowGroups()); got != 3 {
+		t.Fatalf("row groups: got %d, want 3", got)
+	}
+	assertVariantFile(t, buf.Bytes(), values, "multiple row groups")
+}
+
+// TestVariantColumnWriterMisuse checks that malformed row and event
+// sequences produce sticky errors.
+func TestVariantColumnWriterMisuse(t *testing.T) {
+	newWriter := func(t *testing.T, optional bool) *parquet.VariantColumnWriter {
+		t.Helper()
+		node := mustShreddedVariant(t, parquet.Group{"a": parquet.Int(64)})
+		if optional {
+			node = parquet.Optional(node)
+		}
+		schema := parquet.NewSchema("table", parquet.Group{"var": node})
+		w := parquet.NewWriter(io.Discard, schema)
+		vw, err := parquet.NewVariantColumnWriter(w, "var")
+		if err != nil {
+			t.Fatalf("NewVariantColumnWriter: %v", err)
+		}
+		return vw
+	}
+
+	t.Run("EndRow without BeginRow", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.EndRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("BeginRow inside a row", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		if err := vw.BeginRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("EndRow without a value", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		if err := vw.EndRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("EndRow with unclosed container", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		if err := vw.EndRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("two values per row", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.Int32(1)
+		vw.Int32(2)
+		if err := vw.EndRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("value without Field", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Int32(1)
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("residual field without value", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("resid") // not shredded: opens the partial-object residual
+		vw.EndObject()
+		if err := vw.EndRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("duplicate residual field", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("x")
+		vw.Int64(1)
+		vw.Field("x")
+		vw.Int64(2)
+		vw.EndObject()
+		if err := vw.EndRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("duplicate shredded field", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("a")
+		vw.Int64(1)
+		vw.Field("a")
+		vw.Int64(2)
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("Field outside an object", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.Field("a")
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("shredded field without value", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("a") // shredded field
+		vw.Field("b") // previous field has no value
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("EndObject without BeginObject", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.EndObject()
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("EndObject with unvalued shredded field", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("a")
+		vw.EndObject()
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("EndArray without BeginArray", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.EndArray()
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("second top-level container", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.Int32(1)
+		vw.BeginObject()
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("unexpected BeginArray", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.Int32(1)
+		vw.BeginArray()
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("Field inside a list", func(t *testing.T) {
+		schema := parquet.NewSchema("table", parquet.Group{
+			"var": parquet.Optional(mustShreddedVariant(t, parquet.List(parquet.Int(64)))),
+		})
+		w := parquet.NewWriter(io.Discard, schema)
+		vw, err := parquet.NewVariantColumnWriter(w, "var")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginArray()
+		vw.Field("x")
+		if err := vw.Err(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("WriteNullRow inside a row", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		if err := vw.WriteNullRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("WriteNullRow on required column", func(t *testing.T) {
+		vw := newWriter(t, false)
+		if err := vw.WriteNullRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+	t.Run("errors are sticky", func(t *testing.T) {
+		vw := newWriter(t, true)
+		if err := vw.EndRow(); err == nil {
+			t.Fatal("expected an error")
+		}
+		if err := vw.BeginRow(); err == nil {
+			t.Fatal("expected BeginRow to report the sticky error")
+		}
+	})
+}
+
+// TestVariantColumnWriterAllocations checks that writing rows through a
+// warmed-up streaming writer does not allocate per row.
+func TestVariantColumnWriterAllocations(t *testing.T) {
+	shred := parquet.Group{"a": parquet.Int(64), "b": parquet.String()}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(mustShreddedVariant(t, shred)),
+	})
+	w := parquet.NewWriter(io.Discard, schema)
+	vw, err := parquet.NewVariantColumnWriter(w, "var")
+	if err != nil {
+		t.Fatalf("NewVariantColumnWriter: %v", err)
+	}
+
+	writeRow := func() {
+		if err := vw.BeginRow(); err != nil {
+			t.Fatal(err)
+		}
+		vw.BeginObject()
+		vw.Field("a")
+		vw.Int64(42)
+		vw.Field("b")
+		vw.String("hello")
+		vw.Field("c") // residual
+		vw.Double(1.5)
+		vw.EndObject()
+		if err := vw.EndRow(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Warm up buffers (and column buffer growth).
+	for range 1000 {
+		writeRow()
+	}
+	allocs := testing.AllocsPerRun(100, writeRow)
+	// Column buffers grow amortized; a strict zero is flaky, but per-row
+	// work must not allocate proportionally.
+	if allocs > 3 {
+		t.Errorf("allocations per row: %v, want <= 3", allocs)
+	}
+}
+
+// BenchmarkVariantColumnWriter compares writing a shredded variant column
+// through the streaming event API against the row-based write path
+// (GenericWriter.Write of raw variant rows).
+func BenchmarkVariantColumnWriter(b *testing.B) {
+	shred := parquet.Group{
+		"name": parquet.String(),
+		"age":  parquet.Int(64),
+		"tags": parquet.List(parquet.String()),
+	}
+	shredded, err := parquet.ShreddedVariant(shred)
+	if err != nil {
+		b.Fatalf("ShreddedVariant: %v", err)
+	}
+	schema := parquet.NewSchema("table", parquet.Group{
+		"var": parquet.Optional(shredded),
+	})
+
+	value := variant.MakeObject([]variant.Field{
+		{Name: "name", Value: variant.String("alice")},
+		{Name: "age", Value: variant.Int64(30)},
+		{Name: "tags", Value: variant.MakeArray([]variant.Value{
+			variant.String("x"), variant.String("y"), variant.String("z"),
+		})},
+		{Name: "extra", Value: variant.Double(1.5)},
+	})
+	const rowsPerIter = 1000
+
+	b.Run("streaming", func(b *testing.B) {
+		w := parquet.NewWriter(io.Discard, schema)
+		vw, err := parquet.NewVariantColumnWriter(w, "var")
+		if err != nil {
+			b.Fatalf("NewVariantColumnWriter: %v", err)
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			for range rowsPerIter {
+				if err := vw.BeginRow(); err != nil {
+					b.Fatal(err)
+				}
+				vw.BeginObject()
+				vw.Field("name")
+				vw.String("alice")
+				vw.Field("age")
+				vw.Int64(30)
+				vw.Field("tags")
+				vw.BeginArray()
+				vw.String("x")
+				vw.String("y")
+				vw.String("z")
+				vw.EndArray()
+				vw.Field("extra")
+				vw.Double(1.5)
+				vw.EndObject()
+				if err := vw.EndRow(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+
+	b.Run("rows", func(b *testing.B) {
+		type row struct {
+			Var rawVariant `parquet:"var,optional,variant"`
+		}
+		raw := encodeRawVariant(value)
+		rows := make([]row, rowsPerIter)
+		for i := range rows {
+			rows[i] = row{Var: raw}
+		}
+		w := parquet.NewGenericWriter[row](io.Discard, schema)
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := w.Write(rows); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/variant_column_writer_test.go
+++ b/variant_column_writer_test.go
@@ -97,6 +97,72 @@ func assertVariantFile(t *testing.T, data []byte, values []*variant.Value, conte
 	}
 }
 
+// assertRowBasedRead checks a written file through the row-based conversion
+// read path (schema conversion to an unshredded variant), an independent
+// check on files produced by the streaming writer. Nil values are expected
+// to read back as empty metadata/value bytes.
+func assertRowBasedRead(t *testing.T, data []byte, values []*variant.Value) {
+	t.Helper()
+	rows, err := parquet.Read[rawVariantRow](bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("row-based read: %v", err)
+	}
+	if len(rows) != len(values) {
+		t.Fatalf("row-based read: %d rows, want %d", len(rows), len(values))
+	}
+	for i, want := range values {
+		if want == nil {
+			if len(rows[i].Var.Metadata) != 0 || len(rows[i].Var.Value) != 0 {
+				t.Errorf("row-based read: row %d: got %d metadata and %d value bytes, want empty null row",
+					i, len(rows[i].Var.Metadata), len(rows[i].Var.Value))
+			}
+			continue
+		}
+		decoded, err := decodeRawVariant(rows[i].Var)
+		if err != nil {
+			t.Errorf("row-based read: row %d: %v", i, err)
+			continue
+		}
+		if !decoded.Equal(*want) {
+			t.Errorf("row-based read: row %d mismatch:\n got: %#v\nwant: %#v",
+				i, decoded.GoValue(), want.GoValue())
+		}
+	}
+}
+
+// readMetadataColumn opens a written file and returns the raw metadata
+// bytes of every row of leaf column col (the variant group's metadata
+// column), across all its pages.
+func readMetadataColumn(t *testing.T, data []byte, col int) [][]byte {
+	t.Helper()
+	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pages := f.RowGroups()[0].ColumnChunks()[col].Pages()
+	defer pages.Close()
+	var metas [][]byte
+	for {
+		p, err := pages.ReadPage()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		vals := make([]parquet.Value, p.NumRows())
+		n, err := p.Values().ReadValues(vals)
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		for _, v := range vals[:n] {
+			metas = append(metas, bytes.Clone(v.ByteArray()))
+		}
+		parquet.Release(p)
+	}
+	return metas
+}
+
 // TestVariantColumnWriterRandomizedDifferential runs the randomized
 // shredding schema × value matrix through both the streaming writer and the
 // row-based writer, reading each file back through the columnar reader and
@@ -127,34 +193,9 @@ func TestVariantColumnWriterRandomizedDifferential(t *testing.T) {
 			rowData := buildVariantFile(t, shred, values)
 			assertVariantFile(t, rowData, values, "row-based write")
 
-			// The row-based read path (schema conversion to an unshredded
-			// variant) is an independent check on the streaming file. Null
-			// rows read back as empty metadata/value bytes.
-			rows, err := parquet.Read[rawVariantRow](bytes.NewReader(data), int64(len(data)))
-			if err != nil {
-				t.Fatalf("row-based read: %v", err)
-			}
-			if len(rows) != len(values) {
-				t.Fatalf("row-based read: %d rows, want %d", len(rows), len(values))
-			}
-			for j, want := range values {
-				if want == nil {
-					if len(rows[j].Var.Metadata) != 0 || len(rows[j].Var.Value) != 0 {
-						t.Errorf("row-based read: row %d: got %d metadata and %d value bytes, want empty null row",
-							j, len(rows[j].Var.Metadata), len(rows[j].Var.Value))
-					}
-					continue
-				}
-				decoded, err := decodeRawVariant(rows[j].Var)
-				if err != nil {
-					t.Errorf("row-based read: row %d: %v", j, err)
-					continue
-				}
-				if !decoded.Equal(*want) {
-					t.Errorf("row-based read: row %d mismatch:\n got: %#v\nwant: %#v",
-						j, decoded.GoValue(), want.GoValue())
-				}
-			}
+			// Independent check on the streaming file through the row-based
+			// conversion read path.
+			assertRowBasedRead(t, data, values)
 		})
 	}
 }
@@ -173,28 +214,7 @@ func TestVariantColumnWriterUnshredded(t *testing.T) {
 	}
 	data := buildVariantFileStreaming(t, nil, values)
 	assertVariantFile(t, data, values, "unshredded")
-
-	rows, err := parquet.Read[rawVariantRow](bytes.NewReader(data), int64(len(data)))
-	if err != nil {
-		t.Fatalf("row-based read: %v", err)
-	}
-	for i, want := range values {
-		if want == nil {
-			if len(rows[i].Var.Metadata) != 0 || len(rows[i].Var.Value) != 0 {
-				t.Errorf("row-based read: row %d: want empty null row", i)
-			}
-			continue
-		}
-		decoded, err := decodeRawVariant(rows[i].Var)
-		if err != nil {
-			t.Errorf("row-based read: row %d: %v", i, err)
-			continue
-		}
-		if !decoded.Equal(*want) {
-			t.Errorf("row-based read: row %d mismatch:\n got: %#v\nwant: %#v",
-				i, decoded.GoValue(), want.GoValue())
-		}
-	}
+	assertRowBasedRead(t, data, values)
 }
 
 // TestVariantColumnWriterErrors exercises the constructor error paths.
@@ -407,22 +427,7 @@ func TestVariantColumnWriterDeepNesting(t *testing.T) {
 	}
 	data := buildVariantFileStreaming(t, shred, values)
 	assertVariantFile(t, data, values, "deep nesting")
-
-	// Independent check through the row-based conversion read path.
-	rows, err := parquet.Read[rawVariantRow](bytes.NewReader(data), int64(len(data)))
-	if err != nil {
-		t.Fatalf("row-based read: %v", err)
-	}
-	for i, want := range values {
-		decoded, err := decodeRawVariant(rows[i].Var)
-		if err != nil {
-			t.Fatalf("row-based read: row %d: %v", i, err)
-		}
-		if !decoded.Equal(*want) {
-			t.Errorf("row-based read: row %d mismatch:\n got: %#v\nwant: %#v",
-				i, decoded.GoValue(), want.GoValue())
-		}
-	}
+	assertRowBasedRead(t, data, values)
 }
 
 // TestVariantColumnWriterMetadataInterned reads back the raw metadata
@@ -442,24 +447,10 @@ func TestVariantColumnWriterMetadataInterned(t *testing.T) {
 	}
 	data := buildVariantFileStreaming(t, shred, values)
 
-	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
-	if err != nil {
-		t.Fatal(err)
-	}
 	// The metadata column is the first leaf of the variant group; the id
 	// column sorts before var, so it is leaf column 1 of the file.
-	pages := f.RowGroups()[0].ColumnChunks()[1].Pages()
-	defer pages.Close()
-	p, err := pages.ReadPage()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer parquet.Release(p)
-	vals := make([]parquet.Value, 1)
-	if _, err := p.Values().ReadValues(vals); err != nil && err != io.EOF {
-		t.Fatal(err)
-	}
-	m, err := variant.DecodeMetadata(vals[0].ByteArray())
+	metas := readMetadataColumn(t, data, 1)
+	m, err := variant.DecodeMetadata(metas[0])
 	if err != nil {
 		t.Fatalf("decoding written metadata: %v", err)
 	}
@@ -602,22 +593,8 @@ func TestVariantColumnWriterFieldRefAcrossWriters(t *testing.T) {
 	}
 
 	for label, data := range map[string][]byte{"writer 1": buf1.Bytes(), "writer 2": buf2.Bytes()} {
-		f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
-		if err != nil {
-			t.Fatal(err)
-		}
-		pages := f.RowGroups()[0].ColumnChunks()[0].Pages()
-		p, err := pages.ReadPage()
-		if err != nil {
-			t.Fatal(err)
-		}
-		vals := make([]parquet.Value, 1)
-		if _, err := p.Values().ReadValues(vals); err != nil && err != io.EOF {
-			t.Fatal(err)
-		}
-		m, err := variant.DecodeMetadata(vals[0].ByteArray())
-		parquet.Release(p)
-		pages.Close()
+		metas := readMetadataColumn(t, data, 0)
+		m, err := variant.DecodeMetadata(metas[0])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -641,26 +618,12 @@ func TestVariantColumnWriterMetadataPersistent(t *testing.T) {
 	}
 	data := buildVariantFileStreaming(t, shred, values)
 
-	f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
-	if err != nil {
-		t.Fatal(err)
-	}
 	// Leaf column 1 of the file is the variant group's metadata column
 	// (the id column sorts first).
-	pages := f.RowGroups()[0].ColumnChunks()[1].Pages()
-	defer pages.Close()
-	p, err := pages.ReadPage()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer parquet.Release(p)
-	vals := make([]parquet.Value, 2)
-	if _, err := p.Values().ReadValues(vals); err != nil && err != io.EOF {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(vals[0].ByteArray(), vals[1].ByteArray()) {
+	metas := readMetadataColumn(t, data, 1)
+	if !bytes.Equal(metas[0], metas[1]) {
 		t.Errorf("rows with the same field set wrote different metadata:\n row 0: %x\n row 1: %x",
-			vals[0].ByteArray(), vals[1].ByteArray())
+			metas[0], metas[1])
 	}
 
 	// Churn: every row carries unique long residual field names, forcing
@@ -705,40 +668,18 @@ func TestVariantColumnWriterMetadataPersistent(t *testing.T) {
 	// every row's metadata must still contain the shredded field name.
 	// This cannot be caught by reconstruction, which recovers shredded
 	// field names from the schema instead of the dictionary.
-	f, err = parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-	if err != nil {
-		t.Fatal(err)
+	churnMetas := readMetadataColumn(t, buf.Bytes(), 0)
+	if len(churnMetas) != rows {
+		t.Fatalf("read %d metadata values, want %d", len(churnMetas), rows)
 	}
-	metaPages := f.RowGroups()[0].ColumnChunks()[0].Pages()
-	defer metaPages.Close()
-	row := 0
-	for {
-		p, err := metaPages.ReadPage()
-		if err == io.EOF {
-			break
-		}
+	for row, raw := range churnMetas {
+		m, err := variant.DecodeMetadata(raw)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("row %d: decoding metadata: %v", row, err)
 		}
-		metaVals := make([]parquet.Value, p.NumRows())
-		n, err := p.Values().ReadValues(metaVals)
-		if err != nil && err != io.EOF {
-			t.Fatal(err)
+		if !slices.Contains(m.Strings, "name") {
+			t.Errorf("row %d: metadata is missing shredded field name %q after dictionary reset", row, "name")
 		}
-		for _, v := range metaVals[:n] {
-			m, err := variant.DecodeMetadata(v.ByteArray())
-			if err != nil {
-				t.Fatalf("row %d: decoding metadata: %v", row, err)
-			}
-			if !slices.Contains(m.Strings, "name") {
-				t.Errorf("row %d: metadata is missing shredded field name %q after dictionary reset", row, "name")
-			}
-			row++
-		}
-		parquet.Release(p)
-	}
-	if row != rows {
-		t.Fatalf("read %d metadata values, want %d", row, rows)
 	}
 }
 
@@ -872,179 +813,126 @@ func TestVariantColumnWriterMisuse(t *testing.T) {
 		return vw
 	}
 
-	t.Run("EndRow without BeginRow", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.EndRow(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("BeginRow inside a row", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		if err := vw.BeginRow(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("EndRow without a value", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		if err := vw.EndRow(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("EndRow with unclosed container", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		if err := vw.EndRow(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("two values per row", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.Int32(1)
-		vw.Int32(2)
-		if err := vw.EndRow(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("value without Field", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Int32(1)
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("residual field without value", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Field("resid") // not shredded: opens the partial-object residual
-		vw.EndObject()
-		if err := vw.EndRow(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("duplicate residual field", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Field("x")
-		vw.Int64(1)
-		vw.Field("x")
-		vw.Int64(2)
-		vw.EndObject()
-		if err := vw.EndRow(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("duplicate shredded field", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Field("a")
-		vw.Int64(1)
-		vw.Field("a")
-		vw.Int64(2)
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("Field outside an object", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.Field("a")
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("shredded field without value", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Field("a") // shredded field
-		vw.Field("b") // previous field has no value
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("EndObject without BeginObject", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.EndObject()
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("EndObject with unvalued shredded field", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Field("a")
-		vw.EndObject()
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("EndArray without BeginArray", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.EndArray()
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("second top-level container", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.Int32(1)
-		vw.BeginObject()
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
-	t.Run("unexpected BeginArray", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.Int32(1)
-		vw.BeginArray()
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error")
-		}
-	})
+	// Each case drives a misuse sequence on a fresh writer and expects an
+	// error: at the offending event itself when atEvent is set, or at the
+	// latest by EndRow.
+	tests := []struct {
+		name    string
+		atEvent bool
+		drive   func(vw *parquet.VariantColumnWriter)
+	}{
+		{"EndRow without BeginRow", false, func(vw *parquet.VariantColumnWriter) {}},
+		{"BeginRow inside a row", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginRow()
+		}},
+		{"EndRow without a value", false, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+		}},
+		{"EndRow with unclosed container", false, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+		}},
+		{"two values per row", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.Int32(1)
+			vw.Int32(2)
+		}},
+		{"value without Field", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+			vw.Int32(1)
+		}},
+		{"EndObject with pending residual field", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+			vw.Field("resid") // not shredded: opens the partial-object residual
+			vw.EndObject()    // closes the object while the field has no value
+		}},
+		{"duplicate residual field", false, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+			vw.Field("x")
+			vw.Int64(1)
+			vw.Field("x")
+			vw.Int64(2)
+			vw.EndObject()
+		}},
+		{"duplicate shredded field", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+			vw.Field("a")
+			vw.Int64(1)
+			vw.Field("a")
+			vw.Int64(2)
+		}},
+		{"Field outside an object", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.Field("a")
+		}},
+		{"shredded field without value", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+			vw.Field("a") // shredded field
+			vw.Field("b") // previous field has no value
+		}},
+		{"EndObject without BeginObject", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.EndObject()
+		}},
+		{"EndObject with unvalued shredded field", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+			vw.Field("a")
+			vw.EndObject()
+		}},
+		{"EndArray without BeginArray", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.EndArray()
+		}},
+		{"second top-level container", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.Int32(1)
+			vw.BeginObject()
+		}},
+		{"unexpected BeginArray", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.Int32(1)
+			vw.BeginArray()
+		}},
+		{"EndArray with pending residual field", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginObject()
+			vw.Field("resid")
+			vw.EndArray() // no array is open anywhere
+		}},
+		{"mismatched end inside a residual", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.BeginArray() // root is shredded as an object: full residual
+			vw.BeginArray()
+			vw.EndObject() // closes an array frame: builder misuse
+		}},
+		{"WriteNullRow inside a row", true, func(vw *parquet.VariantColumnWriter) {
+			vw.BeginRow()
+			vw.WriteNullRow()
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vw := newWriter(t, true)
+			tc.drive(vw)
+			if vw.Err() == nil {
+				if tc.atEvent {
+					t.Fatal("expected an error at the offending event")
+				}
+				if err := vw.EndRow(); err == nil {
+					t.Fatal("expected an error")
+				}
+			}
+		})
+	}
+
+	// The remaining cases need a different schema or writer configuration.
 	t.Run("Field inside a list", func(t *testing.T) {
 		schema := parquet.NewSchema("table", parquet.Group{
 			"var": parquet.Optional(mustShreddedVariant(t, parquet.List(parquet.Int(64)))),
@@ -1061,42 +949,6 @@ func TestVariantColumnWriterMisuse(t *testing.T) {
 		vw.Field("x")
 		if err := vw.Err(); err == nil {
 			t.Fatal("expected an error")
-		}
-	})
-	t.Run("EndObject with pending residual field fails at the event", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Field("resid") // not shredded: opens the partial-object residual
-		vw.EndObject()    // closes the object while the field has no value
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error at the EndObject event")
-		}
-	})
-	t.Run("EndArray with pending residual field", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginObject()
-		vw.Field("resid")
-		vw.EndArray() // no array is open anywhere
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected an error at the EndArray event")
-		}
-	})
-	t.Run("mismatched end inside a residual", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		vw.BeginArray() // root is shredded as an object: full residual
-		vw.BeginArray()
-		vw.EndObject() // closes an array frame: builder misuse
-		if err := vw.Err(); err == nil {
-			t.Fatal("expected the builder error to surface at the EndObject event")
 		}
 	})
 	t.Run("unshredded field without a value column", func(t *testing.T) {
@@ -1130,15 +982,6 @@ func TestVariantColumnWriterMisuse(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "no value column") {
 			t.Errorf("error should name the missing value column, got: %v", err)
-		}
-	})
-	t.Run("WriteNullRow inside a row", func(t *testing.T) {
-		vw := newWriter(t, true)
-		if err := vw.BeginRow(); err != nil {
-			t.Fatal(err)
-		}
-		if err := vw.WriteNullRow(); err == nil {
-			t.Fatal("expected an error")
 		}
 	})
 	t.Run("WriteNullRow on required column", func(t *testing.T) {

--- a/variant_shredded_read.go
+++ b/variant_shredded_read.go
@@ -65,6 +65,7 @@ type shreddedTypedValue struct {
 	typ     Type                   // primitive
 	element *shreddedVariantGroup  // list
 	fields  []shreddedVariantField // object
+	index   map[string]int         // object: field name to position in fields
 }
 
 type shreddedVariantField struct {
@@ -74,10 +75,8 @@ type shreddedVariantField struct {
 
 // fieldByName returns the shredded field with the given name, or nil.
 func (t *shreddedTypedValue) fieldByName(name string) *shreddedVariantGroup {
-	for _, f := range t.fields {
-		if f.name == name {
-			return f.group
-		}
+	if i, ok := t.index[name]; ok {
+		return t.fields[i].group
 	}
 	return nil
 }
@@ -204,6 +203,13 @@ func buildShreddedTypedValue(node Node, startCol, defLevel, repDepth int) (*shre
 			// An empty object group has no columns to carry its own
 			// presence, so it cannot be reconstructed.
 			return nil, fmt.Errorf("variant: object typed_value group must have at least one field")
+		}
+		// Object field events resolve names against this map; a linear
+		// scan makes wide shredded objects quadratic per row (measurably
+		// dominant from a few dozen fields up).
+		t.index = make(map[string]int, len(t.fields))
+		for i := range t.fields {
+			t.index[t.fields[i].name] = i
 		}
 		t.numCols = col - startCol
 	}


### PR DESCRIPTION
## Summary

The write-side counterpart to #552: a streaming, columnar write path that shreds variant values into parquet column buffers as events arrive — no `variant.Value` tree, `map[string]any`, or per-column `[]parquet.Value` in between. This is the API a query engine or a JSON→VARIANT transcoder would use to write shredded variant data directly.

**Stacked on #552** (columnar reader); only the last commit is new. The shredded read/write/convert commits underneath are the same ones #552 carries. Happy to rebase/split as the earlier PRs land.

### `variant` package

- **`ValueWriter`**: a streaming event interface for describing variant values (scalars, `BeginObject`/`Field`/`EndObject`, `BeginArray`/`EndArray`) with sticky error semantics.
- **`Builder`**: a `ValueWriter` that encodes events directly to variant binary in one growing buffer. When a container closes, its header is spliced in front of the already-encoded children with one memmove; object field values stay in event order and only the header entries are sorted by name, which the encoding permits (field IDs must be sorted, field offsets need not be monotonic — the decoder already handles this, as Spark writes such objects). Builders can share a caller-owned `MetadataBuilder`, so multiple values (e.g. all residuals of one shredded row) intern names into one dictionary.
- **`Value.Write`** replays a decoded value as events, bridging the tree representation to any `ValueWriter`.
- **`MetadataBuilder.AppendTo`** encodes the dictionary into a caller-owned buffer so per-row metadata writes don't allocate.

### `parquet` package

- **`VariantColumnWriter`** implements `variant.ValueWriter` over the `ColumnWriter`s backing a variant column. Rows are bracketed by `BeginRow`/`EndRow` (with `WriteValue` and `WriteNullRow` conveniences), and a shredding state machine routes each event as it arrives: exact type matches append directly to `typed_value` column buffers, mismatches and non-shredded object fields stream into per-node residual `Builder`s sharing the row's metadata dictionary, missing shredded fields null-fill at `EndObject`, and lists shred element-wise through the 3-level structure with correct repetition levels.
- The shredding semantics are identical to the row-based path: both share `variantToParquetValue` and the `shreddedVariantGroup` tree and follow the VariantShredding.md case tables. Pages flush at row boundaries, like `ColumnWriter.WriteRowValues`.
- Works with unshredded variant columns, optional columns (SQL nulls via `WriteNullRow`), and across row group flushes.

### Performance

Writing a typical shredded row (object with three shredded fields incl. a list, plus one residual field) vs the row-based path, 1000 rows per op:

```
BenchmarkVariantColumnWriter/streaming    502308 ns/op     73583 B/op        6 allocs/op
BenchmarkVariantColumnWriter/rows        1792935 ns/op   2850410 B/op    26012 allocs/op
```

~3.5x faster, ~4000x fewer allocations; the per-row hot path is allocation-free once buffers are warm (enforced by `TestVariantColumnWriterAllocations`). A string allocation in `variantToParquetValue` shared with the row path is also removed (it can view string data in place because the returned value is always copied into column buffers).

## Test plan

- [x] `TestBuilderDifferential`: streaming encoder output decodes back to the original value across all primitive types, nesting, empty containers, out-of-order fields, and random values; plus large-container (`is_large`) paths, shared-metadata builders, reset/reuse, misuse errors, and allocation checks.
- [x] `TestVariantColumnWriterRandomizedDifferential`: the randomized shredding schema × value matrix (48 schemas × 11 rows, same generators as the row-path round-trip tests) written through the streaming writer reads back equal through both the columnar reader and the row-based conversion path.
- [x] Direct event-API test with type conflicts (scalar at object position, string in an int list), partial-object residuals, unshredded columns, interleaved null rows, 256-byte pages (multi-page flushing), multiple row groups, and misuse/sticky-error cases.
- [x] Full suite passes with `-race` and `purego`.

Made with [Cursor](https://cursor.com)
