### PR TITLE
Fix encoding handling for schemas derived from legacy files

### DIFF
--- a/column.go
+++ b/column.go
@@ -351,6 +351,17 @@ func (cl *columnLoader) open(file *File, metadata *format.FileMetaData, columnIn
 			// the page headers to determine which compression and encodings are
 			// applied.
 			for _, encoding := range c.chunks[0].MetaData.Encoding {
+				// BIT_PACKED appears in the encodings list when the
+				// deprecated bit-packed encoding was used for repetition
+				// or definition levels. Encodings.md: "Note that the
+				// BIT_PACKED encoding method is only supported for
+				// encoding repetition and definition levels." It is never
+				// a data page encoding, so it must not be reported as the
+				// column encoding (it would make schemas derived from
+				// this file unwritable).
+				if encoding == format.BitPacked {
+					continue
+				}
 				if c.encoding == nil {
 					c.encoding = LookupEncoding(encoding)
 				}

--- a/column_test.go
+++ b/column_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -605,5 +606,49 @@ func TestColumnPages_SeekToRow(t *testing.T) {
 			parquet.Release(page)
 			idx++
 		}
+	}
+}
+
+// TestOpenFileColumnEncodingSkipsBitPacked verifies that BIT_PACKED is never
+// reported as a column's encoding. Legacy writers (parquet-java/Impala) list
+// BIT_PACKED in a column chunk's encodings when it was used for repetition
+// or definition levels, but it is not a data page encoding: picking it as
+// the column encoding makes schemas derived from the file unwritable
+// ("encoding not supported for type ...").
+func TestOpenFileColumnEncodingSkipsBitPacked(t *testing.T) {
+	f, err := os.Open("testdata/alltypes_tiny_pages.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pf, err := parquet.OpenFile(f, st.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The test file must actually list BIT_PACKED in its chunk metadata,
+	// otherwise this test asserts nothing.
+	hasBitPacked := false
+	for _, chunk := range pf.Metadata().RowGroups[0].Columns {
+		for _, enc := range chunk.MetaData.Encoding {
+			hasBitPacked = hasBitPacked || enc == format.BitPacked
+		}
+	}
+	if !hasBitPacked {
+		t.Fatal("test file does not use BIT_PACKED level encoding")
+	}
+
+	err = forEachLeafColumn(pf.Root(), func(leaf *parquet.Column) error {
+		if enc := leaf.Encoding(); enc != nil && enc.Encoding() == format.BitPacked {
+			t.Errorf("column %q reports BIT_PACKED as its encoding", leaf.Name())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -736,6 +736,21 @@ func newConcurrentRowGroupWriter(w *writer, config *WriterConfig) *ConcurrentRow
 		}
 
 		if isDictionaryEncoding(encoding) {
+			// The deprecated PLAIN_DICTIONARY encoding is normalized to
+			// RLE_DICTIONARY on the write path: the spec defines a single
+			// dictionary data page layout for both enum values —
+			// Encodings.md: "Data page format: the bit width used to
+			// encode the entry ids stored as 1 byte (max bit width = 32),
+			// followed by the values encoded using the RLE/Bit-Packing
+			// described above" — and directs writers away from the old
+			// enum: "Using the PLAIN_DICTIONARY enum value is deprecated,
+			// use RLE_DICTIONARY in a data page and PLAIN in a dictionary
+			// page for new Parquet files." Writing the PLAIN int32 index
+			// layout of plain.DictionaryEncoding would produce pages no
+			// reader understands. This matters for schemas derived from
+			// files written by legacy writers, which report
+			// PLAIN_DICTIONARY as the column encoding.
+			encoding = &RLEDictionary
 			dictBuffer := columnType.NewValues(make([]byte, 0, defaultDictBufferSize), nil)
 			dictionary = columnType.NewDictionary(columnIndex, 0, dictBuffer)
 			columnType = dictionary.Type()

--- a/writer.go
+++ b/writer.go
@@ -737,19 +737,15 @@ func newConcurrentRowGroupWriter(w *writer, config *WriterConfig) *ConcurrentRow
 
 		if isDictionaryEncoding(encoding) {
 			// The deprecated PLAIN_DICTIONARY encoding is normalized to
-			// RLE_DICTIONARY on the write path: the spec defines a single
-			// dictionary data page layout for both enum values —
-			// Encodings.md: "Data page format: the bit width used to
-			// encode the entry ids stored as 1 byte (max bit width = 32),
-			// followed by the values encoded using the RLE/Bit-Packing
-			// described above" — and directs writers away from the old
-			// enum: "Using the PLAIN_DICTIONARY enum value is deprecated,
-			// use RLE_DICTIONARY in a data page and PLAIN in a dictionary
-			// page for new Parquet files." Writing the PLAIN int32 index
-			// layout of plain.DictionaryEncoding would produce pages no
-			// reader understands. This matters for schemas derived from
-			// files written by legacy writers, which report
-			// PLAIN_DICTIONARY as the column encoding.
+			// RLE_DICTIONARY: the spec defines a single dictionary data
+			// page layout for both enum values — Encodings.md: "Data page
+			// format: the bit width used to encode the entry ids stored
+			// as 1 byte (max bit width = 32), followed by the values
+			// encoded using the RLE/Bit-Packing described above" — so the
+			// plain int32 index layout of plain.DictionaryEncoding
+			// produces pages no reader understands. Schemas derived from
+			// files written by legacy writers report PLAIN_DICTIONARY as
+			// the column encoding, which is how the configuration arises.
 			encoding = &RLEDictionary
 			dictBuffer := columnType.NewValues(make([]byte, 0, defaultDictBufferSize), nil)
 			dictionary = columnType.NewDictionary(columnIndex, 0, dictBuffer)

--- a/writer_test.go
+++ b/writer_test.go
@@ -4460,3 +4460,49 @@ func TestWriteOptionalListWithGenericWriterReflectionPath(t *testing.T) {
 		t.Errorf("data mismatch:\nwant: %+v\ngot:  %+v", expectedRows, output)
 	}
 }
+
+// TestWriterPlainDictionaryEncoding verifies that a column configured with
+// the deprecated PLAIN_DICTIONARY encoding (typical of schemas derived from
+// files written by legacy parquet-java writers) produces data pages readers
+// understand. plain.DictionaryEncoding lays dictionary indices out as plain
+// int32s, but readers — including this package's own — decode both
+// dictionary encodings with the RLE_DICTIONARY data page layout (bit-width
+// prefix + RLE/bit-packed runs), so pages written with the plain layout
+// silently decoded every row as dictionary entry 0. The writer normalizes
+// PLAIN_DICTIONARY to RLE_DICTIONARY instead.
+func TestWriterPlainDictionaryEncoding(t *testing.T) {
+	type row struct{ Name string }
+	schema := parquet.NewSchema("root", parquet.Group{
+		"Name": parquet.Encoded(parquet.String(), &parquet.PlainDictionary),
+	})
+
+	rows := []row{{"alpha"}, {"beta"}, {"gamma"}}
+	buffer := new(bytes.Buffer)
+	w := parquet.NewGenericWriter[row](buffer, schema)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := parquet.Read[row](bytes.NewReader(buffer.Bytes()), int64(buffer.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, rows) {
+		t.Errorf("rows read back = %v, want %v", got, rows)
+	}
+
+	// The chunk metadata must advertise RLE_DICTIONARY so the pages are
+	// readable by other implementations; a reader-side workaround for the
+	// plain int32 layout would pass the round-trip above but break interop.
+	pf, err := parquet.OpenFile(bytes.NewReader(buffer.Bytes()), int64(buffer.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encodings := pf.Metadata().RowGroups[0].Columns[0].MetaData.Encoding
+	if slices.Contains(encodings, format.PlainDictionary) || !slices.Contains(encodings, format.RLEDictionary) {
+		t.Errorf("column chunk encodings = %v, want RLE_DICTIONARY and no PLAIN_DICTIONARY", encodings)
+	}
+}


### PR DESCRIPTION
## Summary

Two writer-facing fixes for schemas obtained via `parquet.OpenFile` on files produced by legacy writers (parquet-java/Impala). Not variant-specific. Each fix quotes the relevant language from [Encodings.md](https://github.com/apache/parquet-format/blob/master/Encodings.md) so the necessity can be verified directly against the spec.

**BIT_PACKED**: legacy files list `BIT_PACKED` in a column chunk's encodings when it was used for repetition/definition levels. The column loader could pick it as the column's *data* encoding, making file-derived schemas unwritable (`encoding not supported for type ...`). The spec restricts this encoding to levels only:

> Note that the BIT_PACKED encoding method is only supported for encoding repetition and definition levels.

The loader now skips it when selecting the data encoding.

**PLAIN_DICTIONARY**: `plain.DictionaryEncoding` writes dictionary indices as plain int32s, but the spec defines one data page layout for dictionary encoding — the section covers both enum values (`PLAIN_DICTIONARY = 2 and RLE_DICTIONARY = 8`):

> The values are stored as integers using the RLE/Bit-Packing Hybrid encoding. [...]
> Data page format: the bit width used to encode the entry ids stored as 1 byte (max bit width = 32), followed by the values encoded using the RLE/Bit-Packing described above (with the given bit width).

Readers — including this package's own — accordingly decode both dictionary encodings with that layout, so pages written through the plain int32 layout silently decoded every row as dictionary entry 0. The writer now normalizes `PLAIN_DICTIONARY` to `RLE_DICTIONARY`, which is also the spec's direction for the deprecated enum:

> Using the `PLAIN_DICTIONARY` enum value is deprecated, use `RLE_DICTIONARY` in a data page and `PLAIN` in a dictionary page for new Parquet files.

## Testing

- `TestOpenFileColumnEncodingSkipsBitPacked` fails before the fix against the repo's existing `testdata/alltypes_tiny_pages.parquet`.
- `TestWriterPlainDictionaryEncoding` fails before the fix: three distinct strings written through PLAIN_DICTIONARY all read back as the first dictionary entry. It also asserts the written chunk metadata advertises `RLE_DICTIONARY`, so a reader-side workaround for the nonstandard layout (which would pass the round-trip but break interop with other readers) cannot satisfy it.
- `go test ./...` passes.

Made with [Cursor](https://cursor.com)


