### PR TITLE
perf(format): zero-allocation footer decoding with format.FooterDecoder

### DIFF
--- a/encoding/thrift/binary.go
+++ b/encoding/thrift/binary.go
@@ -413,6 +413,18 @@ func (r *binaryBytesReader) Reader() io.Reader {
 	return bytes.NewReader(r.data[r.offset:])
 }
 
+// Discard advances the reader past the next n bytes, reporting how many
+// bytes were discarded. Unlike reading through Reader(), it moves the
+// reader's own offset, which skip operations rely on.
+func (r *binaryBytesReader) Discard(n int) (int, error) {
+	if remain := len(r.data) - r.offset; remain < n {
+		r.offset = len(r.data)
+		return remain, io.ErrUnexpectedEOF
+	}
+	r.offset += n
+	return n, nil
+}
+
 func (r *binaryBytesReader) ReadBool() (bool, error) {
 	b, err := r.ReadByte()
 	// Thrift protocol treats both 0 and 2 as false.

--- a/encoding/thrift/compact.go
+++ b/encoding/thrift/compact.go
@@ -385,6 +385,18 @@ func (r *compactBytesReader) Reader() io.Reader {
 	return bytes.NewReader(r.data[r.offset:])
 }
 
+// Discard advances the reader past the next n bytes, reporting how many
+// bytes were discarded. Unlike reading through Reader(), it moves the
+// reader's own offset, which skip operations rely on.
+func (r *compactBytesReader) Discard(n int) (int, error) {
+	if remain := len(r.data) - r.offset; remain < n {
+		r.offset = len(r.data)
+		return remain, io.ErrUnexpectedEOF
+	}
+	r.offset += n
+	return n, nil
+}
+
 func (r *compactBytesReader) ReadBool() (bool, error) {
 	b, err := r.ReadByte()
 	// Thrift protocol treats both 0 and 2 as false.

--- a/encoding/thrift/debug.go
+++ b/encoding/thrift/debug.go
@@ -128,6 +128,30 @@ func (d *debugReader) BytesRead() int {
 	return d.r.BytesRead()
 }
 
+// Discard forwards discards to the wrapped reader, mirroring the cascade of
+// skipBinary. Without it, a debug-wrapped bytes-backed reader would fall
+// through to a throwaway Reader() view and the discard would not advance
+// the wrapped reader's offset, silently desynchronizing the stream.
+func (d *debugReader) Discard(n int) (int, error) {
+	type discarder interface{ Discard(int) (int, error) }
+	var v int
+	var err error
+	switch x := d.r.(type) {
+	case discarder:
+		v, err = x.Discard(n)
+	default:
+		if x, ok := d.r.Reader().(discarder); ok {
+			v, err = x.Discard(n)
+		} else {
+			var c int64
+			c, err = io.CopyN(io.Discard, d.r.Reader(), int64(n))
+			v = int(c)
+		}
+	}
+	d.log("Discard", v, err)
+	return v, err
+}
+
 type debugWriter struct {
 	w Writer
 	l *log.Logger

--- a/encoding/thrift/debug.go
+++ b/encoding/thrift/debug.go
@@ -128,26 +128,12 @@ func (d *debugReader) BytesRead() int {
 	return d.r.BytesRead()
 }
 
-// Discard forwards discards to the wrapped reader, mirroring the cascade of
-// skipBinary. Without it, a debug-wrapped bytes-backed reader would fall
-// through to a throwaway Reader() view and the discard would not advance
-// the wrapped reader's offset, silently desynchronizing the stream.
+// Discard forwards discards to the wrapped reader. Without it, a
+// debug-wrapped bytes-backed reader would fall through to a throwaway
+// Reader() view and the discard would not advance the wrapped reader's
+// offset, silently desynchronizing the stream.
 func (d *debugReader) Discard(n int) (int, error) {
-	type discarder interface{ Discard(int) (int, error) }
-	var v int
-	var err error
-	switch x := d.r.(type) {
-	case discarder:
-		v, err = x.Discard(n)
-	default:
-		if x, ok := d.r.Reader().(discarder); ok {
-			v, err = x.Discard(n)
-		} else {
-			var c int64
-			c, err = io.CopyN(io.Discard, d.r.Reader(), int64(n))
-			v = int(c)
-		}
-	}
+	v, err := discard(d.r, n)
 	d.log("Discard", v, err)
 	return v, err
 }

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -400,23 +400,18 @@ type structDecoder struct {
 	// optional fields but corrupts values where "which member is non-nil"
 	// carries meaning.
 	clears []int
-	// seenWords is the size of the bitmap needed to track which of the
-	// (sparse, id-indexed) fields were observed in the input.
-	seenWords int
 }
 
 func (dec *structDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	flags = flags.Only(decodeFlags)
 	coalesceBool := flags.Have(coalesceBoolFields)
 
+	// seen tracks which of the (sparse, id-indexed) fields were observed
+	// in the input; required is sized to the same word count.
 	var seenBuf [4]uint64
-	seen := seenBuf[:1]
-	if dec.seenWords > 1 {
-		if dec.seenWords <= len(seenBuf) {
-			seen = seenBuf[:dec.seenWords]
-		} else {
-			seen = make([]uint64, dec.seenWords)
-		}
+	seen := seenBuf[:]
+	if n := len(dec.required); n > len(seenBuf) {
+		seen = make([]uint64, n)
 	}
 
 	// Inlined readStruct loop to avoid closure overhead
@@ -443,25 +438,19 @@ decodeFields:
 		}
 
 		i := int(f.ID) - int(dec.minID)
-		if i < 0 || i >= len(dec.fields) || dec.fields[i].decode == nil {
-			if err := skip(r, f.Type); err != nil {
-				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
-			}
-			lastFieldID = f.ID
-			numFields++
-			continue decodeFields
+		var field *structDecoderField
+		if i >= 0 && i < len(dec.fields) && dec.fields[i].decode != nil {
+			field = &dec.fields[i]
 		}
-		field := &dec.fields[i]
-
+		// Unknown fields and (in non-strict mode) type-mismatched fields
+		// are consumed so the stream stays aligned, and left unseen: they
+		// were not decoded, so they must not satisfy the required check nor
+		// protect a stale pointer from the clearUnseen pass below.
 		// TODO: implement type conversions?
-		if f.Type != field.typ && !(f.Type == TRUE && field.typ == BOOL) {
-			if flags.Have(Strict) {
+		if field == nil || (f.Type != field.typ && !(f.Type == TRUE && field.typ == BOOL)) {
+			if field != nil && flags.Have(Strict) {
 				return &TypeMismatch{item: "field value", Expect: field.typ, Found: f.Type}
 			}
-			// Consume the mismatched value so the stream stays aligned, and
-			// leave the field unseen: it was not decoded, so it must not
-			// satisfy the required check nor protect a stale pointer from
-			// clearUnseenPtrs below.
 			if err := skip(r, f.Type); err != nil {
 				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
 			}
@@ -588,8 +577,7 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 
 	dec.fields = make([]structDecoderField, (maxID-minID)+1)
 	dec.minID = minID
-	dec.seenWords = (len(dec.fields) + 63) / 64
-	dec.required = make([]uint64, dec.seenWords)
+	dec.required = make([]uint64, (len(dec.fields)+63)/64)
 
 	for _, f := range fields {
 		i := f.id - minID
@@ -601,11 +589,8 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 		if f.flags.Have(Required) {
 			dec.required[i/64] |= 1 << (i % 64)
 		}
-	}
-
-	for i := range dec.fields {
-		if dec.fields[i].decode != nil && (dec.fields[i].isPtr || dec.fields[i].flags.Have(UnionType)) {
-			dec.clears = append(dec.clears, i)
+		if f.isPtr || f.flags.Have(UnionType) {
+			dec.clears = append(dec.clears, int(i))
 		}
 	}
 
@@ -700,20 +685,26 @@ func skipBinary(r Reader) error {
 	if n == 0 {
 		return nil
 	}
-	// The bytes-backed readers implement Discard themselves; their Reader()
-	// method returns a throwaway view that does not advance the read offset,
-	// so discarding through it would silently desynchronize the stream.
-	// Streaming readers discard through the underlying io.Reader when it
-	// supports it (*bufio.Reader does).
-	type discarder interface{ Discard(int) (int, error) }
-	if d, ok := r.(discarder); ok {
-		_, err = d.Discard(int(n))
-	} else if d, ok := r.Reader().(discarder); ok {
-		_, err = d.Discard(int(n))
-	} else {
-		_, err = io.CopyN(io.Discard, r.Reader(), int64(n))
-	}
+	_, err = discard(r, int(n))
 	return dontExpectEOF(err)
+}
+
+type discarder interface{ Discard(int) (int, error) }
+
+// discard advances r past n bytes. The bytes-backed readers implement
+// Discard themselves; their Reader() method returns a throwaway view that
+// does not advance the read offset, so discarding through it would silently
+// desynchronize the stream. Streaming readers discard through the
+// underlying io.Reader when it supports it (*bufio.Reader does).
+func discard(r Reader, n int) (int, error) {
+	if d, ok := r.(discarder); ok {
+		return d.Discard(n)
+	}
+	if d, ok := r.Reader().(discarder); ok {
+		return d.Discard(n)
+	}
+	c, err := io.CopyN(io.Discard, r.Reader(), int64(n))
+	return int(c), err
 }
 
 func skipList(r Reader) error {

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -453,17 +453,24 @@ decodeFields:
 			continue decodeFields
 		}
 		field := &dec.fields[i]
-		seen[i/64] |= 1 << (i % 64)
 
 		// TODO: implement type conversions?
 		if f.Type != field.typ && !(f.Type == TRUE && field.typ == BOOL) {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "field value", Expect: field.typ, Found: f.Type}
 			}
+			// Consume the mismatched value so the stream stays aligned, and
+			// leave the field unseen: it was not decoded, so it must not
+			// satisfy the required check nor protect a stale pointer from
+			// clearUnseenPtrs below.
+			if err := skip(r, f.Type); err != nil {
+				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
+			}
 			lastFieldID = f.ID
 			numFields++
 			continue decodeFields
 		}
+		seen[i/64] |= 1 << (i % 64)
 
 		x := v
 		for _, i := range field.index {
@@ -694,11 +701,19 @@ func skipBinary(r Reader) error {
 	if n == 0 {
 		return nil
 	}
-	switch x := r.Reader().(type) {
-	case *bufio.Reader:
+	// The bytes-backed readers implement Discard; their Reader() method
+	// returns a throwaway view that does not advance the read offset, so
+	// discarding through it would silently desynchronize the stream.
+	switch x := r.(type) {
+	case interface{ Discard(int) (int, error) }:
 		_, err = x.Discard(int(n))
 	default:
-		_, err = io.CopyN(io.Discard, x, int64(n))
+		switch x := r.Reader().(type) {
+		case *bufio.Reader:
+			_, err = x.Discard(int(n))
+		default:
+			_, err = io.CopyN(io.Discard, x, int64(n))
+		}
 	}
 	return dontExpectEOF(err)
 }

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -18,8 +18,11 @@ import (
 //
 // As an optimization, the value passed in v may be reused across multiple calls
 // to Unmarshal, allowing the function to reuse objects referenced by pointer
-// fields of struct values. When reusing objects, the application is responsible
-// for resetting the state of v before calling Unmarshal again.
+// fields of struct values: non-nil pointer fields present in the input have
+// their pointed-to value zeroed and decoded in place, and pointer fields
+// absent from the input are set to nil. When reusing objects, the application
+// remains responsible for resetting non-pointer state of v (scalars, strings,
+// and slice lengths) before calling Unmarshal again.
 func Unmarshal(p Protocol, b []byte, v any) error {
 	pr := p.NewReaderFromBytes(slices.Clone(b))
 
@@ -389,15 +392,32 @@ type structDecoder struct {
 	fields   []structDecoderField
 	minID    int16
 	required []uint64
+	// clears contains the indices (into fields) of pointer-typed and
+	// union-typed fields. Such fields absent from the input are zeroed
+	// after decoding, so that reusing a previously decoded value as the
+	// decode target produces the same result as decoding into a fresh
+	// value. Without this, stale pointers (or stale union members) from a
+	// previous decode would survive, which is invisible for regular
+	// optional fields but corrupts values where "which member is non-nil"
+	// carries meaning.
+	clears []int
+	// seenWords is the size of the bitmap needed to track which of the
+	// (sparse, id-indexed) fields were observed in the input.
+	seenWords int
 }
 
 func (dec *structDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	flags = flags.Only(decodeFlags)
 	coalesceBool := flags.Have(coalesceBoolFields)
 
-	seen := make([]uint64, 1)
-	if len(dec.required) > len(seen) {
-		seen = make([]uint64, len(dec.required))
+	var seenBuf [4]uint64
+	seen := seenBuf[:1]
+	if dec.seenWords > 1 {
+		if dec.seenWords <= len(seenBuf) {
+			seen = seenBuf[:dec.seenWords]
+		} else {
+			seen = make([]uint64, dec.seenWords)
+		}
 	}
 
 	// Inlined readStruct loop to avoid closure overhead
@@ -497,6 +517,28 @@ decodeFields:
 		}
 	}
 
+clearUnseen:
+	for _, i := range dec.clears {
+		if seen[i/64]&(1<<(i%64)) != 0 {
+			continue
+		}
+		x := v
+		for _, j := range dec.fields[i].index {
+			if x.Kind() == reflect.Ptr {
+				if x.IsNil() {
+					continue clearUnseen
+				}
+				x = x.Elem()
+			}
+			x = x.Field(j)
+		}
+		// x is either a pointer field or a union struct; zeroing a union
+		// nils its member interface, marking the union unset.
+		if x.Kind() != reflect.Ptr || !x.IsNil() {
+			x.SetZero()
+		}
+	}
+
 	return nil
 }
 
@@ -505,6 +547,7 @@ type structDecoderField struct {
 	id     int16
 	flags  Flags
 	typ    Type
+	isPtr  bool
 	decode DecodeFunc
 }
 
@@ -520,6 +563,7 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			id:     f.id,
 			flags:  f.flags,
 			typ:    TypeOf(f.typ),
+			isPtr:  f.typ.Kind() == reflect.Ptr,
 			decode: decodeFuncStructFieldOf(f, seen),
 		})
 	})
@@ -538,7 +582,8 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 
 	dec.fields = make([]structDecoderField, (maxID-minID)+1)
 	dec.minID = minID
-	dec.required = make([]uint64, len(fields)/64+1)
+	dec.seenWords = (len(dec.fields) + 63) / 64
+	dec.required = make([]uint64, dec.seenWords)
 
 	for _, f := range fields {
 		i := f.id - minID
@@ -549,6 +594,12 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 		dec.fields[i] = f
 		if f.flags.Have(Required) {
 			dec.required[i/64] |= 1 << (i % 64)
+		}
+	}
+
+	for i := range dec.fields {
+		if dec.fields[i].decode != nil && (dec.fields[i].isPtr || dec.fields[i].flags.Have(UnionType)) {
+			dec.clears = append(dec.clears, i)
 		}
 	}
 
@@ -571,6 +622,11 @@ func decodeFuncPtrOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 	return func(r Reader, v reflect.Value, f Flags) error {
 		if v.IsNil() {
 			v.Set(reflect.New(elem))
+		} else {
+			// Reuse the allocation but not the contents: optional fields
+			// of the pointed-to value that are absent from the input must
+			// not survive from a previous decode.
+			v.Elem().SetZero()
 		}
 		return decode(r, v.Elem(), f)
 	}

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -253,7 +253,7 @@ func decodeFuncSliceOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "list item", Expect: typ, Found: l.Type}
 			}
-			return nil
+			return skipListItems(r, l)
 		}
 
 		size := int(l.Size)
@@ -308,14 +308,14 @@ func decodeFuncMapOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "map key", Expect: keyType, Found: m.Key}
 			}
-			return nil
+			return skipMapItems(r, m)
 		}
 
 		if elemType != m.Value {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "map value", Expect: elemType, Found: m.Value}
 			}
-			return nil
+			return skipMapItems(r, m)
 		}
 
 		tmpKey := reflect.New(key).Elem()
@@ -369,7 +369,7 @@ func decodeFuncMapAsSetOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "list item", Expect: typ, Found: s.Type}
 			}
-			return nil
+			return skipSetItems(r, s)
 		}
 
 		tmp := reflect.New(key).Elem()
@@ -721,12 +721,7 @@ func skipList(r Reader) error {
 	if err != nil {
 		return err
 	}
-	for i := range int(l.Size) {
-		if err := skip(r, l.Type); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorList{cause: l, index: i})
-		}
-	}
-	return nil
+	return skipListItems(r, l)
 }
 
 func skipSet(r Reader) error {
@@ -734,12 +729,7 @@ func skipSet(r Reader) error {
 	if err != nil {
 		return err
 	}
-	for i := range int(s.Size) {
-		if err := skip(r, s.Type); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorSet{cause: s, index: i})
-		}
-	}
-	return nil
+	return skipSetItems(r, s)
 }
 
 func skipMap(r Reader) error {
@@ -747,11 +737,52 @@ func skipMap(r Reader) error {
 	if err != nil {
 		return err
 	}
+	return skipMapItems(r, m)
+}
+
+// skipItem consumes one container element of the given type. Unlike bool
+// fields, whose value compact-protocol encoders coalesce into the field
+// type, bool container elements always occupy one byte.
+func skipItem(r Reader, t Type) error {
+	switch t {
+	case TRUE, FALSE:
+		_, err := r.ReadBool()
+		return err
+	default:
+		return skip(r, t)
+	}
+}
+
+// skipListItems, skipSetItems, and skipMapItems consume the elements of a
+// container whose header has already been read. They are used both by the
+// skip functions above and by the decoders when the elements cannot be
+// decoded into the target type: the payload must still be consumed, or the
+// reader would desynchronize from the stream.
+
+func skipListItems(r Reader, l List) error {
+	for i := range int(l.Size) {
+		if err := skipItem(r, l.Type); err != nil {
+			return with(dontExpectEOF(err), &decodeErrorList{cause: l, index: i})
+		}
+	}
+	return nil
+}
+
+func skipSetItems(r Reader, s Set) error {
+	for i := range int(s.Size) {
+		if err := skipItem(r, s.Type); err != nil {
+			return with(dontExpectEOF(err), &decodeErrorSet{cause: s, index: i})
+		}
+	}
+	return nil
+}
+
+func skipMapItems(r Reader, m Map) error {
 	for i := range int(m.Size) {
-		if err := skip(r, m.Key); err != nil {
+		if err := skipItem(r, m.Key); err != nil {
 			return with(dontExpectEOF(err), &decodeErrorMap{cause: m, index: i})
 		}
-		if err := skip(r, m.Value); err != nil {
+		if err := skipItem(r, m.Value); err != nil {
 			return with(dontExpectEOF(err), &decodeErrorMap{cause: m, index: i})
 		}
 	}

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -1,7 +1,6 @@
 package thrift
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"maps"
@@ -701,19 +700,18 @@ func skipBinary(r Reader) error {
 	if n == 0 {
 		return nil
 	}
-	// The bytes-backed readers implement Discard; their Reader() method
-	// returns a throwaway view that does not advance the read offset, so
-	// discarding through it would silently desynchronize the stream.
-	switch x := r.(type) {
-	case interface{ Discard(int) (int, error) }:
-		_, err = x.Discard(int(n))
-	default:
-		switch x := r.Reader().(type) {
-		case *bufio.Reader:
-			_, err = x.Discard(int(n))
-		default:
-			_, err = io.CopyN(io.Discard, x, int64(n))
-		}
+	// The bytes-backed readers implement Discard themselves; their Reader()
+	// method returns a throwaway view that does not advance the read offset,
+	// so discarding through it would silently desynchronize the stream.
+	// Streaming readers discard through the underlying io.Reader when it
+	// supports it (*bufio.Reader does).
+	type discarder interface{ Discard(int) (int, error) }
+	if d, ok := r.(discarder); ok {
+		_, err = d.Discard(int(n))
+	} else if d, ok := r.Reader().(discarder); ok {
+		_, err = d.Discard(int(n))
+	} else {
+		_, err = io.CopyN(io.Discard, r.Reader(), int64(n))
 	}
 	return dontExpectEOF(err)
 }

--- a/encoding/thrift/list.go
+++ b/encoding/thrift/list.go
@@ -69,7 +69,7 @@ func (l Slice[T]) DecodeFunc(cache DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "list item", Expect: elemType, Found: listHeader.Type}
 			}
-			return nil
+			return skipListItems(r, listHeader)
 		}
 
 		size := int(listHeader.Size)

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -105,6 +105,120 @@ func TestUnmarshalReuseZeroesPointee(t *testing.T) {
 	}
 }
 
+// TestUnmarshalReuseTypeMismatchedField checks the non-strict handling of
+// fields whose wire type does not match the target: the value must be
+// consumed (keeping the stream aligned) and the field left untouched, in
+// particular pointer fields populated by a previous decode must be niled
+// exactly as if the field were absent from the input.
+func TestUnmarshalReuseTypeMismatchedField(t *testing.T) {
+	// Same field IDs as reuseOuter but with different wire types.
+	type mismatchedOuter struct {
+		Name  string `thrift:"1"`
+		Inner int32  `thrift:"2,optional"` // STRUCT expected, I32 sent
+		Count string `thrift:"3,optional"` // I64 expected, BINARY sent
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			count := int64(42)
+			first, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "first",
+				Inner: &reuseInner{A: 1, B: "one"},
+				Count: &count,
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			second, err := thrift.Marshal(p.proto, &mismatchedOuter{
+				Name:  "second",
+				Inner: 7,
+				Count: "not an integer",
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+
+			v := new(reuseOuter)
+			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
+				t.Fatal("unmarshal first:", err)
+			}
+			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
+				t.Fatal("unmarshal second:", err)
+			}
+			if v.Name != "second" {
+				t.Errorf("Name = %q, want %q (stream desynchronized?)", v.Name, "second")
+			}
+			if v.Inner != nil {
+				t.Errorf("Inner = %+v, want nil: stale pointer survived a type-mismatched field", v.Inner)
+			}
+			if v.Count != nil {
+				t.Errorf("Count = %d, want nil: stale pointer survived a type-mismatched field", *v.Count)
+			}
+		})
+	}
+}
+
+// TestUnmarshalRequiredTypeMismatch checks that a required field whose wire
+// type does not match is reported as missing rather than silently accepted
+// with a zero value.
+func TestUnmarshalRequiredTypeMismatch(t *testing.T) {
+	type point struct {
+		X float64 `thrift:"1,required"`
+		Y float64 `thrift:"2,required"`
+	}
+	type mismatchedPoint struct {
+		X string  `thrift:"1"` // DOUBLE expected, BINARY sent
+		Y float64 `thrift:"2"`
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &mismatchedPoint{X: "oops", Y: 2})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			err = thrift.Unmarshal(p.proto, b, new(point))
+			missing := new(thrift.MissingField)
+			if !errors.As(err, &missing) {
+				t.Fatalf("expected MissingField error, got %v", err)
+			}
+			if missing.Field.ID != 1 {
+				t.Errorf("missing field ID = %d, want 1", missing.Field.ID)
+			}
+		})
+	}
+}
+
+// TestUnmarshalSkipsUnknownBinaryField checks that skipping an unknown
+// string/binary field advances the reader correctly, so that known fields
+// following it still decode. This exercises the Discard path of the
+// bytes-backed readers, whose Reader() method returns a positionless view.
+func TestUnmarshalSkipsUnknownBinaryField(t *testing.T) {
+	type withString struct {
+		S string `thrift:"1"`
+		B int64  `thrift:"2"`
+	}
+	type withoutString struct {
+		B int64 `thrift:"2"`
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &withString{S: "skip me entirely", B: 42})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			v := new(withoutString)
+			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
+				t.Fatal("unmarshal:", err)
+			}
+			if v.B != 42 {
+				t.Errorf("B = %d, want 42 (unknown binary field was not skipped correctly)", v.B)
+			}
+		})
+	}
+}
+
 // sparseIDs has a field ID span (1..100) wider than one 64-bit bitmap word
 // while declaring only two fields, exercising the sparse sizing of the seen
 // and required bitmaps in the struct decoder.

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -189,6 +189,54 @@ func TestUnmarshalRequiredTypeMismatch(t *testing.T) {
 	}
 }
 
+// TestUnmarshalContainerElementTypeMismatch checks the non-strict handling
+// of containers whose element wire type does not match the target: the
+// elements must still be consumed so that fields following the container
+// decode correctly. Without the skip, the binary protocol fails with
+// trailing bytes and the compact protocol silently misparses the next
+// field.
+func TestUnmarshalContainerElementTypeMismatch(t *testing.T) {
+	type source struct {
+		List  []string             `thrift:"1"`
+		Slice thrift.Slice[string] `thrift:"2"`
+		Map   map[string]string    `thrift:"3"`
+		Set   map[string]struct{}  `thrift:"4"`
+		After int64                `thrift:"5"`
+	}
+	type target struct {
+		List  []int64             `thrift:"1"`
+		Slice thrift.Slice[int64] `thrift:"2"`
+		Map   map[int64]int64     `thrift:"3"`
+		Set   map[int64]struct{}  `thrift:"4"`
+		After int64               `thrift:"5"`
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &source{
+				List:  []string{"a", "bc"},
+				Slice: thrift.Slice[string]{"def"},
+				Map:   map[string]string{"key": "value"},
+				Set:   map[string]struct{}{"member": {}},
+				After: 42,
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			v := new(target)
+			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
+				t.Fatal("unmarshal:", err)
+			}
+			if len(v.List) != 0 || len(v.Slice) != 0 || len(v.Map) != 0 || len(v.Set) != 0 {
+				t.Errorf("mismatched containers should decode empty, got %+v", v)
+			}
+			if v.After != 42 {
+				t.Errorf("After = %d, want 42 (stream desynchronized by a mismatched container)", v.After)
+			}
+		})
+	}
+}
+
 // TestUnmarshalSkipsUnknownBinaryField checks that skipping an unknown
 // string/binary field advances the reader correctly, so that known fields
 // following it still decode. This exercises the Discard path of the

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -1,0 +1,151 @@
+package thrift_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+)
+
+// These tests exercise the decode-target reuse semantics documented on
+// Unmarshal: when decoding into a value that already holds data from a
+// previous decode, pointer fields absent from the input are set to nil, and
+// reused pointees are zeroed before decoding so no stale fields leak through.
+
+type reuseInner struct {
+	A int64  `thrift:"1,optional"`
+	B string `thrift:"2,optional"`
+}
+
+type reuseOuter struct {
+	Name  string      `thrift:"1"`
+	Inner *reuseInner `thrift:"2,optional"`
+	Count *int64      `thrift:"3,optional"`
+}
+
+func TestUnmarshalReuseNilsUnseenPointers(t *testing.T) {
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			count := int64(42)
+			first, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "first",
+				Inner: &reuseInner{A: 1, B: "one"},
+				Count: &count,
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			second, err := thrift.Marshal(p.proto, &reuseOuter{Name: "second"})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+
+			v := new(reuseOuter)
+			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
+				t.Fatal("unmarshal first:", err)
+			}
+			if v.Inner == nil || v.Count == nil {
+				t.Fatalf("first decode did not populate pointer fields: %+v", v)
+			}
+
+			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
+				t.Fatal("unmarshal second:", err)
+			}
+			if v.Name != "second" {
+				t.Errorf("Name = %q, want %q", v.Name, "second")
+			}
+			if v.Inner != nil {
+				t.Errorf("Inner = %+v, want nil after decoding input without field 2", v.Inner)
+			}
+			if v.Count != nil {
+				t.Errorf("Count = %d, want nil after decoding input without field 3", *v.Count)
+			}
+		})
+	}
+}
+
+func TestUnmarshalReuseZeroesPointee(t *testing.T) {
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			first, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "first",
+				Inner: &reuseInner{A: 1, B: "one"},
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			// Second input sets Inner.A but not Inner.B.
+			second, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "second",
+				Inner: &reuseInner{A: 2},
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+
+			v := new(reuseOuter)
+			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
+				t.Fatal("unmarshal first:", err)
+			}
+			firstInner := v.Inner
+
+			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
+				t.Fatal("unmarshal second:", err)
+			}
+			if v.Inner != firstInner {
+				t.Error("Inner pointer was reallocated instead of reused")
+			}
+			if v.Inner.A != 2 {
+				t.Errorf("Inner.A = %d, want 2", v.Inner.A)
+			}
+			if v.Inner.B != "" {
+				t.Errorf("Inner.B = %q, want empty: stale value leaked from previous decode", v.Inner.B)
+			}
+		})
+	}
+}
+
+// sparseIDs has a field ID span (1..100) wider than one 64-bit bitmap word
+// while declaring only two fields, exercising the sparse sizing of the seen
+// and required bitmaps in the struct decoder.
+type sparseIDs struct {
+	First int64 `thrift:"1,required"`
+	Last  int64 `thrift:"100,required"`
+}
+
+type sparseIDsPartial struct {
+	First int64 `thrift:"1"`
+}
+
+func TestUnmarshalSparseFieldIDs(t *testing.T) {
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &sparseIDs{First: 1, Last: 100})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			v := new(sparseIDs)
+			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
+				t.Fatal("unmarshal:", err)
+			}
+			if v.First != 1 || v.Last != 100 {
+				t.Errorf("got %+v, want {First:1 Last:100}", v)
+			}
+
+			// Input missing required field 100 must be rejected, which
+			// requires the required bitmap to cover the full ID span.
+			partial, err := thrift.Marshal(p.proto, &sparseIDsPartial{First: 1})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			err = thrift.Unmarshal(p.proto, partial, new(sparseIDs))
+			missing := new(thrift.MissingField)
+			if !errors.As(err, &missing) {
+				t.Fatalf("expected MissingField error, got %v", err)
+			}
+			if missing.Field.ID != 100 {
+				t.Errorf("missing field ID = %d, want 100", missing.Field.ID)
+			}
+		})
+	}
+}

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -12,6 +12,22 @@ import (
 // previous decode, pointer fields absent from the input are set to nil, and
 // reused pointees are zeroed before decoding so no stale fields leak through.
 
+func mustMarshal(t *testing.T, p thrift.Protocol, v any) []byte {
+	t.Helper()
+	b, err := thrift.Marshal(p, v)
+	if err != nil {
+		t.Fatal("marshal:", err)
+	}
+	return b
+}
+
+func mustUnmarshal(t *testing.T, p thrift.Protocol, b []byte, v any) {
+	t.Helper()
+	if err := thrift.Unmarshal(p, b, v); err != nil {
+		t.Fatal("unmarshal:", err)
+	}
+}
+
 type reuseInner struct {
 	A int64  `thrift:"1,optional"`
 	B string `thrift:"2,optional"`
@@ -27,30 +43,20 @@ func TestUnmarshalReuseNilsUnseenPointers(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
 			count := int64(42)
-			first, err := thrift.Marshal(p.proto, &reuseOuter{
+			first := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "first",
 				Inner: &reuseInner{A: 1, B: "one"},
 				Count: &count,
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			second, err := thrift.Marshal(p.proto, &reuseOuter{Name: "second"})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
+			second := mustMarshal(t, p.proto, &reuseOuter{Name: "second"})
 
 			v := new(reuseOuter)
-			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
-				t.Fatal("unmarshal first:", err)
-			}
+			mustUnmarshal(t, p.proto, first, v)
 			if v.Inner == nil || v.Count == nil {
 				t.Fatalf("first decode did not populate pointer fields: %+v", v)
 			}
 
-			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
-				t.Fatal("unmarshal second:", err)
-			}
+			mustUnmarshal(t, p.proto, second, v)
 			if v.Name != "second" {
 				t.Errorf("Name = %q, want %q", v.Name, "second")
 			}
@@ -67,31 +73,21 @@ func TestUnmarshalReuseNilsUnseenPointers(t *testing.T) {
 func TestUnmarshalReuseZeroesPointee(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			first, err := thrift.Marshal(p.proto, &reuseOuter{
+			first := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "first",
 				Inner: &reuseInner{A: 1, B: "one"},
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 			// Second input sets Inner.A but not Inner.B.
-			second, err := thrift.Marshal(p.proto, &reuseOuter{
+			second := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "second",
 				Inner: &reuseInner{A: 2},
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 
 			v := new(reuseOuter)
-			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
-				t.Fatal("unmarshal first:", err)
-			}
+			mustUnmarshal(t, p.proto, first, v)
 			firstInner := v.Inner
 
-			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
-				t.Fatal("unmarshal second:", err)
-			}
+			mustUnmarshal(t, p.proto, second, v)
 			if v.Inner != firstInner {
 				t.Error("Inner pointer was reallocated instead of reused")
 			}
@@ -121,30 +117,20 @@ func TestUnmarshalReuseTypeMismatchedField(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
 			count := int64(42)
-			first, err := thrift.Marshal(p.proto, &reuseOuter{
+			first := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "first",
 				Inner: &reuseInner{A: 1, B: "one"},
 				Count: &count,
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			second, err := thrift.Marshal(p.proto, &mismatchedOuter{
+			second := mustMarshal(t, p.proto, &mismatchedOuter{
 				Name:  "second",
 				Inner: 7,
 				Count: "not an integer",
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 
 			v := new(reuseOuter)
-			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
-				t.Fatal("unmarshal first:", err)
-			}
-			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
-				t.Fatal("unmarshal second:", err)
-			}
+			mustUnmarshal(t, p.proto, first, v)
+			mustUnmarshal(t, p.proto, second, v)
 			if v.Name != "second" {
 				t.Errorf("Name = %q, want %q (stream desynchronized?)", v.Name, "second")
 			}
@@ -173,11 +159,8 @@ func TestUnmarshalRequiredTypeMismatch(t *testing.T) {
 
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &mismatchedPoint{X: "oops", Y: 2})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			err = thrift.Unmarshal(p.proto, b, new(point))
+			b := mustMarshal(t, p.proto, &mismatchedPoint{X: "oops", Y: 2})
+			err := thrift.Unmarshal(p.proto, b, new(point))
 			missing := new(thrift.MissingField)
 			if !errors.As(err, &missing) {
 				t.Fatalf("expected MissingField error, got %v", err)
@@ -213,20 +196,15 @@ func TestUnmarshalContainerElementTypeMismatch(t *testing.T) {
 
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &source{
+			b := mustMarshal(t, p.proto, &source{
 				List:  []string{"a", "bc"},
 				Slice: thrift.Slice[string]{"def"},
 				Map:   map[string]string{"key": "value"},
 				Set:   map[string]struct{}{"member": {}},
 				After: 42,
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 			v := new(target)
-			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
-				t.Fatal("unmarshal:", err)
-			}
+			mustUnmarshal(t, p.proto, b, v)
 			if len(v.List) != 0 || len(v.Slice) != 0 || len(v.Map) != 0 || len(v.Set) != 0 {
 				t.Errorf("mismatched containers should decode empty, got %+v", v)
 			}
@@ -252,14 +230,9 @@ func TestUnmarshalSkipsUnknownBinaryField(t *testing.T) {
 
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &withString{S: "skip me entirely", B: 42})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
+			b := mustMarshal(t, p.proto, &withString{S: "skip me entirely", B: 42})
 			v := new(withoutString)
-			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
-				t.Fatal("unmarshal:", err)
-			}
+			mustUnmarshal(t, p.proto, b, v)
 			if v.B != 42 {
 				t.Errorf("B = %d, want 42 (unknown binary field was not skipped correctly)", v.B)
 			}
@@ -282,25 +255,17 @@ type sparseIDsPartial struct {
 func TestUnmarshalSparseFieldIDs(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &sparseIDs{First: 1, Last: 100})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
+			b := mustMarshal(t, p.proto, &sparseIDs{First: 1, Last: 100})
 			v := new(sparseIDs)
-			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
-				t.Fatal("unmarshal:", err)
-			}
+			mustUnmarshal(t, p.proto, b, v)
 			if v.First != 1 || v.Last != 100 {
 				t.Errorf("got %+v, want {First:1 Last:100}", v)
 			}
 
 			// Input missing required field 100 must be rejected, which
 			// requires the required bitmap to cover the full ID span.
-			partial, err := thrift.Marshal(p.proto, &sparseIDsPartial{First: 1})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			err = thrift.Unmarshal(p.proto, partial, new(sparseIDs))
+			partial := mustMarshal(t, p.proto, &sparseIDsPartial{First: 1})
+			err := thrift.Unmarshal(p.proto, partial, new(sparseIDs))
 			missing := new(thrift.MissingField)
 			if !errors.As(err, &missing) {
 				t.Fatalf("expected MissingField error, got %v", err)

--- a/encoding/thrift/union.go
+++ b/encoding/thrift/union.go
@@ -232,11 +232,8 @@ func (dec *unionDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	// member of the same type, its allocation is reused instead of
 	// allocating a fresh value.
 	x := v.Field(dec.field)
-	prev := reflect.Value{}
-	if !x.IsNil() {
-		prev = x.Elem()
-		x.SetZero()
-	}
+	prev := x.Elem() // invalid when the union was unset
+	x.SetZero()
 
 	lastFieldID := int16(0)
 	numFields := 0

--- a/encoding/thrift/union.go
+++ b/encoding/thrift/union.go
@@ -212,7 +212,10 @@ type unionDecoderMember struct {
 	// interned is a shared *T for zero-sized members, invalid otherwise.
 	interned reflect.Value
 	typ      reflect.Type
-	decode   DecodeFunc
+	// ptrTyp is *typ, kept to test whether a previously decoded member can
+	// be reused as the decode target without allocating.
+	ptrTyp reflect.Type
+	decode DecodeFunc
 }
 
 type unionDecoder struct {
@@ -224,9 +227,16 @@ type unionDecoder struct {
 func (dec *unionDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	flags = flags.Only(decodeFlags)
 
-	// Reset so that decoding into a reused value cannot retain a stale member.
+	// Reset so that decoding into a reused value cannot retain a stale
+	// member, but remember the previous member: when the input holds a
+	// member of the same type, its allocation is reused instead of
+	// allocating a fresh value.
 	x := v.Field(dec.field)
-	x.SetZero()
+	prev := reflect.Value{}
+	if !x.IsNil() {
+		prev = x.Elem()
+		x.SetZero()
+	}
 
 	lastFieldID := int16(0)
 	numFields := 0
@@ -273,7 +283,12 @@ func (dec *unionDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 
 			p := m.interned
 			if !p.IsValid() {
-				p = reflect.New(m.typ)
+				if prev.IsValid() && prev.Type() == m.ptrTyp && !prev.IsNil() {
+					p = prev
+					p.Elem().SetZero()
+				} else {
+					p = reflect.New(m.typ)
+				}
 			}
 			if err := m.decode(r, p.Elem(), flags); err != nil {
 				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
@@ -301,6 +316,7 @@ func decodeFuncUnionOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 		dec.members[m.id-layout.minID] = unionDecoderMember{
 			interned: m.interned,
 			typ:      m.typ,
+			ptrTyp:   reflect.PointerTo(m.typ),
 			decode:   DecodeFuncOf(m.typ, seen),
 		}
 	}

--- a/format/footer.go
+++ b/format/footer.go
@@ -23,7 +23,6 @@ import (
 type FooterDecoder struct {
 	buf     []byte
 	meta    FileMetaData
-	primed  bool
 	reader  thrift.BytesReader
 	decoder *thrift.Decoder
 }
@@ -48,24 +47,17 @@ func (d *FooterDecoder) Decode(data []byte) (*FileMetaData, int, error) {
 	// would corrupt previously returned values in place. Resetting first
 	// keeps the "valid until next Decode" contract honest instead of
 	// leaving values that are subtly wrong.
-	if d.primed {
-		d.meta.Reset()
-	}
+	d.meta.Reset()
 	d.buf = append(d.buf[:0], data...)
 
 	if d.reader == nil {
-		d.reader = footerProtocol.NewReaderFromBytes(d.buf)
+		d.reader = footerProtocol.NewReaderFromBytes(nil)
 		d.decoder = thrift.NewDecoder(d.reader)
-	} else {
-		d.reader.ResetBytes(d.buf)
 	}
+	d.reader.ResetBytes(d.buf)
 
 	if err := d.decoder.Decode(&d.meta); err != nil {
-		// Leave the decoder marked primed: a partial decode may have
-		// written into d.meta, which must be cleared before the next use.
-		d.primed = true
 		return nil, 0, fmt.Errorf("decoding parquet footer: %w", err)
 	}
-	d.primed = true
 	return &d.meta, d.reader.BytesRead(), nil
 }

--- a/format/footer.go
+++ b/format/footer.go
@@ -16,7 +16,10 @@ import (
 //
 // A decoder never allocates for inputs whose shape fits the capacity
 // retained from previous decodes; larger or differently-shaped inputs grow
-// the retained state as needed.
+// the retained state as needed. The retained state never shrinks: one
+// unusually large footer sizes the decoder's buffer and metadata tree for
+// its remaining lifetime, so long-lived decoders dedicated to a single file
+// may prefer to be discarded after use instead of pooled.
 type FooterDecoder struct {
 	buf     []byte
 	meta    FileMetaData

--- a/format/footer.go
+++ b/format/footer.go
@@ -1,0 +1,68 @@
+package format
+
+import (
+	"fmt"
+
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+)
+
+// FooterDecoder decodes Parquet file footers (thrift compact protocol) with
+// zero steady-state allocations by retaining its input buffer and decoded
+// metadata across calls to Decode.
+//
+// The zero value is ready to use. FooterDecoder values must not be copied
+// after first use and are not safe for concurrent use; to amortize
+// allocations across goroutines, keep decoders in a sync.Pool.
+//
+// A decoder never allocates for inputs whose shape fits the capacity
+// retained from previous decodes; larger or differently-shaped inputs grow
+// the retained state as needed.
+type FooterDecoder struct {
+	buf     []byte
+	meta    FileMetaData
+	primed  bool
+	reader  thrift.BytesReader
+	decoder *thrift.Decoder
+}
+
+// protocol is stateless and shared by all decoders.
+var footerProtocol thrift.CompactProtocol
+
+// Decode parses the thrift-encoded footer in data and returns the decoded
+// metadata along with the number of bytes consumed. Trailing bytes after the
+// thrift payload (such as the 28-byte AES-GCM footer signature written by
+// encrypted-footer-signing writers) are not an error; callers can detect
+// them by comparing the consumed byte count to len(data).
+//
+// The returned metadata, and all strings and byte slices it references, are
+// owned by the decoder and remain valid only until the next call to Decode.
+// Callers that need the metadata to outlive the decoder must deep-copy it.
+//
+// Decode makes a private copy of data; the caller retains ownership of the
+// slice and may reuse it immediately.
+func (d *FooterDecoder) Decode(data []byte) (*FileMetaData, int, error) {
+	// The decoded metadata aliases the retained buffer, so the copy below
+	// would corrupt previously returned values in place. Resetting first
+	// keeps the "valid until next Decode" contract honest instead of
+	// leaving values that are subtly wrong.
+	if d.primed {
+		d.meta.Reset()
+	}
+	d.buf = append(d.buf[:0], data...)
+
+	if d.reader == nil {
+		d.reader = footerProtocol.NewReaderFromBytes(d.buf)
+		d.decoder = thrift.NewDecoder(d.reader)
+	} else {
+		d.reader.ResetBytes(d.buf)
+	}
+
+	if err := d.decoder.Decode(&d.meta); err != nil {
+		// Leave the decoder marked primed: a partial decode may have
+		// written into d.meta, which must be cleared before the next use.
+		d.primed = true
+		return nil, 0, fmt.Errorf("decoding parquet footer: %w", err)
+	}
+	d.primed = true
+	return &d.meta, d.reader.BytesRead(), nil
+}

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -1,10 +1,10 @@
 package format_test
 
 import (
+	"maps"
 	"path/filepath"
 	"reflect"
 	"slices"
-	"sort"
 	"testing"
 
 	"github.com/parquet-go/parquet-go/encoding/thrift"
@@ -31,15 +31,6 @@ func loadAllFooters(t testing.TB) map[string][]byte {
 	return footers
 }
 
-func sortedNames(footers map[string][]byte) []string {
-	names := make([]string, 0, len(footers))
-	for name := range footers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
 func decodeFresh(t testing.TB, footer []byte) *format.FileMetaData {
 	protocol := &thrift.CompactProtocol{}
 	metadata := new(format.FileMetaData)
@@ -56,7 +47,7 @@ func TestFooterDecoderMatchesUnmarshal(t *testing.T) {
 	footers := loadAllFooters(t)
 	decoder := new(format.FooterDecoder)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		decoded, n, err := decoder.Decode(footer)
 		if err != nil {
@@ -72,28 +63,35 @@ func TestFooterDecoderMatchesUnmarshal(t *testing.T) {
 	}
 }
 
-// TestFooterDecoderReuse decodes every ordered pair of testdata footers
-// through a single FooterDecoder and checks the second result against a
-// fresh decode. This catches any state from the first decode leaking into
-// the second (i.e. fields missed by the Reset methods).
+// checkReusePair decodes first then second through a single FooterDecoder
+// and checks the second result against a fresh decode. This catches any
+// state from the first decode leaking into the second (i.e. fields missed
+// by the Reset methods).
+func checkReusePair(t *testing.T, firstName string, first []byte, secondName string, second []byte) {
+	t.Helper()
+	decoder := new(format.FooterDecoder)
+	if _, _, err := decoder.Decode(first); err != nil {
+		t.Fatalf("decoding %s: %v", firstName, err)
+	}
+	decoded, _, err := decoder.Decode(second)
+	if err != nil {
+		t.Fatalf("decoding %s after %s: %v", secondName, firstName, err)
+	}
+	if fresh := decodeFresh(t, second); !equalMetadata(decoded, fresh) {
+		t.Errorf("decoding %s after %s: metadata differs from fresh decode", secondName, firstName)
+	}
+}
+
+// TestFooterDecoderReuse checks every ordered pair of testdata footers
+// through checkReusePair.
 func TestFooterDecoderReuse(t *testing.T) {
 	footers := loadAllFooters(t)
-	names := sortedNames(footers)
+	names := slices.Sorted(maps.Keys(footers))
 
 	for _, first := range names {
 		t.Run(first, func(t *testing.T) {
 			for _, second := range names {
-				decoder := new(format.FooterDecoder)
-				if _, _, err := decoder.Decode(footers[first]); err != nil {
-					t.Fatalf("decoding %s: %v", first, err)
-				}
-				decoded, _, err := decoder.Decode(footers[second])
-				if err != nil {
-					t.Fatalf("decoding %s after %s: %v", second, first, err)
-				}
-				if fresh := decodeFresh(t, footers[second]); !equalMetadata(decoded, fresh) {
-					t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
-				}
+				checkReusePair(t, first, footers[first], second, footers[second])
 			}
 		})
 	}
@@ -105,7 +103,7 @@ func TestFooterDecoderInputOwnership(t *testing.T) {
 	footers := loadAllFooters(t)
 	decoder := new(format.FooterDecoder)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := slices.Clone(footers[name])
 		decoded, _, err := decoder.Decode(footer)
 		if err != nil {
@@ -125,7 +123,7 @@ func TestFooterDecoderInputOwnership(t *testing.T) {
 func TestFooterDecoderZeroAllocs(t *testing.T) {
 	footers := loadAllFooters(t)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		decoder := new(format.FooterDecoder)
 		if _, _, err := decoder.Decode(footer); err != nil {
@@ -342,17 +340,7 @@ func TestFooterDecoderReuseSynthetic(t *testing.T) {
 	footers := map[string][]byte{"maximal": maximal, "minimal": minimal}
 	for first, firstFooter := range footers {
 		for second, secondFooter := range footers {
-			decoder := new(format.FooterDecoder)
-			if _, _, err := decoder.Decode(firstFooter); err != nil {
-				t.Fatalf("decoding %s: %v", first, err)
-			}
-			decoded, _, err := decoder.Decode(secondFooter)
-			if err != nil {
-				t.Fatalf("decoding %s after %s: %v", second, first, err)
-			}
-			if fresh := decodeFresh(t, secondFooter); !equalMetadata(decoded, fresh) {
-				t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
-			}
+			checkReusePair(t, first, firstFooter, second, secondFooter)
 		}
 	}
 }
@@ -438,7 +426,7 @@ func TestFooterDecoderTrailingBytes(t *testing.T) {
 	footers := loadAllFooters(t)
 	decoder := new(format.FooterDecoder)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		signed := make([]byte, 0, len(footer)+28)
 		signed = append(signed, footer...)
@@ -467,7 +455,7 @@ func TestFooterDecoderErrorRecovery(t *testing.T) {
 
 	// Truncated inputs fail partway through decoding, leaving partially
 	// populated metadata that the next Decode must fully reset.
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		if _, _, err := decoder.Decode(footer[:len(footer)/2]); err == nil {
 			t.Fatalf("%s: expected error decoding truncated footer", name)
@@ -511,11 +499,6 @@ func equalMetadata(a, b *format.FileMetaData) bool {
 	return equalValue(reflect.ValueOf(a).Elem(), reflect.ValueOf(b).Elem())
 }
 
-// isNullType reports whether t has the shape of thrift.Null[T].
-func isNullType(t reflect.Type) bool {
-	return t.NumField() == 2 && t.Field(0).Name == "V" && t.Field(1).Name == "Valid"
-}
-
 func equalValue(a, b reflect.Value) bool {
 	if a.Type() != b.Type() {
 		return false
@@ -537,18 +520,6 @@ func equalValue(a, b reflect.Value) bool {
 		}
 		return true
 	case reflect.Struct:
-		// thrift.Null[T] values compare by validity first: when both are
-		// invalid, the inner value is unobservable and may contain stale
-		// data retained for reuse by Reset.
-		if isNullType(a.Type()) {
-			av, bv := a.FieldByName("Valid"), b.FieldByName("Valid")
-			if av.Bool() != bv.Bool() {
-				return false
-			}
-			if !av.Bool() {
-				return true
-			}
-		}
 		for i := range a.NumField() {
 			if !equalValue(a.Field(i), b.Field(i)) {
 				return false

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -381,6 +381,55 @@ func TestSchemaElementResetClearsGeospatialMembers(t *testing.T) {
 	}
 }
 
+// TestResetClearsCryptoUnionMembers pins the buffer-aliasing scrub of the
+// two retained crypto unions, mirroring the CRS handling above: a retained
+// EncryptionAlgorithm or CryptoMetadata member must not keep byte slices or
+// strings that alias the previous decode's input buffer.
+func TestResetClearsCryptoUnionMembers(t *testing.T) {
+	m := format.FileMetaData{
+		EncryptionAlgorithm: format.EncryptionAlgorithm{
+			Value: &format.AesGcmV1{
+				AadPrefix:       []byte("prefix"),
+				AadFileUnique:   []byte("unique"),
+				SupplyAadPrefix: true,
+			},
+		},
+	}
+	m.Reset()
+	if v, ok := m.EncryptionAlgorithm.Value.(*format.AesGcmV1); !ok {
+		t.Errorf("AesGcmV1 member allocation not retained by Reset")
+	} else if v.AadPrefix != nil || v.AadFileUnique != nil || v.SupplyAadPrefix {
+		t.Errorf("AesGcmV1 member not cleared by Reset: %+v", *v)
+	}
+
+	m = format.FileMetaData{
+		EncryptionAlgorithm: format.EncryptionAlgorithm{
+			Value: &format.AesGcmCtrV1{AadPrefix: []byte("prefix")},
+		},
+	}
+	m.Reset()
+	if v, ok := m.EncryptionAlgorithm.Value.(*format.AesGcmCtrV1); !ok {
+		t.Errorf("AesGcmCtrV1 member allocation not retained by Reset")
+	} else if v.AadPrefix != nil || v.AadFileUnique != nil || v.SupplyAadPrefix {
+		t.Errorf("AesGcmCtrV1 member not cleared by Reset: %+v", *v)
+	}
+
+	c := format.ColumnChunk{
+		CryptoMetadata: format.ColumnCryptoMetaData{
+			Value: &format.EncryptionWithColumnKey{
+				PathInSchema: thrift.Slice[string]{"a", "b"},
+				KeyMetadata:  []byte("key"),
+			},
+		},
+	}
+	c.Reset()
+	if v, ok := c.CryptoMetadata.Value.(*format.EncryptionWithColumnKey); !ok {
+		t.Errorf("EncryptionWithColumnKey member allocation not retained by Reset")
+	} else if v.PathInSchema != nil || v.KeyMetadata != nil {
+		t.Errorf("EncryptionWithColumnKey member not cleared by Reset: %+v", *v)
+	}
+}
+
 // TestFooterDecoderTrailingBytes checks the documented tolerance for
 // trailing bytes: signed plaintext footers carry a 28-byte signature after
 // the thrift payload, which Decode must not treat as an error, reporting the

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -1,0 +1,221 @@
+package format_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// loadAllFooters extracts the raw footer bytes of every readable plain
+// parquet file under ../testdata, keyed by file name.
+func loadAllFooters(t testing.TB) map[string][]byte {
+	paths, err := filepath.Glob(filepath.Join("..", "testdata", "*.parquet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	footers := make(map[string][]byte)
+	for _, path := range paths {
+		// Skips encrypted (PARE) and malformed files.
+		if footer, err := extractFooterBytes(path); err == nil {
+			footers[filepath.Base(path)] = footer
+		}
+	}
+	if len(footers) == 0 {
+		t.Skip("no parquet testdata files found")
+	}
+	return footers
+}
+
+func sortedNames(footers map[string][]byte) []string {
+	names := make([]string, 0, len(footers))
+	for name := range footers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func decodeFresh(t testing.TB, footer []byte) *format.FileMetaData {
+	protocol := &thrift.CompactProtocol{}
+	metadata := new(format.FileMetaData)
+	if err := thrift.Unmarshal(protocol, footer, metadata); err != nil {
+		t.Fatal(err)
+	}
+	return metadata
+}
+
+// TestFooterDecoderMatchesUnmarshal checks that FooterDecoder produces the
+// same result as a fresh thrift.Unmarshal for every testdata footer, and
+// that it consumes the entire input.
+func TestFooterDecoderMatchesUnmarshal(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		decoded, n, err := decoder.Decode(footer)
+		if err != nil {
+			t.Errorf("%s: %v", name, err)
+			continue
+		}
+		if n != len(footer) {
+			t.Errorf("%s: consumed %d bytes, want %d", name, n, len(footer))
+		}
+		if fresh := decodeFresh(t, footer); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: decoded metadata differs from fresh decode", name)
+		}
+	}
+}
+
+// TestFooterDecoderReuse decodes every ordered pair of testdata footers
+// through a single FooterDecoder and checks the second result against a
+// fresh decode. This catches any state from the first decode leaking into
+// the second (i.e. fields missed by the Reset methods).
+func TestFooterDecoderReuse(t *testing.T) {
+	footers := loadAllFooters(t)
+	names := sortedNames(footers)
+
+	for _, first := range names {
+		t.Run(first, func(t *testing.T) {
+			for _, second := range names {
+				decoder := new(format.FooterDecoder)
+				if _, _, err := decoder.Decode(footers[first]); err != nil {
+					t.Fatalf("decoding %s: %v", first, err)
+				}
+				decoded, _, err := decoder.Decode(footers[second])
+				if err != nil {
+					t.Fatalf("decoding %s after %s: %v", second, first, err)
+				}
+				if fresh := decodeFresh(t, footers[second]); !equalMetadata(decoded, fresh) {
+					t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
+				}
+			}
+		})
+	}
+}
+
+// TestFooterDecoderInputOwnership checks that the decoder copies its input:
+// clobbering the caller's buffer after Decode must not corrupt the result.
+func TestFooterDecoderInputOwnership(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	for _, name := range sortedNames(footers) {
+		footer := slices.Clone(footers[name])
+		decoded, _, err := decoder.Decode(footer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range footer {
+			footer[i] = 0xff
+		}
+		if fresh := decodeFresh(t, footers[name]); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: metadata corrupted after mutating the input buffer", name)
+		}
+	}
+}
+
+// TestFooterDecoderZeroAllocs checks the zero-allocation guarantee: after a
+// warmup decode, repeated decodes of the same footer must not allocate.
+func TestFooterDecoderZeroAllocs(t *testing.T) {
+	footers := loadAllFooters(t)
+
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		decoder := new(format.FooterDecoder)
+		if _, _, err := decoder.Decode(footer); err != nil {
+			t.Fatal(err)
+		}
+		allocs := testing.AllocsPerRun(10, func() {
+			if _, _, err := decoder.Decode(footer); err != nil {
+				t.Fatal(err)
+			}
+		})
+		if allocs != 0 {
+			t.Errorf("%s: %v allocs per decode, want 0", name, allocs)
+		}
+	}
+}
+
+func BenchmarkFooterDecoder(b *testing.B) {
+	footers := loadAllFooters(b)
+
+	for _, name := range []string{"trace.snappy.parquet", "nested_structs.rust.parquet", "alltypes_tiny_pages_plain.parquet"} {
+		footer, ok := footers[name]
+		if !ok {
+			continue
+		}
+		b.Run(name, func(b *testing.B) {
+			decoder := new(format.FooterDecoder)
+			b.SetBytes(int64(len(footer)))
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, _, err := decoder.Decode(footer); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// equalMetadata compares two FileMetaData values, treating nil and empty
+// slices as equal. The distinction is unavoidable when reusing decode
+// targets: truncated slices retain their backing arrays where a fresh
+// decode would leave the field nil.
+func equalMetadata(a, b *format.FileMetaData) bool {
+	return equalValue(reflect.ValueOf(a).Elem(), reflect.ValueOf(b).Elem())
+}
+
+// isNullType reports whether t has the shape of thrift.Null[T].
+func isNullType(t reflect.Type) bool {
+	return t.NumField() == 2 && t.Field(0).Name == "V" && t.Field(1).Name == "Valid"
+}
+
+func equalValue(a, b reflect.Value) bool {
+	if a.Type() != b.Type() {
+		return false
+	}
+	switch a.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		return equalValue(a.Elem(), b.Elem())
+	case reflect.Slice:
+		if a.Len() != b.Len() {
+			return false
+		}
+		for i := range a.Len() {
+			if !equalValue(a.Index(i), b.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Struct:
+		// thrift.Null[T] values compare by validity first: when both are
+		// invalid, the inner value is unobservable and may contain stale
+		// data retained for reuse by Reset.
+		if isNullType(a.Type()) {
+			av, bv := a.FieldByName("Valid"), b.FieldByName("Valid")
+			if av.Bool() != bv.Bool() {
+				return false
+			}
+			if !av.Bool() {
+				return true
+			}
+		}
+		for i := range a.NumField() {
+			if !equalValue(a.Field(i), b.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a.Interface() == b.Interface()
+	}
+}

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -142,6 +142,30 @@ func TestFooterDecoderZeroAllocs(t *testing.T) {
 	}
 }
 
+// TestFooterDecoderErrorRecovery checks that a failed decode does not
+// poison the decoder: decoding a valid footer after an invalid input must
+// produce the same result as a fresh decode.
+func TestFooterDecoderErrorRecovery(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	// Truncated inputs fail partway through decoding, leaving partially
+	// populated metadata that the next Decode must fully reset.
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		if _, _, err := decoder.Decode(footer[:len(footer)/2]); err == nil {
+			t.Fatalf("%s: expected error decoding truncated footer", name)
+		}
+		decoded, _, err := decoder.Decode(footer)
+		if err != nil {
+			t.Fatalf("%s: decoding after a failed decode: %v", name, err)
+		}
+		if fresh := decodeFresh(t, footer); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: metadata differs from fresh decode after a failed decode", name)
+		}
+	}
+}
+
 func BenchmarkFooterDecoder(b *testing.B) {
 	footers := loadAllFooters(b)
 

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -142,6 +142,273 @@ func TestFooterDecoderZeroAllocs(t *testing.T) {
 	}
 }
 
+// maximalFileMetaData returns a FileMetaData with every optional field
+// populated, including the ones no testdata footer exercises (sorting
+// columns, non-zero ordinals, file paths, crypto metadata, geospatial
+// statistics, geometry/geography logical types, ...). It anchors the reuse
+// tests below to the full type tree instead of whatever testdata contains.
+func maximalFileMetaData() *format.FileMetaData {
+	return &format.FileMetaData{
+		Version: 2,
+		Schema: thrift.Slice[format.SchemaElement]{
+			{
+				Name:        "root",
+				NumChildren: thrift.New(int32(2)),
+			},
+			{
+				Type:           thrift.New(format.ByteArray),
+				RepetitionType: thrift.New(format.Optional),
+				Name:           "geometry",
+				FieldID:        7,
+				LogicalType: format.LogicalType{
+					Value: &format.GeometryType{CRS: "EPSG:4326"},
+				},
+			},
+			{
+				Type:           thrift.New(format.ByteArray),
+				TypeLength:     thrift.New(int32(16)),
+				RepetitionType: thrift.New(format.Required),
+				Name:           "geography",
+				Scale:          thrift.New(int32(2)),
+				Precision:      thrift.New(int32(10)),
+				LogicalType: format.LogicalType{
+					Value: &format.GeographyType{CRS: "OGC:CRS84", Algorithm: 1},
+				},
+			},
+		},
+		NumRows: 3,
+		RowGroups: thrift.Slice[format.RowGroup]{
+			{
+				Columns: thrift.Slice[format.ColumnChunk]{
+					{
+						FilePath:   "part-0001.parquet",
+						FileOffset: 4,
+						MetaData: format.ColumnMetaData{
+							Type:                  format.ByteArray,
+							Encoding:              thrift.Slice[format.Encoding]{format.Plain},
+							PathInSchema:          thrift.Slice[string]{"geometry"},
+							Codec:                 format.Snappy,
+							NumValues:             3,
+							TotalUncompressedSize: 100,
+							TotalCompressedSize:   80,
+							KeyValueMetadata:      []format.KeyValue{{Key: "ck", Value: "cv"}},
+							DataPageOffset:        4,
+							IndexPageOffset:       8,
+							DictionaryPageOffset:  12,
+							Statistics: format.Statistics{
+								Max: []byte("z"), Min: []byte("a"),
+								NullCount: 1, DistinctCount: 2,
+								MaxValue: []byte("z"), MinValue: []byte("a"),
+							},
+							EncodingStats: []format.PageEncodingStats{
+								{PageType: format.DataPage, Encoding: format.Plain, Count: 1},
+							},
+							BloomFilterOffset: 16,
+							BloomFilterLength: 32,
+							SizeStatistics: format.SizeStatistics{
+								UnencodedByteArrayDataBytes: 7,
+								RepetitionLevelHistogram:    []int64{1, 2},
+								DefinitionLevelHistogram:    []int64{3, 4},
+							},
+							GeospatialStatistics: format.GeospatialStatistics{
+								BBox: format.BoundingBox{
+									XMin: 1, XMax: 2, YMin: 3, YMax: 4,
+									ZMin: thrift.New(5.0), ZMax: thrift.New(6.0),
+								},
+								GeoSpatialTypes: []int32{1},
+							},
+						},
+						OffsetIndexOffset: 20,
+						OffsetIndexLength: 4,
+						ColumnIndexOffset: 24,
+						ColumnIndexLength: 4,
+						CryptoMetadata: format.ColumnCryptoMetaData{
+							Value: &format.EncryptionWithColumnKey{
+								PathInSchema: []string{"geometry"},
+								KeyMetadata:  []byte("key-meta"),
+							},
+						},
+						EncryptedColumnMetadata: []byte("encrypted-blob"),
+					},
+				},
+				TotalByteSize: 100,
+				NumRows:       3,
+				SortingColumns: []format.SortingColumn{
+					{ColumnIdx: 0, Descending: true, NullsFirst: true},
+				},
+				FileOffset:          4,
+				TotalCompressedSize: 80,
+				Ordinal:             5,
+			},
+		},
+		KeyValueMetadata: []format.KeyValue{{Key: "k", Value: "v"}},
+		CreatedBy:        "synthetic-test",
+		ColumnOrders: []format.ColumnOrder{
+			{Value: &format.TypeDefinedOrder{}},
+			{Value: &format.TypeDefinedOrder{}},
+		},
+		EncryptionAlgorithm: format.EncryptionAlgorithm{
+			Value: &format.AesGcmV1{
+				AadPrefix:       []byte("prefix"),
+				AadFileUnique:   []byte("unique"),
+				SupplyAadPrefix: true,
+			},
+		},
+		FooterSigningKeyMetadata: []byte("signing-key"),
+	}
+}
+
+// The minimal* structs mirror the thrift field IDs of FileMetaData but
+// declare only the required fields, producing an input where every optional
+// field is genuinely absent. Marshaling a format.FileMetaData cannot produce
+// such an input for fields with writezero tags (e.g. RowGroup.Ordinal).
+type minimalColumnMetaData struct {
+	Type                  int32    `thrift:"1,required"`
+	Encoding              []int32  `thrift:"2,required"`
+	PathInSchema          []string `thrift:"3,required"`
+	Codec                 int32    `thrift:"4,required"`
+	NumValues             int64    `thrift:"5,required"`
+	TotalUncompressedSize int64    `thrift:"6,required"`
+	TotalCompressedSize   int64    `thrift:"7,required"`
+	DataPageOffset        int64    `thrift:"9,required"`
+}
+
+type minimalColumnChunk struct {
+	FileOffset int64                 `thrift:"2,required"`
+	MetaData   minimalColumnMetaData `thrift:"3,optional"`
+}
+
+type minimalRowGroup struct {
+	Columns       []minimalColumnChunk `thrift:"1,required"`
+	TotalByteSize int64                `thrift:"2,required"`
+	NumRows       int64                `thrift:"3,required"`
+}
+
+type minimalSchemaElement struct {
+	Type        int32  `thrift:"1,optional"`
+	Name        string `thrift:"4,required"`
+	NumChildren int32  `thrift:"5,optional"`
+}
+
+type minimalFileMetaData struct {
+	Version   int32                  `thrift:"1,required"`
+	Schema    []minimalSchemaElement `thrift:"2,required"`
+	NumRows   int64                  `thrift:"3,required"`
+	RowGroups []minimalRowGroup      `thrift:"4,required"`
+}
+
+// TestFooterDecoderReuseSynthetic decodes a footer with every optional field
+// populated and a footer with every optional field absent through the same
+// FooterDecoder, in both orders, and checks the second result against a
+// fresh decode. Unlike TestFooterDecoderReuse this does not depend on what
+// the testdata footers happen to contain, so it covers the Reset methods of
+// fields absent from all testdata (ordinals, sorting columns, file paths,
+// crypto metadata, geospatial types, ...).
+func TestFooterDecoderReuseSynthetic(t *testing.T) {
+	protocol := &thrift.CompactProtocol{}
+
+	maximal, err := thrift.Marshal(protocol, maximalFileMetaData())
+	if err != nil {
+		t.Fatal(err)
+	}
+	minimal, err := thrift.Marshal(protocol, &minimalFileMetaData{
+		Version: 1,
+		Schema: []minimalSchemaElement{
+			{Name: "root", NumChildren: 1},
+			{Type: int32(format.ByteArray), Name: "geometry"},
+		},
+		NumRows: 1,
+		RowGroups: []minimalRowGroup{{
+			Columns: []minimalColumnChunk{{
+				FileOffset: 4,
+				MetaData: minimalColumnMetaData{
+					Type:                  int32(format.ByteArray),
+					Encoding:              []int32{int32(format.Plain)},
+					PathInSchema:          []string{"geometry"},
+					NumValues:             1,
+					TotalUncompressedSize: 10,
+					TotalCompressedSize:   8,
+					DataPageOffset:        4,
+				},
+			}},
+			TotalByteSize: 10,
+			NumRows:       1,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	footers := map[string][]byte{"maximal": maximal, "minimal": minimal}
+	for first, firstFooter := range footers {
+		for second, secondFooter := range footers {
+			decoder := new(format.FooterDecoder)
+			if _, _, err := decoder.Decode(firstFooter); err != nil {
+				t.Fatalf("decoding %s: %v", first, err)
+			}
+			decoded, _, err := decoder.Decode(secondFooter)
+			if err != nil {
+				t.Fatalf("decoding %s after %s: %v", second, first, err)
+			}
+			if fresh := decodeFresh(t, secondFooter); !equalMetadata(decoded, fresh) {
+				t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
+			}
+		}
+	}
+}
+
+// TestSchemaElementResetClearsGeospatialMembers pins the CRS-clearing
+// behavior of SchemaElement.Reset directly: retained Geometry/Geography
+// union members must not keep strings that alias the previous decode's
+// input buffer.
+func TestSchemaElementResetClearsGeospatialMembers(t *testing.T) {
+	s := format.SchemaElement{
+		Name:        "geometry",
+		LogicalType: format.LogicalType{Value: &format.GeometryType{CRS: "EPSG:4326"}},
+	}
+	s.Reset()
+	if g, ok := s.LogicalType.Value.(*format.GeometryType); ok && *g != (format.GeometryType{}) {
+		t.Errorf("Geometry member not cleared by Reset: %+v", *g)
+	}
+
+	s = format.SchemaElement{
+		Name:        "geography",
+		LogicalType: format.LogicalType{Value: &format.GeographyType{CRS: "OGC:CRS84", Algorithm: 1}},
+	}
+	s.Reset()
+	if g, ok := s.LogicalType.Value.(*format.GeographyType); ok && *g != (format.GeographyType{}) {
+		t.Errorf("Geography member not cleared by Reset: %+v", *g)
+	}
+}
+
+// TestFooterDecoderTrailingBytes checks the documented tolerance for
+// trailing bytes: signed plaintext footers carry a 28-byte signature after
+// the thrift payload, which Decode must not treat as an error, reporting the
+// consumed byte count instead.
+func TestFooterDecoderTrailingBytes(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		signed := make([]byte, 0, len(footer)+28)
+		signed = append(signed, footer...)
+		for range 28 {
+			signed = append(signed, 0xa5)
+		}
+		decoded, n, err := decoder.Decode(signed)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if n != len(footer) {
+			t.Errorf("%s: consumed %d bytes, want %d", name, n, len(footer))
+		}
+		if fresh := decodeFresh(t, footer); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: metadata differs from fresh decode", name)
+		}
+	}
+}
+
 // TestFooterDecoderErrorRecovery checks that a failed decode does not
 // poison the decoder: decoding a valid footer after an invalid input must
 // produce the same result as a fresh decode.

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -1143,15 +1143,22 @@ type RowGroup struct {
 	Ordinal int16 `thrift:"7,optional,writezero"`
 }
 
+// Reset clears r in place, retaining allocated capacity for reuse. Elements
+// of the retained slices are recursively cleared so that values from a
+// previous thrift decode cannot leak into the next one (the decoder only
+// writes fields present in its input).
 func (r *RowGroup) Reset() {
-	r.FileOffset = 0
-	r.NumRows = 0
-	r.TotalByteSize = 0
-	r.SortingColumns = r.SortingColumns[:0]
+	for i := range r.Columns {
+		r.Columns[i].Reset()
+	}
 	r.Columns = r.Columns[:0]
-	r.Ordinal = 0
 	r.TotalByteSize = 0
+	r.NumRows = 0
+	clear(r.SortingColumns)
+	r.SortingColumns = r.SortingColumns[:0]
+	r.FileOffset = 0
 	r.TotalCompressedSize = 0
+	r.Ordinal = 0
 }
 
 // Empty struct to signal the order defined by the physical or logical type.

--- a/format/reset.go
+++ b/format/reset.go
@@ -1,0 +1,132 @@
+package format
+
+// The Reset methods in this file clear values in place while retaining
+// allocated slice capacity, so that a value can be reused as the decode
+// target of multiple thrift deserializations without allocating on each
+// decode (see FooterDecoder).
+//
+// Because the thrift decoder only writes fields that are present in the
+// input, Reset must recursively clear the elements of retained slices;
+// otherwise fields decoded from a previous input would leak into the next
+// decoded value. Union fields are the exception: the decoder itself clears
+// unions absent from the input and zeroes reused members, so Reset retains
+// their member allocations for the next decode to reuse.
+//
+// Byte slice and string fields decoded from footers alias the input buffer
+// (they are replaced, never reused, by the decoder), so Reset sets them to
+// nil or empty instead of truncating, releasing references to the previous
+// input buffer.
+
+// Reset clears m in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+//
+// Note that after reuse, optional list fields that are absent from the
+// decoded input are left empty but non-nil, whereas decoding into a fresh
+// FileMetaData leaves them nil. Both states are semantically equivalent
+// (zero-length), but programs distinguishing nil from empty slices, or
+// re-encoding the value, can observe the difference.
+func (m *FileMetaData) Reset() {
+	m.Version = 0
+	for i := range m.Schema {
+		m.Schema[i].Reset()
+	}
+	m.Schema = m.Schema[:0]
+	m.NumRows = 0
+	for i := range m.RowGroups {
+		m.RowGroups[i].Reset()
+	}
+	m.RowGroups = m.RowGroups[:0]
+	clear(m.KeyValueMetadata)
+	m.KeyValueMetadata = m.KeyValueMetadata[:0]
+	m.CreatedBy = ""
+	m.ColumnOrders = m.ColumnOrders[:0]
+	// EncryptionAlgorithm is a union; its member allocation is retained
+	// for reuse by the next decode (see SchemaElement.Reset).
+	m.FooterSigningKeyMetadata = nil
+}
+
+// Reset clears s in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (s *SchemaElement) Reset() {
+	s.Type.Reset()
+	s.TypeLength.Reset()
+	s.RepetitionType.Reset()
+	s.Name = ""
+	s.NumChildren.Reset()
+	s.ConvertedType.Reset()
+	s.Scale.Reset()
+	s.Precision.Reset()
+	s.FieldID = 0
+	// The LogicalType union member is deliberately retained: when the
+	// element is decoded again, the thrift decoder reuses the member
+	// allocation if the input holds the same member type (zeroing its
+	// contents first), and clears the union if the field is absent from
+	// the input. Either way no stale state survives a decode.
+}
+
+// Reset clears c in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (c *ColumnChunk) Reset() {
+	c.FilePath = ""
+	c.FileOffset = 0
+	c.MetaData.Reset()
+	c.OffsetIndexOffset = 0
+	c.OffsetIndexLength = 0
+	c.ColumnIndexOffset = 0
+	c.ColumnIndexLength = 0
+	// CryptoMetadata is a union; its member allocation is retained for
+	// reuse by the next decode (see SchemaElement.Reset).
+	c.EncryptedColumnMetadata = nil
+}
+
+// Reset clears c in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (c *ColumnMetaData) Reset() {
+	c.Type = 0
+	c.Encoding = c.Encoding[:0]
+	clear(c.PathInSchema)
+	c.PathInSchema = c.PathInSchema[:0]
+	c.Codec = 0
+	c.NumValues = 0
+	c.TotalUncompressedSize = 0
+	c.TotalCompressedSize = 0
+	clear(c.KeyValueMetadata)
+	c.KeyValueMetadata = c.KeyValueMetadata[:0]
+	c.DataPageOffset = 0
+	c.IndexPageOffset = 0
+	c.DictionaryPageOffset = 0
+	c.Statistics.Reset()
+	clear(c.EncodingStats)
+	c.EncodingStats = c.EncodingStats[:0]
+	c.BloomFilterOffset = 0
+	c.BloomFilterLength = 0
+	c.SizeStatistics.Reset()
+	c.GeospatialStatistics.Reset()
+}
+
+// Reset clears s in place. The byte slice fields are set to nil rather than
+// truncated because decoded values alias the input buffer and are always
+// replaced, never appended to.
+func (s *Statistics) Reset() {
+	s.Max = nil
+	s.Min = nil
+	s.NullCount = 0
+	s.DistinctCount = 0
+	s.MaxValue = nil
+	s.MinValue = nil
+}
+
+// Reset clears s in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (s *SizeStatistics) Reset() {
+	s.UnencodedByteArrayDataBytes = 0
+	s.RepetitionLevelHistogram = s.RepetitionLevelHistogram[:0]
+	s.DefinitionLevelHistogram = s.DefinitionLevelHistogram[:0]
+}
+
+// Reset clears g in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (g *GeospatialStatistics) Reset() {
+	g.BBox = BoundingBox{}
+	g.GeoSpatialTypes = g.GeoSpatialTypes[:0]
+}

--- a/format/reset.go
+++ b/format/reset.go
@@ -62,6 +62,17 @@ func (s *SchemaElement) Reset() {
 	// allocation if the input holds the same member type (zeroing its
 	// contents first), and clears the union if the field is absent from
 	// the input. Either way no stale state survives a decode.
+	//
+	// The Geometry and Geography members are the exception: their CRS
+	// strings alias the decode input buffer, which the owner of this value
+	// may overwrite before the next decode. Clear their contents so no
+	// retained member holds a reference into a buffer with unrelated data.
+	switch m := s.LogicalType.Value.(type) {
+	case *GeometryType:
+		*m = GeometryType{}
+	case *GeographyType:
+		*m = GeographyType{}
+	}
 }
 
 // Reset clears c in place, retaining allocated capacity for reuse in

--- a/format/reset.go
+++ b/format/reset.go
@@ -15,7 +15,10 @@ package format
 // Byte slice and string fields decoded from footers alias the input buffer
 // (they are replaced, never reused, by the decoder), so Reset sets them to
 // nil or empty instead of truncating, releasing references to the previous
-// input buffer.
+// input buffer. This includes the contents of retained union members whose
+// fields alias the buffer: the member allocation is kept for the next
+// decode to reuse, but its contents are zeroed so no retained member holds
+// a reference into a buffer with unrelated data.
 
 // Reset clears m in place, retaining allocated capacity for reuse in
 // subsequent thrift decodes.
@@ -40,10 +43,7 @@ func (m *FileMetaData) Reset() {
 	m.KeyValueMetadata = m.KeyValueMetadata[:0]
 	m.CreatedBy = ""
 	m.ColumnOrders = m.ColumnOrders[:0]
-	// EncryptionAlgorithm is a union; its member allocation is retained
-	// for reuse by the next decode (see SchemaElement.Reset). The members'
-	// byte slices alias the decode input buffer, so their contents are
-	// cleared like the CRS strings of SchemaElement.
+	// Retained union member; scrub buffer-aliasing contents (see file header).
 	switch v := m.EncryptionAlgorithm.Value.(type) {
 	case *AesGcmV1:
 		*v = AesGcmV1{}
@@ -65,16 +65,8 @@ func (s *SchemaElement) Reset() {
 	s.Scale.Reset()
 	s.Precision.Reset()
 	s.FieldID = 0
-	// The LogicalType union member is deliberately retained: when the
-	// element is decoded again, the thrift decoder reuses the member
-	// allocation if the input holds the same member type (zeroing its
-	// contents first), and clears the union if the field is absent from
-	// the input. Either way no stale state survives a decode.
-	//
-	// The Geometry and Geography members are the exception: their CRS
-	// strings alias the decode input buffer, which the owner of this value
-	// may overwrite before the next decode. Clear their contents so no
-	// retained member holds a reference into a buffer with unrelated data.
+	// Retained union member; scrub the buffer-aliasing CRS strings of the
+	// Geometry and Geography members (see file header).
 	switch m := s.LogicalType.Value.(type) {
 	case *GeometryType:
 		*m = GeometryType{}
@@ -93,11 +85,7 @@ func (c *ColumnChunk) Reset() {
 	c.OffsetIndexLength = 0
 	c.ColumnIndexOffset = 0
 	c.ColumnIndexLength = 0
-	// CryptoMetadata is a union; its member allocation is retained for
-	// reuse by the next decode (see SchemaElement.Reset). The column-key
-	// member's path strings and key metadata alias the decode input
-	// buffer, so its contents are cleared like the CRS strings of
-	// SchemaElement.
+	// Retained union member; scrub buffer-aliasing contents (see file header).
 	if v, ok := c.CryptoMetadata.Value.(*EncryptionWithColumnKey); ok {
 		*v = EncryptionWithColumnKey{}
 	}
@@ -120,38 +108,17 @@ func (c *ColumnMetaData) Reset() {
 	c.DataPageOffset = 0
 	c.IndexPageOffset = 0
 	c.DictionaryPageOffset = 0
-	c.Statistics.Reset()
+	// Statistics byte slices alias the input buffer (replaced, never
+	// appended to), so zero the whole struct instead of truncating.
+	c.Statistics = Statistics{}
 	clear(c.EncodingStats)
 	c.EncodingStats = c.EncodingStats[:0]
 	c.BloomFilterOffset = 0
 	c.BloomFilterLength = 0
-	c.SizeStatistics.Reset()
-	c.GeospatialStatistics.Reset()
-}
-
-// Reset clears s in place. The byte slice fields are set to nil rather than
-// truncated because decoded values alias the input buffer and are always
-// replaced, never appended to.
-func (s *Statistics) Reset() {
-	s.Max = nil
-	s.Min = nil
-	s.NullCount = 0
-	s.DistinctCount = 0
-	s.MaxValue = nil
-	s.MinValue = nil
-}
-
-// Reset clears s in place, retaining allocated capacity for reuse in
-// subsequent thrift decodes.
-func (s *SizeStatistics) Reset() {
-	s.UnencodedByteArrayDataBytes = 0
-	s.RepetitionLevelHistogram = s.RepetitionLevelHistogram[:0]
-	s.DefinitionLevelHistogram = s.DefinitionLevelHistogram[:0]
-}
-
-// Reset clears g in place, retaining allocated capacity for reuse in
-// subsequent thrift decodes.
-func (g *GeospatialStatistics) Reset() {
-	g.BBox = BoundingBox{}
-	g.GeoSpatialTypes = g.GeoSpatialTypes[:0]
+	// The histograms and geospatial types retain capacity.
+	c.SizeStatistics.UnencodedByteArrayDataBytes = 0
+	c.SizeStatistics.RepetitionLevelHistogram = c.SizeStatistics.RepetitionLevelHistogram[:0]
+	c.SizeStatistics.DefinitionLevelHistogram = c.SizeStatistics.DefinitionLevelHistogram[:0]
+	c.GeospatialStatistics.BBox = BoundingBox{}
+	c.GeospatialStatistics.GeoSpatialTypes = c.GeospatialStatistics.GeoSpatialTypes[:0]
 }

--- a/format/reset.go
+++ b/format/reset.go
@@ -41,7 +41,15 @@ func (m *FileMetaData) Reset() {
 	m.CreatedBy = ""
 	m.ColumnOrders = m.ColumnOrders[:0]
 	// EncryptionAlgorithm is a union; its member allocation is retained
-	// for reuse by the next decode (see SchemaElement.Reset).
+	// for reuse by the next decode (see SchemaElement.Reset). The members'
+	// byte slices alias the decode input buffer, so their contents are
+	// cleared like the CRS strings of SchemaElement.
+	switch v := m.EncryptionAlgorithm.Value.(type) {
+	case *AesGcmV1:
+		*v = AesGcmV1{}
+	case *AesGcmCtrV1:
+		*v = AesGcmCtrV1{}
+	}
 	m.FooterSigningKeyMetadata = nil
 }
 
@@ -86,7 +94,13 @@ func (c *ColumnChunk) Reset() {
 	c.ColumnIndexOffset = 0
 	c.ColumnIndexLength = 0
 	// CryptoMetadata is a union; its member allocation is retained for
-	// reuse by the next decode (see SchemaElement.Reset).
+	// reuse by the next decode (see SchemaElement.Reset). The column-key
+	// member's path strings and key metadata alias the decode input
+	// buffer, so its contents are cleared like the CRS strings of
+	// SchemaElement.
+	if v, ok := c.CryptoMetadata.Value.(*EncryptionWithColumnKey); ok {
+		*v = EncryptionWithColumnKey{}
+	}
 	c.EncryptedColumnMetadata = nil
 }
 


### PR DESCRIPTION
## Summary

This is the first of two stacked PRs aimed at programs that decode many parquet footers repeatedly (e.g. query engines caching file metadata). It adds a reusable, steady-state zero-allocation decode path for `format.FileMetaData`:

- **`format.FooterDecoder`**: a reusable decoder that retains its input buffer, thrift reader, and decoded `FileMetaData` across calls. `Decode(data)` returns the decoded metadata (valid until the next call), the number of bytes consumed (so callers can detect trailing footer signatures), and an error. Steady-state decodes of stable schemas perform **0 allocations/op**.
- **Capacity-preserving `Reset` methods** on `FileMetaData` and every reachable type, which clear values in place while retaining slice capacity, and release all references into the previous input buffer (decoded strings/byte slices alias the input).
- **Thrift decoder reuse semantics** (`encoding/thrift`): decoding into a non-zero value now produces the same result as decoding into a fresh one — pointer fields absent from the input are set to nil after decoding, and reused pointees are zeroed before decoding into them. This is what lets `Reset` retain allocated union arms (e.g. `LogicalType`) without leaking data between decodes.
- **Bug fixes found along the way**:
  - The `seen`/`required` bitmaps were sized by field *count* but indexed by sparse field-ID *span*, so a struct with required IDs spanning more than 64 (e.g. IDs 1 and 100) panicked; they are now sized by span.
  - In non-strict mode, a field with a mismatched wire type was counted as "seen" without being decoded (silently satisfying the required-field check) and its payload was not consumed (desynchronizing the stream). Mismatched fields are now skipped properly and reported as missing when required.
  - Skipping an unknown BINARY field through the zero-copy bytes readers never advanced their offset (their `Reader()` returns a positionless view), desynchronizing the stream; the bytes readers now implement `Discard`.

## Benchmarks

Decoding testdata footers through a reused `FooterDecoder` vs `thrift.Unmarshal` into a fresh value:

| footer | fresh Unmarshal | FooterDecoder (reused) |
|---|---|---|
| alltypes_tiny_pages_plain.parquet | ~59 µs/op, ~1100 allocs | ~18 µs/op, **0 allocs** |
| trace.snappy.parquet | ~195 µs/op, ~3300 allocs | ~60 µs/op, **0 allocs** |

## Testing

- Pairwise reuse test: every ordered pair of testdata footers decoded through one decoder, compared against a fresh decode.
- Synthetic maximal/minimal footer pair covering every optional field of the `FileMetaData` tree (sorting columns, non-zero ordinals, crypto metadata, geospatial types, ...) — fields no testdata footer populates.
- Input ownership, error recovery, trailing-signature tolerance, and `testing.AllocsPerRun` zero-allocation assertions.
- Direct unit tests for the thrift reuse semantics (unseen-pointer nil-ing, pointee zeroing, sparse-ID bitmaps, type-mismatch handling, unknown-binary skip), each verified to fail against the previous code.

Stacked PR 2 (public `parquet.Footer` API with a `WithFooter` open option) builds on this.

Made with [Cursor](https://cursor.com)