### PR TITLE
feat: immutable parquet.Footer with ReadFooter and the WithFooter open option

### DIFF
--- a/config.go
+++ b/config.go
@@ -572,36 +572,31 @@ func FileSchema(schema *Schema) FileOption {
 }
 
 // WithFooter is used to open a parquet file from an already-decoded footer,
-// obtained from ReadFooter, skipping the footer read and
-// decode entirely. Programs which open the same parquet files repeatedly can
-// cache footers to amortize the cost of decoding them:
+// obtained from ReadFooter, skipping the footer read and decode entirely.
+// Programs which open the same parquet files repeatedly can cache footers
+// to amortize the cost of decoding them:
 //
 //	footer, err := parquet.ReadFooter(reader, size)
 //	...
 //	f, err := parquet.OpenFile(reader, size, parquet.WithFooter(footer))
 //
 // Footers are immutable and safe for concurrent use: a single footer can
-// back any number of open files at the same time. The footer must correspond
-// to the file passed to OpenFile, and the size passed to OpenFile must be
-// the size of that file. OpenFile reports an error when the footer records a
-// different size, but footers read from a bare footer section carry no size and a footer
-// applied to the wrong file of the same size is not detected at open time:
-// it results in decode errors or corrupt reads later.
+// back any number of open files at the same time. The footer must
+// correspond to the file passed to OpenFile. OpenFile reports an error when
+// the footer records a different file size, but a footer applied to the
+// wrong file of the same size (or a footer read from a bare footer section,
+// which carries no size) is not detected at open time: it results in decode
+// errors or corrupt reads later.
 //
-// Because the footer is not read or decoded by OpenFile, the options that
-// affect footer reading and decoding are ignored when WithFooter is used;
-// they took effect when the footer was constructed instead. In particular
-// decryption is inherited from the footer: WithDecryption passed to OpenFile
-// has no effect, and encrypted files require the DecryptionConfig to be
-// passed to ReadFooter. SkipMagicBytes and OptimisticRead
-// only affect the footer read and are likewise ignored; note that without
-// OptimisticRead prefetching, the page index is read directly from r on
-// every open (the footer does not cache it), so footer-cached opens should
-// usually skip or separately cache the page index. FileSchema is still
-// honored and overrides the footer's schema.
-//
-// Combined with SkipPageIndex and SkipBloomFilters, opening a file with a
-// footer performs no I/O.
+// Options that affect footer reading and decoding (WithDecryption,
+// SkipMagicBytes, OptimisticRead) are ignored when WithFooter is used; they
+// took effect when the footer was constructed. In particular, encrypted
+// files require the DecryptionConfig to be passed to ReadFooter, and files
+// opened from the footer inherit it. The page index is not cached in the
+// footer and is read from r on every open, so footer-cached opens should
+// usually skip or separately cache it; combined with SkipPageIndex and
+// SkipBloomFilters, opening a file with a footer performs no I/O.
+// FileSchema is still honored and overrides the footer's schema.
 //
 // Defaults to nil.
 func WithFooter(footer *Footer) FileOption {

--- a/config.go
+++ b/config.go
@@ -581,8 +581,18 @@ func FileSchema(schema *Schema) FileOption {
 //	f, err := parquet.OpenFile(reader, size, parquet.WithFooter(footer))
 //
 // Footers are immutable and safe for concurrent use: a single footer can
-// back any number of open files at the same time. The size passed to
-// OpenFile must be the size of the file the footer was read from.
+// back any number of open files at the same time. The footer must have been
+// read from the same file passed to OpenFile, and the size passed to OpenFile
+// must be the size of that file (OpenFile reports an error when the footer
+// records a different size).
+//
+// Because the footer is not read or decoded by OpenFile, the options that
+// affect footer reading and decoding are ignored when WithFooter is used;
+// they took effect when the footer was constructed instead. In particular
+// decryption is inherited from the footer: WithDecryption passed to OpenFile
+// has no effect, and encrypted files require the DecryptionConfig to be
+// passed to ReadFooter or DecodeFooter. SkipMagicBytes, OptimisticRead, and
+// ReadBufferSize only affect the footer read and are likewise ignored.
 //
 // Combined with SkipPageIndex and SkipBloomFilters, opening a file with a
 // footer performs no I/O.

--- a/config.go
+++ b/config.go
@@ -581,18 +581,24 @@ func FileSchema(schema *Schema) FileOption {
 //	f, err := parquet.OpenFile(reader, size, parquet.WithFooter(footer))
 //
 // Footers are immutable and safe for concurrent use: a single footer can
-// back any number of open files at the same time. The footer must have been
-// read from the same file passed to OpenFile, and the size passed to OpenFile
-// must be the size of that file (OpenFile reports an error when the footer
-// records a different size).
+// back any number of open files at the same time. The footer must correspond
+// to the file passed to OpenFile, and the size passed to OpenFile must be
+// the size of that file. OpenFile reports an error when the footer records a
+// different size, but footers from DecodeFooter carry no size and a footer
+// applied to the wrong file of the same size is not detected at open time:
+// it results in decode errors or corrupt reads later.
 //
 // Because the footer is not read or decoded by OpenFile, the options that
 // affect footer reading and decoding are ignored when WithFooter is used;
 // they took effect when the footer was constructed instead. In particular
 // decryption is inherited from the footer: WithDecryption passed to OpenFile
 // has no effect, and encrypted files require the DecryptionConfig to be
-// passed to ReadFooter or DecodeFooter. SkipMagicBytes, OptimisticRead, and
-// ReadBufferSize only affect the footer read and are likewise ignored.
+// passed to ReadFooter or DecodeFooter. SkipMagicBytes and OptimisticRead
+// only affect the footer read and are likewise ignored; note that without
+// OptimisticRead prefetching, the page index is read directly from r on
+// every open (the footer does not cache it), so footer-cached opens should
+// usually skip or separately cache the page index. FileSchema is still
+// honored and overrides the footer's schema.
 //
 // Combined with SkipPageIndex and SkipBloomFilters, opening a file with a
 // footer performs no I/O.

--- a/config.go
+++ b/config.go
@@ -572,7 +572,7 @@ func FileSchema(schema *Schema) FileOption {
 }
 
 // WithFooter is used to open a parquet file from an already-decoded footer,
-// obtained from ReadFooter or DecodeFooter, skipping the footer read and
+// obtained from ReadFooter, skipping the footer read and
 // decode entirely. Programs which open the same parquet files repeatedly can
 // cache footers to amortize the cost of decoding them:
 //
@@ -584,7 +584,7 @@ func FileSchema(schema *Schema) FileOption {
 // back any number of open files at the same time. The footer must correspond
 // to the file passed to OpenFile, and the size passed to OpenFile must be
 // the size of that file. OpenFile reports an error when the footer records a
-// different size, but footers from DecodeFooter carry no size and a footer
+// different size, but footers read from a bare footer section carry no size and a footer
 // applied to the wrong file of the same size is not detected at open time:
 // it results in decode errors or corrupt reads later.
 //
@@ -593,7 +593,7 @@ func FileSchema(schema *Schema) FileOption {
 // they took effect when the footer was constructed instead. In particular
 // decryption is inherited from the footer: WithDecryption passed to OpenFile
 // has no effect, and encrypted files require the DecryptionConfig to be
-// passed to ReadFooter or DecodeFooter. SkipMagicBytes and OptimisticRead
+// passed to ReadFooter. SkipMagicBytes and OptimisticRead
 // only affect the footer read and are likewise ignored; note that without
 // OptimisticRead prefetching, the page index is read directly from r on
 // every open (the footer does not cache it), so footer-cached opens should

--- a/config.go
+++ b/config.go
@@ -106,6 +106,7 @@ type FileConfig struct {
 	ReadMode             ReadMode
 	Schema               *Schema
 	Decryption           *DecryptionConfig
+	Footer               *Footer
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
@@ -151,6 +152,7 @@ func (c *FileConfig) ConfigureFile(config *FileConfig) {
 		ReadMode:             ReadMode(cmp.Or(int(c.ReadMode), int(config.ReadMode))),
 		Schema:               cmp.Or(c.Schema, config.Schema),
 		Decryption:           cmp.Or(c.Decryption, config.Decryption),
+		Footer:               cmp.Or(c.Footer, config.Footer),
 	}
 }
 
@@ -567,6 +569,27 @@ func ReadBufferSize(size int) FileOption {
 // Defaults to nil.
 func FileSchema(schema *Schema) FileOption {
 	return fileOption(func(config *FileConfig) { config.Schema = schema })
+}
+
+// WithFooter is used to open a parquet file from an already-decoded footer,
+// obtained from ReadFooter or DecodeFooter, skipping the footer read and
+// decode entirely. Programs which open the same parquet files repeatedly can
+// cache footers to amortize the cost of decoding them:
+//
+//	footer, err := parquet.ReadFooter(reader, size)
+//	...
+//	f, err := parquet.OpenFile(reader, size, parquet.WithFooter(footer))
+//
+// Footers are immutable and safe for concurrent use: a single footer can
+// back any number of open files at the same time. The size passed to
+// OpenFile must be the size of the file the footer was read from.
+//
+// Combined with SkipPageIndex and SkipBloomFilters, opening a file with a
+// footer performs no I/O.
+//
+// Defaults to nil.
+func WithFooter(footer *Footer) FileOption {
+	return fileOption(func(config *FileConfig) { config.Footer = footer })
 }
 
 // PageBufferSize configures the size of column page buffers on parquet writers.

--- a/encoding/thrift/binary.go
+++ b/encoding/thrift/binary.go
@@ -413,6 +413,18 @@ func (r *binaryBytesReader) Reader() io.Reader {
 	return bytes.NewReader(r.data[r.offset:])
 }
 
+// Discard advances the reader past the next n bytes, reporting how many
+// bytes were discarded. Unlike reading through Reader(), it moves the
+// reader's own offset, which skip operations rely on.
+func (r *binaryBytesReader) Discard(n int) (int, error) {
+	if remain := len(r.data) - r.offset; remain < n {
+		r.offset = len(r.data)
+		return remain, io.ErrUnexpectedEOF
+	}
+	r.offset += n
+	return n, nil
+}
+
 func (r *binaryBytesReader) ReadBool() (bool, error) {
 	b, err := r.ReadByte()
 	// Thrift protocol treats both 0 and 2 as false.

--- a/encoding/thrift/compact.go
+++ b/encoding/thrift/compact.go
@@ -385,6 +385,18 @@ func (r *compactBytesReader) Reader() io.Reader {
 	return bytes.NewReader(r.data[r.offset:])
 }
 
+// Discard advances the reader past the next n bytes, reporting how many
+// bytes were discarded. Unlike reading through Reader(), it moves the
+// reader's own offset, which skip operations rely on.
+func (r *compactBytesReader) Discard(n int) (int, error) {
+	if remain := len(r.data) - r.offset; remain < n {
+		r.offset = len(r.data)
+		return remain, io.ErrUnexpectedEOF
+	}
+	r.offset += n
+	return n, nil
+}
+
 func (r *compactBytesReader) ReadBool() (bool, error) {
 	b, err := r.ReadByte()
 	// Thrift protocol treats both 0 and 2 as false.

--- a/encoding/thrift/debug.go
+++ b/encoding/thrift/debug.go
@@ -128,6 +128,30 @@ func (d *debugReader) BytesRead() int {
 	return d.r.BytesRead()
 }
 
+// Discard forwards discards to the wrapped reader, mirroring the cascade of
+// skipBinary. Without it, a debug-wrapped bytes-backed reader would fall
+// through to a throwaway Reader() view and the discard would not advance
+// the wrapped reader's offset, silently desynchronizing the stream.
+func (d *debugReader) Discard(n int) (int, error) {
+	type discarder interface{ Discard(int) (int, error) }
+	var v int
+	var err error
+	switch x := d.r.(type) {
+	case discarder:
+		v, err = x.Discard(n)
+	default:
+		if x, ok := d.r.Reader().(discarder); ok {
+			v, err = x.Discard(n)
+		} else {
+			var c int64
+			c, err = io.CopyN(io.Discard, d.r.Reader(), int64(n))
+			v = int(c)
+		}
+	}
+	d.log("Discard", v, err)
+	return v, err
+}
+
 type debugWriter struct {
 	w Writer
 	l *log.Logger

--- a/encoding/thrift/debug.go
+++ b/encoding/thrift/debug.go
@@ -128,26 +128,12 @@ func (d *debugReader) BytesRead() int {
 	return d.r.BytesRead()
 }
 
-// Discard forwards discards to the wrapped reader, mirroring the cascade of
-// skipBinary. Without it, a debug-wrapped bytes-backed reader would fall
-// through to a throwaway Reader() view and the discard would not advance
-// the wrapped reader's offset, silently desynchronizing the stream.
+// Discard forwards discards to the wrapped reader. Without it, a
+// debug-wrapped bytes-backed reader would fall through to a throwaway
+// Reader() view and the discard would not advance the wrapped reader's
+// offset, silently desynchronizing the stream.
 func (d *debugReader) Discard(n int) (int, error) {
-	type discarder interface{ Discard(int) (int, error) }
-	var v int
-	var err error
-	switch x := d.r.(type) {
-	case discarder:
-		v, err = x.Discard(n)
-	default:
-		if x, ok := d.r.Reader().(discarder); ok {
-			v, err = x.Discard(n)
-		} else {
-			var c int64
-			c, err = io.CopyN(io.Discard, d.r.Reader(), int64(n))
-			v = int(c)
-		}
-	}
+	v, err := discard(d.r, n)
 	d.log("Discard", v, err)
 	return v, err
 }

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -400,23 +400,18 @@ type structDecoder struct {
 	// optional fields but corrupts values where "which member is non-nil"
 	// carries meaning.
 	clears []int
-	// seenWords is the size of the bitmap needed to track which of the
-	// (sparse, id-indexed) fields were observed in the input.
-	seenWords int
 }
 
 func (dec *structDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	flags = flags.Only(decodeFlags)
 	coalesceBool := flags.Have(coalesceBoolFields)
 
+	// seen tracks which of the (sparse, id-indexed) fields were observed
+	// in the input; required is sized to the same word count.
 	var seenBuf [4]uint64
-	seen := seenBuf[:1]
-	if dec.seenWords > 1 {
-		if dec.seenWords <= len(seenBuf) {
-			seen = seenBuf[:dec.seenWords]
-		} else {
-			seen = make([]uint64, dec.seenWords)
-		}
+	seen := seenBuf[:]
+	if n := len(dec.required); n > len(seenBuf) {
+		seen = make([]uint64, n)
 	}
 
 	// Inlined readStruct loop to avoid closure overhead
@@ -443,25 +438,19 @@ decodeFields:
 		}
 
 		i := int(f.ID) - int(dec.minID)
-		if i < 0 || i >= len(dec.fields) || dec.fields[i].decode == nil {
-			if err := skip(r, f.Type); err != nil {
-				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
-			}
-			lastFieldID = f.ID
-			numFields++
-			continue decodeFields
+		var field *structDecoderField
+		if i >= 0 && i < len(dec.fields) && dec.fields[i].decode != nil {
+			field = &dec.fields[i]
 		}
-		field := &dec.fields[i]
-
+		// Unknown fields and (in non-strict mode) type-mismatched fields
+		// are consumed so the stream stays aligned, and left unseen: they
+		// were not decoded, so they must not satisfy the required check nor
+		// protect a stale pointer from the clearUnseen pass below.
 		// TODO: implement type conversions?
-		if f.Type != field.typ && !(f.Type == TRUE && field.typ == BOOL) {
-			if flags.Have(Strict) {
+		if field == nil || (f.Type != field.typ && !(f.Type == TRUE && field.typ == BOOL)) {
+			if field != nil && flags.Have(Strict) {
 				return &TypeMismatch{item: "field value", Expect: field.typ, Found: f.Type}
 			}
-			// Consume the mismatched value so the stream stays aligned, and
-			// leave the field unseen: it was not decoded, so it must not
-			// satisfy the required check nor protect a stale pointer from
-			// clearUnseenPtrs below.
 			if err := skip(r, f.Type); err != nil {
 				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
 			}
@@ -588,8 +577,7 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 
 	dec.fields = make([]structDecoderField, (maxID-minID)+1)
 	dec.minID = minID
-	dec.seenWords = (len(dec.fields) + 63) / 64
-	dec.required = make([]uint64, dec.seenWords)
+	dec.required = make([]uint64, (len(dec.fields)+63)/64)
 
 	for _, f := range fields {
 		i := f.id - minID
@@ -601,11 +589,8 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 		if f.flags.Have(Required) {
 			dec.required[i/64] |= 1 << (i % 64)
 		}
-	}
-
-	for i := range dec.fields {
-		if dec.fields[i].decode != nil && (dec.fields[i].isPtr || dec.fields[i].flags.Have(UnionType)) {
-			dec.clears = append(dec.clears, i)
+		if f.isPtr || f.flags.Have(UnionType) {
+			dec.clears = append(dec.clears, int(i))
 		}
 	}
 
@@ -700,20 +685,26 @@ func skipBinary(r Reader) error {
 	if n == 0 {
 		return nil
 	}
-	// The bytes-backed readers implement Discard themselves; their Reader()
-	// method returns a throwaway view that does not advance the read offset,
-	// so discarding through it would silently desynchronize the stream.
-	// Streaming readers discard through the underlying io.Reader when it
-	// supports it (*bufio.Reader does).
-	type discarder interface{ Discard(int) (int, error) }
-	if d, ok := r.(discarder); ok {
-		_, err = d.Discard(int(n))
-	} else if d, ok := r.Reader().(discarder); ok {
-		_, err = d.Discard(int(n))
-	} else {
-		_, err = io.CopyN(io.Discard, r.Reader(), int64(n))
-	}
+	_, err = discard(r, int(n))
 	return dontExpectEOF(err)
+}
+
+type discarder interface{ Discard(int) (int, error) }
+
+// discard advances r past n bytes. The bytes-backed readers implement
+// Discard themselves; their Reader() method returns a throwaway view that
+// does not advance the read offset, so discarding through it would silently
+// desynchronize the stream. Streaming readers discard through the
+// underlying io.Reader when it supports it (*bufio.Reader does).
+func discard(r Reader, n int) (int, error) {
+	if d, ok := r.(discarder); ok {
+		return d.Discard(n)
+	}
+	if d, ok := r.Reader().(discarder); ok {
+		return d.Discard(n)
+	}
+	c, err := io.CopyN(io.Discard, r.Reader(), int64(n))
+	return int(c), err
 }
 
 func skipList(r Reader) error {

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -453,17 +453,24 @@ decodeFields:
 			continue decodeFields
 		}
 		field := &dec.fields[i]
-		seen[i/64] |= 1 << (i % 64)
 
 		// TODO: implement type conversions?
 		if f.Type != field.typ && !(f.Type == TRUE && field.typ == BOOL) {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "field value", Expect: field.typ, Found: f.Type}
 			}
+			// Consume the mismatched value so the stream stays aligned, and
+			// leave the field unseen: it was not decoded, so it must not
+			// satisfy the required check nor protect a stale pointer from
+			// clearUnseenPtrs below.
+			if err := skip(r, f.Type); err != nil {
+				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
+			}
 			lastFieldID = f.ID
 			numFields++
 			continue decodeFields
 		}
+		seen[i/64] |= 1 << (i % 64)
 
 		x := v
 		for _, i := range field.index {
@@ -694,11 +701,19 @@ func skipBinary(r Reader) error {
 	if n == 0 {
 		return nil
 	}
-	switch x := r.Reader().(type) {
-	case *bufio.Reader:
+	// The bytes-backed readers implement Discard; their Reader() method
+	// returns a throwaway view that does not advance the read offset, so
+	// discarding through it would silently desynchronize the stream.
+	switch x := r.(type) {
+	case interface{ Discard(int) (int, error) }:
 		_, err = x.Discard(int(n))
 	default:
-		_, err = io.CopyN(io.Discard, x, int64(n))
+		switch x := r.Reader().(type) {
+		case *bufio.Reader:
+			_, err = x.Discard(int(n))
+		default:
+			_, err = io.CopyN(io.Discard, x, int64(n))
+		}
 	}
 	return dontExpectEOF(err)
 }

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -18,8 +18,11 @@ import (
 //
 // As an optimization, the value passed in v may be reused across multiple calls
 // to Unmarshal, allowing the function to reuse objects referenced by pointer
-// fields of struct values. When reusing objects, the application is responsible
-// for resetting the state of v before calling Unmarshal again.
+// fields of struct values: non-nil pointer fields present in the input have
+// their pointed-to value zeroed and decoded in place, and pointer fields
+// absent from the input are set to nil. When reusing objects, the application
+// remains responsible for resetting non-pointer state of v (scalars, strings,
+// and slice lengths) before calling Unmarshal again.
 func Unmarshal(p Protocol, b []byte, v any) error {
 	pr := p.NewReaderFromBytes(slices.Clone(b))
 
@@ -389,15 +392,32 @@ type structDecoder struct {
 	fields   []structDecoderField
 	minID    int16
 	required []uint64
+	// clears contains the indices (into fields) of pointer-typed and
+	// union-typed fields. Such fields absent from the input are zeroed
+	// after decoding, so that reusing a previously decoded value as the
+	// decode target produces the same result as decoding into a fresh
+	// value. Without this, stale pointers (or stale union members) from a
+	// previous decode would survive, which is invisible for regular
+	// optional fields but corrupts values where "which member is non-nil"
+	// carries meaning.
+	clears []int
+	// seenWords is the size of the bitmap needed to track which of the
+	// (sparse, id-indexed) fields were observed in the input.
+	seenWords int
 }
 
 func (dec *structDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	flags = flags.Only(decodeFlags)
 	coalesceBool := flags.Have(coalesceBoolFields)
 
-	seen := make([]uint64, 1)
-	if len(dec.required) > len(seen) {
-		seen = make([]uint64, len(dec.required))
+	var seenBuf [4]uint64
+	seen := seenBuf[:1]
+	if dec.seenWords > 1 {
+		if dec.seenWords <= len(seenBuf) {
+			seen = seenBuf[:dec.seenWords]
+		} else {
+			seen = make([]uint64, dec.seenWords)
+		}
 	}
 
 	// Inlined readStruct loop to avoid closure overhead
@@ -497,6 +517,28 @@ decodeFields:
 		}
 	}
 
+clearUnseen:
+	for _, i := range dec.clears {
+		if seen[i/64]&(1<<(i%64)) != 0 {
+			continue
+		}
+		x := v
+		for _, j := range dec.fields[i].index {
+			if x.Kind() == reflect.Ptr {
+				if x.IsNil() {
+					continue clearUnseen
+				}
+				x = x.Elem()
+			}
+			x = x.Field(j)
+		}
+		// x is either a pointer field or a union struct; zeroing a union
+		// nils its member interface, marking the union unset.
+		if x.Kind() != reflect.Ptr || !x.IsNil() {
+			x.SetZero()
+		}
+	}
+
 	return nil
 }
 
@@ -505,6 +547,7 @@ type structDecoderField struct {
 	id     int16
 	flags  Flags
 	typ    Type
+	isPtr  bool
 	decode DecodeFunc
 }
 
@@ -520,6 +563,7 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			id:     f.id,
 			flags:  f.flags,
 			typ:    TypeOf(f.typ),
+			isPtr:  f.typ.Kind() == reflect.Ptr,
 			decode: decodeFuncStructFieldOf(f, seen),
 		})
 	})
@@ -538,7 +582,8 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 
 	dec.fields = make([]structDecoderField, (maxID-minID)+1)
 	dec.minID = minID
-	dec.required = make([]uint64, len(fields)/64+1)
+	dec.seenWords = (len(dec.fields) + 63) / 64
+	dec.required = make([]uint64, dec.seenWords)
 
 	for _, f := range fields {
 		i := f.id - minID
@@ -549,6 +594,12 @@ func decodeFuncStructOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 		dec.fields[i] = f
 		if f.flags.Have(Required) {
 			dec.required[i/64] |= 1 << (i % 64)
+		}
+	}
+
+	for i := range dec.fields {
+		if dec.fields[i].decode != nil && (dec.fields[i].isPtr || dec.fields[i].flags.Have(UnionType)) {
+			dec.clears = append(dec.clears, i)
 		}
 	}
 
@@ -571,6 +622,11 @@ func decodeFuncPtrOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 	return func(r Reader, v reflect.Value, f Flags) error {
 		if v.IsNil() {
 			v.Set(reflect.New(elem))
+		} else {
+			// Reuse the allocation but not the contents: optional fields
+			// of the pointed-to value that are absent from the input must
+			// not survive from a previous decode.
+			v.Elem().SetZero()
 		}
 		return decode(r, v.Elem(), f)
 	}

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -253,7 +253,7 @@ func decodeFuncSliceOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "list item", Expect: typ, Found: l.Type}
 			}
-			return nil
+			return skipListItems(r, l)
 		}
 
 		size := int(l.Size)
@@ -308,14 +308,14 @@ func decodeFuncMapOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "map key", Expect: keyType, Found: m.Key}
 			}
-			return nil
+			return skipMapItems(r, m)
 		}
 
 		if elemType != m.Value {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "map value", Expect: elemType, Found: m.Value}
 			}
-			return nil
+			return skipMapItems(r, m)
 		}
 
 		tmpKey := reflect.New(key).Elem()
@@ -369,7 +369,7 @@ func decodeFuncMapAsSetOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "list item", Expect: typ, Found: s.Type}
 			}
-			return nil
+			return skipSetItems(r, s)
 		}
 
 		tmp := reflect.New(key).Elem()
@@ -721,12 +721,7 @@ func skipList(r Reader) error {
 	if err != nil {
 		return err
 	}
-	for i := range int(l.Size) {
-		if err := skip(r, l.Type); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorList{cause: l, index: i})
-		}
-	}
-	return nil
+	return skipListItems(r, l)
 }
 
 func skipSet(r Reader) error {
@@ -734,12 +729,7 @@ func skipSet(r Reader) error {
 	if err != nil {
 		return err
 	}
-	for i := range int(s.Size) {
-		if err := skip(r, s.Type); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorSet{cause: s, index: i})
-		}
-	}
-	return nil
+	return skipSetItems(r, s)
 }
 
 func skipMap(r Reader) error {
@@ -747,11 +737,52 @@ func skipMap(r Reader) error {
 	if err != nil {
 		return err
 	}
+	return skipMapItems(r, m)
+}
+
+// skipItem consumes one container element of the given type. Unlike bool
+// fields, whose value compact-protocol encoders coalesce into the field
+// type, bool container elements always occupy one byte.
+func skipItem(r Reader, t Type) error {
+	switch t {
+	case TRUE, FALSE:
+		_, err := r.ReadBool()
+		return err
+	default:
+		return skip(r, t)
+	}
+}
+
+// skipListItems, skipSetItems, and skipMapItems consume the elements of a
+// container whose header has already been read. They are used both by the
+// skip functions above and by the decoders when the elements cannot be
+// decoded into the target type: the payload must still be consumed, or the
+// reader would desynchronize from the stream.
+
+func skipListItems(r Reader, l List) error {
+	for i := range int(l.Size) {
+		if err := skipItem(r, l.Type); err != nil {
+			return with(dontExpectEOF(err), &decodeErrorList{cause: l, index: i})
+		}
+	}
+	return nil
+}
+
+func skipSetItems(r Reader, s Set) error {
+	for i := range int(s.Size) {
+		if err := skipItem(r, s.Type); err != nil {
+			return with(dontExpectEOF(err), &decodeErrorSet{cause: s, index: i})
+		}
+	}
+	return nil
+}
+
+func skipMapItems(r Reader, m Map) error {
 	for i := range int(m.Size) {
-		if err := skip(r, m.Key); err != nil {
+		if err := skipItem(r, m.Key); err != nil {
 			return with(dontExpectEOF(err), &decodeErrorMap{cause: m, index: i})
 		}
-		if err := skip(r, m.Value); err != nil {
+		if err := skipItem(r, m.Value); err != nil {
 			return with(dontExpectEOF(err), &decodeErrorMap{cause: m, index: i})
 		}
 	}

--- a/encoding/thrift/decode.go
+++ b/encoding/thrift/decode.go
@@ -1,7 +1,6 @@
 package thrift
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"maps"
@@ -701,19 +700,18 @@ func skipBinary(r Reader) error {
 	if n == 0 {
 		return nil
 	}
-	// The bytes-backed readers implement Discard; their Reader() method
-	// returns a throwaway view that does not advance the read offset, so
-	// discarding through it would silently desynchronize the stream.
-	switch x := r.(type) {
-	case interface{ Discard(int) (int, error) }:
-		_, err = x.Discard(int(n))
-	default:
-		switch x := r.Reader().(type) {
-		case *bufio.Reader:
-			_, err = x.Discard(int(n))
-		default:
-			_, err = io.CopyN(io.Discard, x, int64(n))
-		}
+	// The bytes-backed readers implement Discard themselves; their Reader()
+	// method returns a throwaway view that does not advance the read offset,
+	// so discarding through it would silently desynchronize the stream.
+	// Streaming readers discard through the underlying io.Reader when it
+	// supports it (*bufio.Reader does).
+	type discarder interface{ Discard(int) (int, error) }
+	if d, ok := r.(discarder); ok {
+		_, err = d.Discard(int(n))
+	} else if d, ok := r.Reader().(discarder); ok {
+		_, err = d.Discard(int(n))
+	} else {
+		_, err = io.CopyN(io.Discard, r.Reader(), int64(n))
 	}
 	return dontExpectEOF(err)
 }

--- a/encoding/thrift/list.go
+++ b/encoding/thrift/list.go
@@ -69,7 +69,7 @@ func (l Slice[T]) DecodeFunc(cache DecodeFuncCache) DecodeFunc {
 			if flags.Have(Strict) {
 				return &TypeMismatch{item: "list item", Expect: elemType, Found: listHeader.Type}
 			}
-			return nil
+			return skipListItems(r, listHeader)
 		}
 
 		size := int(listHeader.Size)

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -105,6 +105,120 @@ func TestUnmarshalReuseZeroesPointee(t *testing.T) {
 	}
 }
 
+// TestUnmarshalReuseTypeMismatchedField checks the non-strict handling of
+// fields whose wire type does not match the target: the value must be
+// consumed (keeping the stream aligned) and the field left untouched, in
+// particular pointer fields populated by a previous decode must be niled
+// exactly as if the field were absent from the input.
+func TestUnmarshalReuseTypeMismatchedField(t *testing.T) {
+	// Same field IDs as reuseOuter but with different wire types.
+	type mismatchedOuter struct {
+		Name  string `thrift:"1"`
+		Inner int32  `thrift:"2,optional"` // STRUCT expected, I32 sent
+		Count string `thrift:"3,optional"` // I64 expected, BINARY sent
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			count := int64(42)
+			first, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "first",
+				Inner: &reuseInner{A: 1, B: "one"},
+				Count: &count,
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			second, err := thrift.Marshal(p.proto, &mismatchedOuter{
+				Name:  "second",
+				Inner: 7,
+				Count: "not an integer",
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+
+			v := new(reuseOuter)
+			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
+				t.Fatal("unmarshal first:", err)
+			}
+			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
+				t.Fatal("unmarshal second:", err)
+			}
+			if v.Name != "second" {
+				t.Errorf("Name = %q, want %q (stream desynchronized?)", v.Name, "second")
+			}
+			if v.Inner != nil {
+				t.Errorf("Inner = %+v, want nil: stale pointer survived a type-mismatched field", v.Inner)
+			}
+			if v.Count != nil {
+				t.Errorf("Count = %d, want nil: stale pointer survived a type-mismatched field", *v.Count)
+			}
+		})
+	}
+}
+
+// TestUnmarshalRequiredTypeMismatch checks that a required field whose wire
+// type does not match is reported as missing rather than silently accepted
+// with a zero value.
+func TestUnmarshalRequiredTypeMismatch(t *testing.T) {
+	type point struct {
+		X float64 `thrift:"1,required"`
+		Y float64 `thrift:"2,required"`
+	}
+	type mismatchedPoint struct {
+		X string  `thrift:"1"` // DOUBLE expected, BINARY sent
+		Y float64 `thrift:"2"`
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &mismatchedPoint{X: "oops", Y: 2})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			err = thrift.Unmarshal(p.proto, b, new(point))
+			missing := new(thrift.MissingField)
+			if !errors.As(err, &missing) {
+				t.Fatalf("expected MissingField error, got %v", err)
+			}
+			if missing.Field.ID != 1 {
+				t.Errorf("missing field ID = %d, want 1", missing.Field.ID)
+			}
+		})
+	}
+}
+
+// TestUnmarshalSkipsUnknownBinaryField checks that skipping an unknown
+// string/binary field advances the reader correctly, so that known fields
+// following it still decode. This exercises the Discard path of the
+// bytes-backed readers, whose Reader() method returns a positionless view.
+func TestUnmarshalSkipsUnknownBinaryField(t *testing.T) {
+	type withString struct {
+		S string `thrift:"1"`
+		B int64  `thrift:"2"`
+	}
+	type withoutString struct {
+		B int64 `thrift:"2"`
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &withString{S: "skip me entirely", B: 42})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			v := new(withoutString)
+			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
+				t.Fatal("unmarshal:", err)
+			}
+			if v.B != 42 {
+				t.Errorf("B = %d, want 42 (unknown binary field was not skipped correctly)", v.B)
+			}
+		})
+	}
+}
+
 // sparseIDs has a field ID span (1..100) wider than one 64-bit bitmap word
 // while declaring only two fields, exercising the sparse sizing of the seen
 // and required bitmaps in the struct decoder.

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -189,6 +189,54 @@ func TestUnmarshalRequiredTypeMismatch(t *testing.T) {
 	}
 }
 
+// TestUnmarshalContainerElementTypeMismatch checks the non-strict handling
+// of containers whose element wire type does not match the target: the
+// elements must still be consumed so that fields following the container
+// decode correctly. Without the skip, the binary protocol fails with
+// trailing bytes and the compact protocol silently misparses the next
+// field.
+func TestUnmarshalContainerElementTypeMismatch(t *testing.T) {
+	type source struct {
+		List  []string             `thrift:"1"`
+		Slice thrift.Slice[string] `thrift:"2"`
+		Map   map[string]string    `thrift:"3"`
+		Set   map[string]struct{}  `thrift:"4"`
+		After int64                `thrift:"5"`
+	}
+	type target struct {
+		List  []int64             `thrift:"1"`
+		Slice thrift.Slice[int64] `thrift:"2"`
+		Map   map[int64]int64     `thrift:"3"`
+		Set   map[int64]struct{}  `thrift:"4"`
+		After int64               `thrift:"5"`
+	}
+
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &source{
+				List:  []string{"a", "bc"},
+				Slice: thrift.Slice[string]{"def"},
+				Map:   map[string]string{"key": "value"},
+				Set:   map[string]struct{}{"member": {}},
+				After: 42,
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			v := new(target)
+			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
+				t.Fatal("unmarshal:", err)
+			}
+			if len(v.List) != 0 || len(v.Slice) != 0 || len(v.Map) != 0 || len(v.Set) != 0 {
+				t.Errorf("mismatched containers should decode empty, got %+v", v)
+			}
+			if v.After != 42 {
+				t.Errorf("After = %d, want 42 (stream desynchronized by a mismatched container)", v.After)
+			}
+		})
+	}
+}
+
 // TestUnmarshalSkipsUnknownBinaryField checks that skipping an unknown
 // string/binary field advances the reader correctly, so that known fields
 // following it still decode. This exercises the Discard path of the

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -1,0 +1,151 @@
+package thrift_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+)
+
+// These tests exercise the decode-target reuse semantics documented on
+// Unmarshal: when decoding into a value that already holds data from a
+// previous decode, pointer fields absent from the input are set to nil, and
+// reused pointees are zeroed before decoding so no stale fields leak through.
+
+type reuseInner struct {
+	A int64  `thrift:"1,optional"`
+	B string `thrift:"2,optional"`
+}
+
+type reuseOuter struct {
+	Name  string      `thrift:"1"`
+	Inner *reuseInner `thrift:"2,optional"`
+	Count *int64      `thrift:"3,optional"`
+}
+
+func TestUnmarshalReuseNilsUnseenPointers(t *testing.T) {
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			count := int64(42)
+			first, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "first",
+				Inner: &reuseInner{A: 1, B: "one"},
+				Count: &count,
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			second, err := thrift.Marshal(p.proto, &reuseOuter{Name: "second"})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+
+			v := new(reuseOuter)
+			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
+				t.Fatal("unmarshal first:", err)
+			}
+			if v.Inner == nil || v.Count == nil {
+				t.Fatalf("first decode did not populate pointer fields: %+v", v)
+			}
+
+			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
+				t.Fatal("unmarshal second:", err)
+			}
+			if v.Name != "second" {
+				t.Errorf("Name = %q, want %q", v.Name, "second")
+			}
+			if v.Inner != nil {
+				t.Errorf("Inner = %+v, want nil after decoding input without field 2", v.Inner)
+			}
+			if v.Count != nil {
+				t.Errorf("Count = %d, want nil after decoding input without field 3", *v.Count)
+			}
+		})
+	}
+}
+
+func TestUnmarshalReuseZeroesPointee(t *testing.T) {
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			first, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "first",
+				Inner: &reuseInner{A: 1, B: "one"},
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			// Second input sets Inner.A but not Inner.B.
+			second, err := thrift.Marshal(p.proto, &reuseOuter{
+				Name:  "second",
+				Inner: &reuseInner{A: 2},
+			})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+
+			v := new(reuseOuter)
+			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
+				t.Fatal("unmarshal first:", err)
+			}
+			firstInner := v.Inner
+
+			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
+				t.Fatal("unmarshal second:", err)
+			}
+			if v.Inner != firstInner {
+				t.Error("Inner pointer was reallocated instead of reused")
+			}
+			if v.Inner.A != 2 {
+				t.Errorf("Inner.A = %d, want 2", v.Inner.A)
+			}
+			if v.Inner.B != "" {
+				t.Errorf("Inner.B = %q, want empty: stale value leaked from previous decode", v.Inner.B)
+			}
+		})
+	}
+}
+
+// sparseIDs has a field ID span (1..100) wider than one 64-bit bitmap word
+// while declaring only two fields, exercising the sparse sizing of the seen
+// and required bitmaps in the struct decoder.
+type sparseIDs struct {
+	First int64 `thrift:"1,required"`
+	Last  int64 `thrift:"100,required"`
+}
+
+type sparseIDsPartial struct {
+	First int64 `thrift:"1"`
+}
+
+func TestUnmarshalSparseFieldIDs(t *testing.T) {
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) {
+			b, err := thrift.Marshal(p.proto, &sparseIDs{First: 1, Last: 100})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			v := new(sparseIDs)
+			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
+				t.Fatal("unmarshal:", err)
+			}
+			if v.First != 1 || v.Last != 100 {
+				t.Errorf("got %+v, want {First:1 Last:100}", v)
+			}
+
+			// Input missing required field 100 must be rejected, which
+			// requires the required bitmap to cover the full ID span.
+			partial, err := thrift.Marshal(p.proto, &sparseIDsPartial{First: 1})
+			if err != nil {
+				t.Fatal("marshal:", err)
+			}
+			err = thrift.Unmarshal(p.proto, partial, new(sparseIDs))
+			missing := new(thrift.MissingField)
+			if !errors.As(err, &missing) {
+				t.Fatalf("expected MissingField error, got %v", err)
+			}
+			if missing.Field.ID != 100 {
+				t.Errorf("missing field ID = %d, want 100", missing.Field.ID)
+			}
+		})
+	}
+}

--- a/encoding/thrift/reuse_test.go
+++ b/encoding/thrift/reuse_test.go
@@ -12,6 +12,22 @@ import (
 // previous decode, pointer fields absent from the input are set to nil, and
 // reused pointees are zeroed before decoding so no stale fields leak through.
 
+func mustMarshal(t *testing.T, p thrift.Protocol, v any) []byte {
+	t.Helper()
+	b, err := thrift.Marshal(p, v)
+	if err != nil {
+		t.Fatal("marshal:", err)
+	}
+	return b
+}
+
+func mustUnmarshal(t *testing.T, p thrift.Protocol, b []byte, v any) {
+	t.Helper()
+	if err := thrift.Unmarshal(p, b, v); err != nil {
+		t.Fatal("unmarshal:", err)
+	}
+}
+
 type reuseInner struct {
 	A int64  `thrift:"1,optional"`
 	B string `thrift:"2,optional"`
@@ -27,30 +43,20 @@ func TestUnmarshalReuseNilsUnseenPointers(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
 			count := int64(42)
-			first, err := thrift.Marshal(p.proto, &reuseOuter{
+			first := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "first",
 				Inner: &reuseInner{A: 1, B: "one"},
 				Count: &count,
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			second, err := thrift.Marshal(p.proto, &reuseOuter{Name: "second"})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
+			second := mustMarshal(t, p.proto, &reuseOuter{Name: "second"})
 
 			v := new(reuseOuter)
-			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
-				t.Fatal("unmarshal first:", err)
-			}
+			mustUnmarshal(t, p.proto, first, v)
 			if v.Inner == nil || v.Count == nil {
 				t.Fatalf("first decode did not populate pointer fields: %+v", v)
 			}
 
-			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
-				t.Fatal("unmarshal second:", err)
-			}
+			mustUnmarshal(t, p.proto, second, v)
 			if v.Name != "second" {
 				t.Errorf("Name = %q, want %q", v.Name, "second")
 			}
@@ -67,31 +73,21 @@ func TestUnmarshalReuseNilsUnseenPointers(t *testing.T) {
 func TestUnmarshalReuseZeroesPointee(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			first, err := thrift.Marshal(p.proto, &reuseOuter{
+			first := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "first",
 				Inner: &reuseInner{A: 1, B: "one"},
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 			// Second input sets Inner.A but not Inner.B.
-			second, err := thrift.Marshal(p.proto, &reuseOuter{
+			second := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "second",
 				Inner: &reuseInner{A: 2},
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 
 			v := new(reuseOuter)
-			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
-				t.Fatal("unmarshal first:", err)
-			}
+			mustUnmarshal(t, p.proto, first, v)
 			firstInner := v.Inner
 
-			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
-				t.Fatal("unmarshal second:", err)
-			}
+			mustUnmarshal(t, p.proto, second, v)
 			if v.Inner != firstInner {
 				t.Error("Inner pointer was reallocated instead of reused")
 			}
@@ -121,30 +117,20 @@ func TestUnmarshalReuseTypeMismatchedField(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
 			count := int64(42)
-			first, err := thrift.Marshal(p.proto, &reuseOuter{
+			first := mustMarshal(t, p.proto, &reuseOuter{
 				Name:  "first",
 				Inner: &reuseInner{A: 1, B: "one"},
 				Count: &count,
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			second, err := thrift.Marshal(p.proto, &mismatchedOuter{
+			second := mustMarshal(t, p.proto, &mismatchedOuter{
 				Name:  "second",
 				Inner: 7,
 				Count: "not an integer",
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 
 			v := new(reuseOuter)
-			if err := thrift.Unmarshal(p.proto, first, v); err != nil {
-				t.Fatal("unmarshal first:", err)
-			}
-			if err := thrift.Unmarshal(p.proto, second, v); err != nil {
-				t.Fatal("unmarshal second:", err)
-			}
+			mustUnmarshal(t, p.proto, first, v)
+			mustUnmarshal(t, p.proto, second, v)
 			if v.Name != "second" {
 				t.Errorf("Name = %q, want %q (stream desynchronized?)", v.Name, "second")
 			}
@@ -173,11 +159,8 @@ func TestUnmarshalRequiredTypeMismatch(t *testing.T) {
 
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &mismatchedPoint{X: "oops", Y: 2})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			err = thrift.Unmarshal(p.proto, b, new(point))
+			b := mustMarshal(t, p.proto, &mismatchedPoint{X: "oops", Y: 2})
+			err := thrift.Unmarshal(p.proto, b, new(point))
 			missing := new(thrift.MissingField)
 			if !errors.As(err, &missing) {
 				t.Fatalf("expected MissingField error, got %v", err)
@@ -213,20 +196,15 @@ func TestUnmarshalContainerElementTypeMismatch(t *testing.T) {
 
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &source{
+			b := mustMarshal(t, p.proto, &source{
 				List:  []string{"a", "bc"},
 				Slice: thrift.Slice[string]{"def"},
 				Map:   map[string]string{"key": "value"},
 				Set:   map[string]struct{}{"member": {}},
 				After: 42,
 			})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
 			v := new(target)
-			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
-				t.Fatal("unmarshal:", err)
-			}
+			mustUnmarshal(t, p.proto, b, v)
 			if len(v.List) != 0 || len(v.Slice) != 0 || len(v.Map) != 0 || len(v.Set) != 0 {
 				t.Errorf("mismatched containers should decode empty, got %+v", v)
 			}
@@ -252,14 +230,9 @@ func TestUnmarshalSkipsUnknownBinaryField(t *testing.T) {
 
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &withString{S: "skip me entirely", B: 42})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
+			b := mustMarshal(t, p.proto, &withString{S: "skip me entirely", B: 42})
 			v := new(withoutString)
-			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
-				t.Fatal("unmarshal:", err)
-			}
+			mustUnmarshal(t, p.proto, b, v)
 			if v.B != 42 {
 				t.Errorf("B = %d, want 42 (unknown binary field was not skipped correctly)", v.B)
 			}
@@ -282,25 +255,17 @@ type sparseIDsPartial struct {
 func TestUnmarshalSparseFieldIDs(t *testing.T) {
 	for _, p := range protocols {
 		t.Run(p.name, func(t *testing.T) {
-			b, err := thrift.Marshal(p.proto, &sparseIDs{First: 1, Last: 100})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
+			b := mustMarshal(t, p.proto, &sparseIDs{First: 1, Last: 100})
 			v := new(sparseIDs)
-			if err := thrift.Unmarshal(p.proto, b, v); err != nil {
-				t.Fatal("unmarshal:", err)
-			}
+			mustUnmarshal(t, p.proto, b, v)
 			if v.First != 1 || v.Last != 100 {
 				t.Errorf("got %+v, want {First:1 Last:100}", v)
 			}
 
 			// Input missing required field 100 must be rejected, which
 			// requires the required bitmap to cover the full ID span.
-			partial, err := thrift.Marshal(p.proto, &sparseIDsPartial{First: 1})
-			if err != nil {
-				t.Fatal("marshal:", err)
-			}
-			err = thrift.Unmarshal(p.proto, partial, new(sparseIDs))
+			partial := mustMarshal(t, p.proto, &sparseIDsPartial{First: 1})
+			err := thrift.Unmarshal(p.proto, partial, new(sparseIDs))
 			missing := new(thrift.MissingField)
 			if !errors.As(err, &missing) {
 				t.Fatalf("expected MissingField error, got %v", err)

--- a/encoding/thrift/union.go
+++ b/encoding/thrift/union.go
@@ -232,11 +232,8 @@ func (dec *unionDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	// member of the same type, its allocation is reused instead of
 	// allocating a fresh value.
 	x := v.Field(dec.field)
-	prev := reflect.Value{}
-	if !x.IsNil() {
-		prev = x.Elem()
-		x.SetZero()
-	}
+	prev := x.Elem() // invalid when the union was unset
+	x.SetZero()
 
 	lastFieldID := int16(0)
 	numFields := 0

--- a/encoding/thrift/union.go
+++ b/encoding/thrift/union.go
@@ -212,7 +212,10 @@ type unionDecoderMember struct {
 	// interned is a shared *T for zero-sized members, invalid otherwise.
 	interned reflect.Value
 	typ      reflect.Type
-	decode   DecodeFunc
+	// ptrTyp is *typ, kept to test whether a previously decoded member can
+	// be reused as the decode target without allocating.
+	ptrTyp reflect.Type
+	decode DecodeFunc
 }
 
 type unionDecoder struct {
@@ -224,9 +227,16 @@ type unionDecoder struct {
 func (dec *unionDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 	flags = flags.Only(decodeFlags)
 
-	// Reset so that decoding into a reused value cannot retain a stale member.
+	// Reset so that decoding into a reused value cannot retain a stale
+	// member, but remember the previous member: when the input holds a
+	// member of the same type, its allocation is reused instead of
+	// allocating a fresh value.
 	x := v.Field(dec.field)
-	x.SetZero()
+	prev := reflect.Value{}
+	if !x.IsNil() {
+		prev = x.Elem()
+		x.SetZero()
+	}
 
 	lastFieldID := int16(0)
 	numFields := 0
@@ -273,7 +283,12 @@ func (dec *unionDecoder) decode(r Reader, v reflect.Value, flags Flags) error {
 
 			p := m.interned
 			if !p.IsValid() {
-				p = reflect.New(m.typ)
+				if prev.IsValid() && prev.Type() == m.ptrTyp && !prev.IsNil() {
+					p = prev
+					p.Elem().SetZero()
+				} else {
+					p = reflect.New(m.typ)
+				}
 			}
 			if err := m.decode(r, p.Elem(), flags); err != nil {
 				return with(dontExpectEOF(err), &decodeErrorField{cause: f})
@@ -301,6 +316,7 @@ func decodeFuncUnionOf(t reflect.Type, seen DecodeFuncCache) DecodeFunc {
 		dec.members[m.id-layout.minID] = unionDecoderMember{
 			interned: m.interned,
 			typ:      m.typ,
+			ptrTyp:   reflect.PointerTo(m.typ),
 			decode:   DecodeFuncOf(m.typ, seen),
 		}
 	}

--- a/encrypt_internal_test.go
+++ b/encrypt_internal_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/parquet-go/parquet-go/format"
 )
 
-// TestValidateRowGroupOrdinalsAllZeroBackfilled covers the "writer omitted the
+// TestNormalizeRowGroupOrdinalsAllZeroBackfilled covers the "writer omitted the
 // optional Ordinal field" case: every value is zero, so the validator should
 // back-fill sequential ordinals and not return an error.
-func TestValidateRowGroupOrdinalsAllZeroBackfilled(t *testing.T) {
+func TestNormalizeRowGroupOrdinalsAllZeroBackfilled(t *testing.T) {
 	rgs := []format.RowGroup{{Ordinal: 0}, {Ordinal: 0}, {Ordinal: 0}}
-	if err := validateRowGroupOrdinals(rgs); err != nil {
+	if err := normalizeRowGroupOrdinals(rgs); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	for i, rg := range rgs {
@@ -22,11 +22,11 @@ func TestValidateRowGroupOrdinalsAllZeroBackfilled(t *testing.T) {
 	}
 }
 
-// TestValidateRowGroupOrdinalsSequentialAccepted covers explicit, sequential,
+// TestNormalizeRowGroupOrdinalsSequentialAccepted covers explicit, sequential,
 // in-order ordinals: the validator must accept them unchanged.
-func TestValidateRowGroupOrdinalsSequentialAccepted(t *testing.T) {
+func TestNormalizeRowGroupOrdinalsSequentialAccepted(t *testing.T) {
 	rgs := []format.RowGroup{{Ordinal: 0}, {Ordinal: 1}, {Ordinal: 2}}
-	if err := validateRowGroupOrdinals(rgs); err != nil {
+	if err := normalizeRowGroupOrdinals(rgs); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	for i, rg := range rgs {
@@ -36,30 +36,30 @@ func TestValidateRowGroupOrdinalsSequentialAccepted(t *testing.T) {
 	}
 }
 
-// TestValidateRowGroupOrdinalsMismatchRejected verifies that files with
+// TestNormalizeRowGroupOrdinalsMismatchRejected verifies that files with
 // non-sequential row group ordinals (e.g. [0,2]) are rejected.  Downstream
 // code — page-index lookup and AAD construction for column encryption —
 // assumes rg.Ordinal == slice index, so accepting [0,2] would silently
 // produce wrong AADs or out-of-range page-index lookups.  Regression for
 // codex finding 5.
-func TestValidateRowGroupOrdinalsMismatchRejected(t *testing.T) {
+func TestNormalizeRowGroupOrdinalsMismatchRejected(t *testing.T) {
 	rgs := []format.RowGroup{{Ordinal: 0}, {Ordinal: 2}}
-	err := validateRowGroupOrdinals(rgs)
+	err := normalizeRowGroupOrdinals(rgs)
 	if err == nil {
-		t.Fatal("expected validateRowGroupOrdinals([0,2]) to fail, got nil")
+		t.Fatal("expected normalizeRowGroupOrdinals([0,2]) to fail, got nil")
 	}
 	if !strings.Contains(err.Error(), "does not match its position") {
 		t.Errorf("expected 'does not match its position' in error, got %q", err.Error())
 	}
 }
 
-// TestValidateRowGroupOrdinalsOutOfOrderRejected covers a different mismatch:
+// TestNormalizeRowGroupOrdinalsOutOfOrderRejected covers a different mismatch:
 // every ordinal is unique and within range, but the order does not match the
 // slice — also incompatible with the rg.Ordinal == slice-index assumption.
-func TestValidateRowGroupOrdinalsOutOfOrderRejected(t *testing.T) {
+func TestNormalizeRowGroupOrdinalsOutOfOrderRejected(t *testing.T) {
 	rgs := []format.RowGroup{{Ordinal: 1}, {Ordinal: 0}}
-	err := validateRowGroupOrdinals(rgs)
+	err := normalizeRowGroupOrdinals(rgs)
 	if err == nil {
-		t.Fatal("expected validateRowGroupOrdinals([1,0]) to fail, got nil")
+		t.Fatal("expected normalizeRowGroupOrdinals([1,0]) to fail, got nil")
 	}
 }

--- a/file.go
+++ b/file.go
@@ -28,6 +28,7 @@ const (
 // here: https://github.com/apache/parquet-format#file-format
 type File struct {
 	metadata      *format.FileMetaData
+	footer        *Footer
 	protocol      thrift.CompactProtocol
 	reader        io.ReaderAt
 	size          int64
@@ -81,15 +82,24 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		if footer, reader, err = readFooter(r, size, c); err != nil {
 			return nil, err
 		}
-	} else if footer.size != 0 && footer.size != size {
-		// Guards against passing a cached footer with the wrong file: a
-		// footer read from a file of a different size cannot be the footer
-		// of this one.
-		return nil, fmt.Errorf("opening parquet file of size %d with footer read from a file of size %d", size, footer.size)
+		footer.size = size
+	} else {
+		if len(footer.metadata.Schema) == 0 {
+			// The constructors validate the schema, so an empty one means
+			// the footer is a hand-constructed zero value.
+			return nil, fmt.Errorf("opening parquet file with a footer that was not created by ReadFooter, DecodeFooter, or File.Footer")
+		}
+		if footer.size != 0 && footer.size != size {
+			// Guards against passing a cached footer with the wrong file: a
+			// footer read from a file of a different size cannot be the
+			// footer of this one.
+			return nil, fmt.Errorf("opening parquet file of size %d with footer read from a file of size %d", size, footer.size)
+		}
 	}
 
 	f := &File{
 		metadata:   &footer.metadata,
+		footer:     footer,
 		reader:     reader,
 		size:       size,
 		config:     c,
@@ -108,9 +118,14 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		return nil, fmt.Errorf("opening columns of parquet file: %w", err)
 	}
 
-	if c.Schema != nil {
+	switch {
+	case c.Schema != nil:
 		f.schema = c.Schema
-	} else {
+	case c.Footer != nil && c.Footer.Schema() != nil:
+		// Footers from the public constructors already carry a schema built
+		// from the same metadata; share it instead of rebuilding.
+		f.schema = c.Footer.Schema()
+	default:
 		f.schema = NewSchema(f.root.Name(), f.root)
 	}
 	columns := makeLeafColumns(f.root)
@@ -409,6 +424,16 @@ func (f *File) Schema() *Schema { return f.schema }
 // is shared with the footer (and any other files opened from it) and must be
 // treated as read-only.
 func (f *File) Metadata() *format.FileMetaData { return f.metadata }
+
+// Footer returns the footer of f, suitable for caching and for opening the
+// same file again with the WithFooter option. When f was opened with
+// WithFooter, the footer it was opened with is returned; otherwise the
+// footer read by OpenFile is returned, so programs that cache footers do
+// not need a separate ReadFooter call after opening a file.
+//
+// Like the footer's other consumers, callers must treat the returned value
+// as read-only.
+func (f *File) Footer() *Footer { return f.footer }
 
 // Size returns the size of f (in bytes).
 func (f *File) Size() int64 { return f.size }

--- a/file.go
+++ b/file.go
@@ -81,6 +81,11 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		if footer, reader, err = readFooter(r, size, c); err != nil {
 			return nil, err
 		}
+	} else if footer.size != 0 && footer.size != size {
+		// Guards against passing a cached footer with the wrong file: a
+		// footer read from a file of a different size cannot be the footer
+		// of this one.
+		return nil, fmt.Errorf("opening parquet file of size %d with footer read from a file of size %d", size, footer.size)
 	}
 
 	f := &File{

--- a/file.go
+++ b/file.go
@@ -79,15 +79,14 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	// It is unwrapped before the file is returned.
 	footer, reader := c.Footer, r
 	if footer == nil {
-		if footer, reader, err = readFooter(r, size, c); err != nil {
+		if footer, reader, err = readFooter(r, size, c, false); err != nil {
 			return nil, err
 		}
-		footer.size = size
 	} else {
 		if len(footer.metadata.Schema) == 0 {
 			// The constructors validate the schema, so an empty one means
 			// the footer is a hand-constructed zero value.
-			return nil, fmt.Errorf("opening parquet file with a footer that was not created by ReadFooter, DecodeFooter, or File.Footer")
+			return nil, fmt.Errorf("opening parquet file with a footer that was not created by ReadFooter or File.Footer")
 		}
 		if footer.size != 0 && footer.size != size {
 			// Guards against passing a cached footer with the wrong file: a

--- a/file.go
+++ b/file.go
@@ -27,7 +27,7 @@ const (
 // File represents a parquet file. The layout of a Parquet file can be found
 // here: https://github.com/apache/parquet-format#file-format
 type File struct {
-	metadata      format.FileMetaData
+	metadata      *format.FileMetaData
 	protocol      thrift.CompactProtocol
 	reader        io.ReaderAt
 	size          int64
@@ -62,169 +62,35 @@ type FileView interface {
 // Only the parquet magic bytes and footer are read, column chunks and other
 // parts of the file are left untouched; this means that successfully opening
 // a file does not validate that the pages have valid checksums.
+//
+// If the WithFooter option is used, the footer is not read from r at all:
+// the file is opened from the already-decoded footer, and r is only accessed
+// to read the page index and bloom filters (unless those are skipped too, in
+// which case OpenFile performs no reads).
 func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	c, err := NewFileConfig(options...)
 	if err != nil {
 		return nil, err
 	}
-	f := &File{reader: r, size: size, config: c}
 
-	var headerMagic [4]byte
-	if !c.SkipMagicBytes {
-		if _, err := readAt(r, headerMagic[:], 0); err != nil {
-			return nil, fmt.Errorf("reading magic header of parquet file: %w", err)
-		}
-		switch string(headerMagic[:]) {
-		case "PAR1":
-			// plain or plaintext-footer-with-signature
-		case "PARE":
-			// encrypted footer
-			if c.Decryption == nil {
-				return nil, fmt.Errorf("parquet file has encrypted footer (magic \"PARE\") but no DecryptionConfig was provided")
-			}
-		default:
-			return nil, fmt.Errorf("invalid magic header of parquet file: %q", headerMagic[:])
-		}
-	}
-
-	if cast, ok := f.reader.(interface{ SetMagicFooterSection(offset, length int64) }); ok {
-		cast.SetMagicFooterSection(size-8, 8)
-	}
-
-	optimisticRead := c.OptimisticRead
-	optimisticFooterSize := min(int64(c.ReadBufferSize), size)
-	if !optimisticRead || optimisticFooterSize < 8 {
-		optimisticFooterSize = 8
-	}
-	optimisticFooterData := make([]byte, optimisticFooterSize)
-	if optimisticRead {
-		f.reader = &optimisticFileReaderAt{
-			reader: f.reader,
-			offset: size - optimisticFooterSize,
-			footer: optimisticFooterData,
-		}
-	}
-
-	if n, err := readAt(r, optimisticFooterData, size-optimisticFooterSize); n != len(optimisticFooterData) {
-		return nil, fmt.Errorf("reading magic footer of parquet file: %w (read: %d)", err, n)
-	}
-	optimisticFooterSize -= 8
-	b := optimisticFooterData[optimisticFooterSize:]
-	footerMagic := string(b[4:])
-	if footerMagic != "PAR1" && footerMagic != "PARE" {
-		return nil, fmt.Errorf("invalid magic footer of parquet file: %q", b[4:])
-	}
-
-	footerSize := int64(binary.LittleEndian.Uint32(b[:4]))
-	footerData := []byte(nil)
-
-	if footerSize <= optimisticFooterSize {
-		footerData = optimisticFooterData[optimisticFooterSize-footerSize : optimisticFooterSize]
-	} else {
-		footerData = make([]byte, footerSize)
-		if cast, ok := f.reader.(interface{ SetFooterSection(offset, length int64) }); ok {
-			cast.SetFooterSection(size-(footerSize+8), footerSize)
-		}
-		if _, err := f.readAt(footerData, size-(footerSize+8)); err != nil {
-			return nil, fmt.Errorf("reading footer of parquet file: %w", err)
-		}
-	}
-
-	if footerMagic == "PARE" {
-		// Encrypted footer: footerData = FileCryptoMetaData (thrift) || encrypted footer module.
-		// Decode FileCryptoMetaData using a bytes-backed reader to count bytes consumed.
-		pr := f.protocol.NewReaderFromBytes(footerData)
-		var cryptoMeta format.FileCryptoMetaData
-		if err := thrift.NewDecoder(pr).Decode(&cryptoMeta); err != nil {
-			return nil, fmt.Errorf("reading FileCryptoMetaData: %w", err)
-		}
-		encFooterEnvelope := footerData[pr.BytesRead():]
-
-		// Extract AAD parameters from the encryption algorithm.
-		var fileUnique, aadPrefix []byte
-		switch algo := cryptoMeta.EncryptionAlgorithm.Value.(type) {
-		case *format.AesGcmV1:
-			fileUnique = algo.AadFileUnique
-			aadPrefix = algo.AadPrefix
-		case *format.AesGcmCtrV1:
-			fileUnique = algo.AadFileUnique
-			aadPrefix = algo.AadPrefix
-		}
-
-		footerKey, err := c.Decryption.Keys.FooterKey(cryptoMeta.KeyMetadata)
-		if err != nil {
-			return nil, fmt.Errorf("retrieving footer key: %w", err)
-		}
-		footerAAD := makeAAD(aadPrefix, fileUnique, footerModule)
-		plainFooter, err := decryptModule(footerKey, footerAAD, encFooterEnvelope)
-		if err != nil {
-			return nil, fmt.Errorf("decrypting footer: %w", err)
-		}
-		if err := thrift.Unmarshal(&f.protocol, plainFooter, &f.metadata); err != nil {
-			return nil, fmt.Errorf("reading parquet file metadata from decrypted footer: %w", err)
-		}
-		f.decryption = c.Decryption
-		f.fileUnique = fileUnique
-		f.aadPrefix = aadPrefix
-	} else {
-		// Decode the footer metadata using a reader that tracks bytes consumed,
-		// so that we can detect a trailing 28-byte AES-GCM signature without
-		// tripping over the "unexpected trailing bytes" check in thrift.Unmarshal.
-		pr := f.protocol.NewReaderFromBytes(bytes.Clone(footerData))
-		if err := thrift.NewDecoder(pr).Decode(&f.metadata); err != nil {
-			return nil, fmt.Errorf("reading parquet file metadata: %w", err)
-		}
-		trailing := len(footerData) - pr.BytesRead()
-		const sigLen = encNonceSize + encTagSize
-		switch {
-		case trailing == 0:
-			// Plain, unsigned footer — nothing to do.
-		case trailing == sigLen:
-			// Plaintext footer with AES-GCM signature appended.
-			if c.Decryption == nil {
-				return nil, fmt.Errorf("parquet file has a signed footer but no DecryptionConfig was provided")
-			}
-			var fileUnique, aadPrefix []byte
-			switch algo := f.metadata.EncryptionAlgorithm.Value.(type) {
-			case *format.AesGcmV1:
-				fileUnique = algo.AadFileUnique
-				aadPrefix = algo.AadPrefix
-			case *format.AesGcmCtrV1:
-				fileUnique = algo.AadFileUnique
-				aadPrefix = algo.AadPrefix
-			}
-			plainFooterBytes := footerData[:pr.BytesRead()]
-			sig := footerData[pr.BytesRead():]
-
-			footerKey, err := c.Decryption.Keys.FooterKey(f.metadata.FooterSigningKeyMetadata)
-			if err != nil {
-				return nil, fmt.Errorf("retrieving footer signing key: %w", err)
-			}
-			footerAAD := makeAAD(aadPrefix, fileUnique, footerModule)
-			if err := verifyFooterSignature(footerKey, footerAAD, plainFooterBytes, sig); err != nil {
-				return nil, err
-			}
-			f.decryption = c.Decryption
-			f.fileUnique = fileUnique
-			f.aadPrefix = aadPrefix
-		default:
-			return nil, fmt.Errorf("reading parquet file metadata: unexpected trailing bytes at the end of thrift input: %d", trailing)
-		}
-	}
-
-	if len(f.metadata.Schema) == 0 {
-		return nil, ErrMissingRootColumn
-	}
-
-	// In plaintext-footer mode with encryption, column metadata is stored as
-	// EncryptedColumnMetadata. Decrypt it into MetaData before reading the page
-	// index — column index/offset index offsets live in MetaData and would
-	// otherwise be zero, silently losing the page index for every encrypted
-	// plaintext-footer file.
-	if f.decryption != nil {
-		if err := f.decryptAllColumnMetadata(); err != nil {
+	// reader may wrap r with a prefetched footer region (OptimisticRead),
+	// which the page index and bloom filter reads below take advantage of.
+	// It is unwrapped before the file is returned.
+	footer, reader := c.Footer, r
+	if footer == nil {
+		if footer, reader, err = readFooter(r, size, c); err != nil {
 			return nil, err
 		}
+	}
+
+	f := &File{
+		metadata:   &footer.metadata,
+		reader:     reader,
+		size:       size,
+		config:     c,
+		decryption: footer.decryption,
+		fileUnique: footer.fileUnique,
+		aadPrefix:  footer.aadPrefix,
 	}
 
 	if !c.SkipPageIndex {
@@ -233,7 +99,7 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		}
 	}
 
-	if f.root, err = openColumns(f, &f.metadata, f.columnIndexes, f.offsetIndexes); err != nil {
+	if f.root, err = openColumns(f, f.metadata, f.columnIndexes, f.offsetIndexes); err != nil {
 		return nil, fmt.Errorf("opening columns of parquet file: %w", err)
 	}
 
@@ -312,7 +178,6 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		}
 	}
 
-	sortKeyValueMetadata(f.metadata.KeyValueMetadata)
 	f.reader = r // restore in case an optimistic reader was used
 	return f, nil
 }
@@ -519,65 +384,6 @@ func (f *File) ReadPageIndex() ([]format.ColumnIndex, []format.OffsetIndex, erro
 	return columnIndexes, offsetIndexes, nil
 }
 
-// decryptAllColumnMetadata decrypts EncryptedColumnMetadata for every column
-// chunk in every row group, restoring ColumnChunk.MetaData so that
-// openColumns and schema construction see the full encoding/compression info.
-// This must be called before openColumns.
-func (f *File) decryptAllColumnMetadata() error {
-	// Normalize ordinals before using them in AADs.  Files from writers that
-	// omit the optional Ordinal field have all zeros; validateRowGroupOrdinals
-	// back-fills sequential values so rg.Ordinal is guaranteed to equal the
-	// slice index — matching exactly what the writer embedded in every AAD.
-	if err := validateRowGroupOrdinals(f.metadata.RowGroups); err != nil {
-		return err
-	}
-
-	for rgIdx := range f.metadata.RowGroups {
-		rg := &f.metadata.RowGroups[rgIdx]
-		for colIdx := range rg.Columns {
-			chunk := &rg.Columns[colIdx]
-			if len(chunk.EncryptedColumnMetadata) == 0 {
-				continue
-			}
-			var key []byte
-			switch crypto := chunk.CryptoMetadata.Value.(type) {
-			case *format.EncryptionWithFooterKey:
-				var err error
-				key, err = f.decryption.Keys.FooterKey(nil)
-				if err != nil {
-					return fmt.Errorf("resolving footer key for column metadata: %w", err)
-				}
-			case *format.EncryptionWithColumnKey:
-				var err error
-				key, err = f.decryption.Keys.ColumnKey(crypto.PathInSchema, crypto.KeyMetadata)
-				if err != nil {
-					// Only treat an explicit ErrKeyNotFound as non-fatal: the
-					// caller intentionally omitted this column's key.  Any other
-					// error (KMS failure, bad metadata, …) is propagated so the
-					// caller sees the real problem instead of silent zero data.
-					if errors.Is(err, ErrKeyNotFound) {
-						continue
-					}
-					return fmt.Errorf("resolving column key for column metadata: %w", err)
-				}
-			default:
-				continue
-			}
-			// rg.Ordinal is reliable here because validateRowGroupOrdinals ran above.
-			aad := makeAAD(f.aadPrefix, f.fileUnique, columnMetaDataModule, rg.Ordinal, int16(colIdx))
-			plain, err := decryptModule(key, aad, chunk.EncryptedColumnMetadata)
-			if err != nil {
-				return fmt.Errorf("decrypting column metadata: rowGroup=%d col=%d: %w", rg.Ordinal, colIdx, err)
-			}
-			compact := thrift.CompactProtocol{}
-			if err := thrift.Unmarshal(&compact, plain, &chunk.MetaData); err != nil {
-				return fmt.Errorf("decoding column metadata: rowGroup=%d col=%d: %w", rg.Ordinal, colIdx, err)
-			}
-		}
-	}
-	return nil
-}
-
 // NumRows returns the number of rows in the file.
 func (f *File) NumRows() int64 { return f.metadata.NumRows }
 
@@ -593,7 +399,11 @@ func (f *File) Root() *Column { return f.root }
 func (f *File) Schema() *Schema { return f.schema }
 
 // Metadata returns the metadata of f.
-func (f *File) Metadata() *format.FileMetaData { return &f.metadata }
+//
+// When the file was opened with the WithFooter option, the returned metadata
+// is shared with the footer (and any other files opened from it) and must be
+// treated as read-only.
+func (f *File) Metadata() *format.FileMetaData { return f.metadata }
 
 // Size returns the size of f (in bytes).
 func (f *File) Size() int64 { return f.size }

--- a/file.go
+++ b/file.go
@@ -419,9 +419,11 @@ func (f *File) Schema() *Schema { return f.schema }
 
 // Metadata returns the metadata of f.
 //
-// When the file was opened with the WithFooter option, the returned metadata
-// is shared with the footer (and any other files opened from it) and must be
-// treated as read-only.
+// The returned metadata is always shared with f.Footer() — and, when the
+// file was opened with the WithFooter option, with the footer passed to
+// OpenFile and any other files opened from it — so it must be treated as
+// read-only. Mutating it corrupts the shared footer and is a data race if
+// any file backed by it is in use concurrently.
 func (f *File) Metadata() *format.FileMetaData { return f.metadata }
 
 // Footer returns the footer of f, suitable for caching and for opening the

--- a/file.go
+++ b/file.go
@@ -120,9 +120,11 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	switch {
 	case c.Schema != nil:
 		f.schema = c.Schema
-	case c.Footer != nil && c.Footer.Schema() != nil:
+	case c.Footer != nil:
 		// Footers from the public constructors already carry a schema built
-		// from the same metadata; share it instead of rebuilding.
+		// from the same metadata; share it instead of rebuilding. Building
+		// it cannot fail here: openColumns just succeeded above on the same
+		// metadata.
 		f.schema = c.Footer.Schema()
 	default:
 		f.schema = NewSchema(f.root.Name(), f.root)

--- a/footer.go
+++ b/footer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"slices"
 	"sync"
 
@@ -151,6 +152,13 @@ func (f *Footer) buildSchema() error {
 // header magic check is skipped (there is no header) and the returned footer
 // records no file size.
 func readFooter(r io.ReaderAt, size int64, c *FileConfig, allowBareFooter bool) (*Footer, io.ReaderAt, error) {
+	// The size and the footer length decoded below come from untrusted
+	// input; validate both before any offset arithmetic reaches the
+	// caller's io.ReaderAt, which is not required to reject negative
+	// offsets.
+	if size < 8 {
+		return nil, nil, fmt.Errorf("parquet file of size %d is too small to hold a footer", size)
+	}
 	if cast, ok := r.(interface{ SetMagicFooterSection(offset, length int64) }); ok {
 		cast.SetMagicFooterSection(size-8, 8)
 	}
@@ -181,6 +189,9 @@ func readFooter(r io.ReaderAt, size int64, c *FileConfig, allowBareFooter bool) 
 	}
 
 	footerSize := int64(binary.LittleEndian.Uint32(b[:4]))
+	if footerSize+8 > size {
+		return nil, nil, fmt.Errorf("invalid footer size %d in parquet file of size %d", footerSize, size)
+	}
 
 	// A complete file is always larger than footerSize+8: at minimum the
 	// 4-byte header magic precedes the footer section. An input of exactly
@@ -209,7 +220,9 @@ func readFooter(r io.ReaderAt, size int64, c *FileConfig, allowBareFooter bool) 
 	footerData := []byte(nil)
 
 	if footerSize <= optimisticFooterSize {
-		footerData = optimisticFooterData[optimisticFooterSize-footerSize : optimisticFooterSize]
+		// The prefetch buffer may outlive this call (it backs the returned
+		// optimistic reader), so hand newFooter a copy it can own.
+		footerData = bytes.Clone(optimisticFooterData[optimisticFooterSize-footerSize : optimisticFooterSize])
 	} else {
 		footerData = make([]byte, footerSize)
 		if cast, ok := reader.(interface{ SetFooterSection(offset, length int64) }); ok {
@@ -231,8 +244,11 @@ func readFooter(r io.ReaderAt, size int64, c *FileConfig, allowBareFooter bool) 
 }
 
 // newFooter decodes and normalizes a footer from the raw footer section
-// bytes (without the trailing size and magic). newFooter does not retain
-// data.
+// bytes (without the trailing size and magic). newFooter takes ownership of
+// data: the returned footer may retain it, so callers must not reuse or
+// mutate the slice. This spares footers larger than the prefetch buffer —
+// the exact case footer caching targets — from being allocated and copied
+// twice.
 func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 	f := new(Footer)
 	protocol := new(thrift.CompactProtocol)
@@ -283,11 +299,11 @@ func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 		f.fileUnique = slices.Clone(fileUnique)
 		f.aadPrefix = slices.Clone(aadPrefix)
 	} else {
-		// Decoded strings and byte slices alias the input, so make a private
-		// copy for the footer to own. Decode using a reader that tracks
+		// Decoded strings and byte slices alias the input, which the footer
+		// owns (see the function doc). Decode using a reader that tracks
 		// bytes consumed, so that we can detect a trailing 28-byte AES-GCM
 		// signature without treating it as trailing garbage.
-		f.data = bytes.Clone(data)
+		f.data = data
 		pr := protocol.NewReaderFromBytes(f.data)
 		if err := thrift.NewDecoder(pr).Decode(&f.metadata); err != nil {
 			return nil, fmt.Errorf("reading parquet file metadata: %w", err)
@@ -399,7 +415,15 @@ func (f *Footer) decryptAllColumnMetadata() error {
 					return fmt.Errorf("resolving column key for column metadata: %w", err)
 				}
 			default:
-				continue
+				// The column carries encrypted metadata but no key
+				// reference; without one the metadata cannot be decrypted
+				// and every later read of the column would fail with
+				// confusing zero-metadata decode errors. Report the corrupt
+				// footer here instead.
+				return fmt.Errorf("column metadata is encrypted but the column carries no crypto metadata: rowGroup=%d col=%d", rg.Ordinal, colIdx)
+			}
+			if colIdx > math.MaxInt16 {
+				return fmt.Errorf("cannot compute AAD for column %d: column ordinals are 16-bit in the parquet encryption spec", colIdx)
 			}
 			aad := makeAAD(f.aadPrefix, f.fileUnique, columnMetaDataModule, rg.Ordinal, int16(colIdx))
 			plain, err := decryptModule(key, aad, chunk.EncryptedColumnMetadata)

--- a/footer.go
+++ b/footer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sync"
 
 	"github.com/parquet-go/parquet-go/encoding/thrift"
 	"github.com/parquet-go/parquet-go/format"
@@ -25,11 +26,23 @@ import (
 // time: key/value metadata is sorted, row group ordinals are back-filled,
 // and encrypted column metadata is decrypted. Files opened with WithFooter
 // never write to the footer.
+//
+// A cached Footer retains the decoded metadata graph, one backing byte
+// buffer, and the schema (including a column tree with per-leaf slices
+// proportional to the number of row groups). The page index is not part of
+// the footer: files opened with WithFooter read it from the file unless
+// SkipPageIndex is used.
 type Footer struct {
 	metadata format.FileMetaData
 	data     []byte // backing buffer aliased by metadata strings and byte slices
-	schema   *Schema
-	size     int64 // size of the file the footer was read from, 0 if unknown
+	size     int64  // size of the file the footer was read from, 0 if unknown
+
+	// The schema is built eagerly by ReadFooter and DecodeFooter (which
+	// report schema validation errors), and lazily through schemaOnce for
+	// footers created internally by OpenFile and exposed via File.Footer.
+	schemaOnce sync.Once
+	schema     *Schema
+	schemaErr  error
 
 	// Decryption state carried over to files opened from this footer;
 	// non-nil only when the file has encryption metadata.
@@ -96,7 +109,7 @@ func DecodeFooter(data []byte, options ...FileOption) (*Footer, error) {
 		return nil, fmt.Errorf("invalid magic footer of parquet file: %q", trailer[4:])
 	}
 	if footerSize := int64(binary.LittleEndian.Uint32(trailer[:4])); footerSize != int64(len(data)-8) {
-		return nil, fmt.Errorf("decoding parquet footer: input of %d bytes does not match footer size %d", len(data)-8, footerSize)
+		return nil, fmt.Errorf("decoding parquet footer: input of %d bytes implies a footer of %d bytes, but the trailer records %d", len(data), len(data)-8, footerSize)
 	}
 	footer, err := newFooter(data[:len(data)-8], magic, c)
 	if err != nil {
@@ -132,21 +145,31 @@ func (f *Footer) Lookup(key string) (value string, ok bool) {
 
 // Schema returns the schema of the file the footer was read from.
 //
-// The schema is constructed when the footer is, and shared by all callers;
-// like the footer itself it is safe for concurrent use.
-func (f *Footer) Schema() *Schema { return f.schema }
+// The schema is shared by all callers and safe for concurrent use. For
+// footers returned by ReadFooter and DecodeFooter it was constructed and
+// validated when the footer was; for footers obtained from File.Footer it
+// is constructed lazily on first call.
+func (f *Footer) Schema() *Schema {
+	f.buildSchema()
+	return f.schema
+}
 
 // buildSchema constructs the schema from the footer metadata, validating the
-// schema tree in the process. It is called by the public footer constructors
+// schema tree in the process. The public footer constructors call it eagerly
 // so that a Footer obtained from ReadFooter or DecodeFooter is guaranteed to
-// carry a valid schema.
+// carry a valid schema; footers created internally by OpenFile skip it
+// because OpenFile builds (and validates) its own file-bound column tree
+// from the same metadata.
 func (f *Footer) buildSchema() error {
-	root, err := openColumns(nil, &f.metadata, nil, nil)
-	if err != nil {
-		return fmt.Errorf("opening columns of parquet footer: %w", err)
-	}
-	f.schema = NewSchema(root.Name(), root)
-	return nil
+	f.schemaOnce.Do(func() {
+		root, err := openColumns(nil, &f.metadata, nil, nil)
+		if err != nil {
+			f.schemaErr = fmt.Errorf("opening columns of parquet footer: %w", err)
+			return
+		}
+		f.schema = NewSchema(root.Name(), root)
+	})
+	return f.schemaErr
 }
 
 // readFooter reads the footer section of the parquet file of the given size
@@ -335,7 +358,7 @@ func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 	// Files from writers that omit the optional Ordinal field have all
 	// zeros; back-fill sequential values so all downstream code (page-index
 	// lookup, AAD construction) can rely on rg.Ordinal == slice index.
-	if err := validateRowGroupOrdinals(f.metadata.RowGroups); err != nil {
+	if err := normalizeRowGroupOrdinals(f.metadata.RowGroups); err != nil {
 		return nil, err
 	}
 	if err := validateRowCounts(f.metadata.NumRows, f.metadata.RowGroups); err != nil {

--- a/footer.go
+++ b/footer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"sync"
 
 	"github.com/parquet-go/parquet-go/encoding/thrift"
 	"github.com/parquet-go/parquet-go/format"
@@ -29,15 +28,14 @@ import (
 type Footer struct {
 	metadata format.FileMetaData
 	data     []byte // backing buffer aliased by metadata strings and byte slices
+	schema   *Schema
+	size     int64 // size of the file the footer was read from, 0 if unknown
 
 	// Decryption state carried over to files opened from this footer;
 	// non-nil only when the file has encryption metadata.
 	decryption *DecryptionConfig
 	fileUnique []byte
 	aadPrefix  []byte
-
-	schemaOnce sync.Once
-	schema     *Schema
 }
 
 // ReadFooter reads and decodes the footer of the parquet file of the given
@@ -47,25 +45,40 @@ type Footer struct {
 // Options are interpreted the same way as OpenFile: WithDecryption is
 // required for files with encrypted or signed footers, SkipMagicBytes skips
 // the header magic check, and OptimisticRead and ReadBufferSize control how
-// the footer bytes are fetched.
+// the footer bytes are fetched. Decryption is resolved at construction time:
+// the footer (and the column metadata it contains) is decrypted here, and
+// files later opened from it inherit this decryption configuration
+// regardless of the options passed to OpenFile.
 func ReadFooter(r io.ReaderAt, size int64, options ...FileOption) (*Footer, error) {
 	c, err := NewFileConfig(options...)
 	if err != nil {
 		return nil, err
 	}
 	footer, _, err := readFooter(r, size, c)
-	return footer, err
+	if err != nil {
+		return nil, err
+	}
+	footer.size = size
+	if err := footer.buildSchema(); err != nil {
+		return nil, err
+	}
+	return footer, nil
 }
 
 // DecodeFooter decodes a parquet footer from bytes previously read from the
 // end of a parquet file, as cached by programs that store raw footer bytes
 // instead of decoded footers.
 //
-// The data must be the last footerSize+8 bytes of the file excluding the
-// final magic: the thrift-encoded footer (and trailing signature, if any)
-// followed by the 4-byte footer size and 4-byte magic ("PAR1" or "PARE").
-// Equivalently: with footerSize the little-endian uint32 stored at offset
-// size-8, data must be file[size-(footerSize+8) : size].
+// The data must be the last footerSize+8 bytes of the file: the
+// thrift-encoded footer (and trailing signature, if any) followed by the
+// 8-byte trailer holding the 4-byte little-endian footer size and the
+// 4-byte magic ("PAR1" or "PARE"). Equivalently: with footerSize the
+// little-endian uint32 stored at offset size-8, data must be
+// file[size-(footerSize+8) : size].
+//
+// The WithDecryption option is required for encrypted or signed footers,
+// and is resolved at construction time like in ReadFooter; I/O related
+// options have no effect since no reads are performed.
 //
 // DecodeFooter does not retain data; it makes a private copy of the parts it
 // needs, and the caller remains free to reuse the slice.
@@ -85,17 +98,31 @@ func DecodeFooter(data []byte, options ...FileOption) (*Footer, error) {
 	if footerSize := int64(binary.LittleEndian.Uint32(trailer[:4])); footerSize != int64(len(data)-8) {
 		return nil, fmt.Errorf("decoding parquet footer: input of %d bytes does not match footer size %d", len(data)-8, footerSize)
 	}
-	return newFooter(data[:len(data)-8], magic, c)
+	footer, err := newFooter(data[:len(data)-8], magic, c)
+	if err != nil {
+		return nil, err
+	}
+	if err := footer.buildSchema(); err != nil {
+		return nil, err
+	}
+	return footer, nil
 }
 
 // Metadata returns the file metadata of the footer.
 //
-// The returned value is shared by all files opened from this footer and must
-// be treated as read-only; modifying it results in undefined behavior.
+// The returned value is shared by every file opened from this footer, across
+// goroutines: it must be treated as strictly read-only. Mutating it corrupts
+// all files backed by the footer and is a data race if any of them is in use
+// concurrently.
 func (f *Footer) Metadata() *format.FileMetaData { return &f.metadata }
 
 // NumRows returns the number of rows in the file.
 func (f *Footer) NumRows() int64 { return f.metadata.NumRows }
+
+// Size returns the size of the file the footer was read from, or 0 when the
+// size is unknown (footers constructed by DecodeFooter, which only sees the
+// footer bytes).
+func (f *Footer) Size() int64 { return f.size }
 
 // Lookup returns the value associated with the given key in the file
 // key/value metadata.
@@ -105,19 +132,21 @@ func (f *Footer) Lookup(key string) (value string, ok bool) {
 
 // Schema returns the schema of the file the footer was read from.
 //
-// The schema is constructed lazily on first call and shared by subsequent
-// calls; like the footer it is safe for concurrent use.
-func (f *Footer) Schema() *Schema {
-	f.schemaOnce.Do(func() {
-		root, err := openColumns(nil, &f.metadata, nil, nil)
-		if err != nil {
-			// The schema was validated when the footer was constructed, so
-			// errors here indicate a bug rather than a malformed input.
-			panic(fmt.Errorf("parquet: constructing schema from footer: %w", err))
-		}
-		f.schema = NewSchema(root.Name(), root)
-	})
-	return f.schema
+// The schema is constructed when the footer is, and shared by all callers;
+// like the footer itself it is safe for concurrent use.
+func (f *Footer) Schema() *Schema { return f.schema }
+
+// buildSchema constructs the schema from the footer metadata, validating the
+// schema tree in the process. It is called by the public footer constructors
+// so that a Footer obtained from ReadFooter or DecodeFooter is guaranteed to
+// carry a valid schema.
+func (f *Footer) buildSchema() error {
+	root, err := openColumns(nil, &f.metadata, nil, nil)
+	if err != nil {
+		return fmt.Errorf("opening columns of parquet footer: %w", err)
+	}
+	f.schema = NewSchema(root.Name(), root)
+	return nil
 }
 
 // readFooter reads the footer section of the parquet file of the given size
@@ -288,8 +317,8 @@ func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 				return nil, err
 			}
 			f.decryption = c.Decryption
-			f.fileUnique = fileUnique
-			f.aadPrefix = aadPrefix
+			f.fileUnique = slices.Clone(fileUnique)
+			f.aadPrefix = slices.Clone(aadPrefix)
 		default:
 			return nil, fmt.Errorf("reading parquet file metadata: unexpected trailing bytes at the end of thrift input: %d", trailing)
 		}

--- a/footer.go
+++ b/footer.go
@@ -19,8 +19,8 @@ import (
 // a single Footer may back any number of Files opened with the WithFooter
 // option, across goroutines, without synchronization. This makes Footer
 // suitable for caching: programs opening the same file repeatedly can read
-// the footer once with ReadFooter (or decode cached footer bytes with
-// DecodeFooter) and amortize the decoding cost across opens.
+// the footer once with ReadFooter (from the file, or from cached raw footer
+// bytes) and amortize the decoding cost across opens.
 //
 // All footer normalization performed by OpenFile happens at construction
 // time: key/value metadata is sorted, row group ordinals are back-filled,
@@ -37,8 +37,8 @@ type Footer struct {
 	data     []byte // backing buffer aliased by metadata strings and byte slices
 	size     int64  // size of the file the footer was read from, 0 if unknown
 
-	// The schema is built eagerly by ReadFooter and DecodeFooter (which
-	// report schema validation errors), and lazily through schemaOnce for
+	// The schema is built eagerly by ReadFooter (which reports schema
+	// validation errors), and lazily through schemaOnce for
 	// footers created internally by OpenFile and exposed via File.Footer.
 	schemaOnce sync.Once
 	schema     *Schema
@@ -62,56 +62,24 @@ type Footer struct {
 // the footer (and the column metadata it contains) is decrypted here, and
 // files later opened from it inherit this decryption configuration
 // regardless of the options passed to OpenFile.
+//
+// ReadFooter also accepts a bare footer section — the last footerSize+8
+// bytes of a file, as cached by programs that store raw footer bytes
+// instead of decoded footers:
+//
+//	footer, err := parquet.ReadFooter(bytes.NewReader(blob), int64(len(blob)))
+//
+// The input is recognized as a bare footer when it is exactly footerSize+8
+// bytes (a complete file is always larger, since at least the 4-byte header
+// magic precedes the footer). In that case the header magic check does not
+// apply and the footer records no file size (see Size). ReadFooter does not
+// retain the input; it makes a private copy of the parts it needs.
 func ReadFooter(r io.ReaderAt, size int64, options ...FileOption) (*Footer, error) {
 	c, err := NewFileConfig(options...)
 	if err != nil {
 		return nil, err
 	}
-	footer, _, err := readFooter(r, size, c)
-	if err != nil {
-		return nil, err
-	}
-	footer.size = size
-	if err := footer.buildSchema(); err != nil {
-		return nil, err
-	}
-	return footer, nil
-}
-
-// DecodeFooter decodes a parquet footer from bytes previously read from the
-// end of a parquet file, as cached by programs that store raw footer bytes
-// instead of decoded footers.
-//
-// The data must be the last footerSize+8 bytes of the file: the
-// thrift-encoded footer (and trailing signature, if any) followed by the
-// 8-byte trailer holding the 4-byte little-endian footer size and the
-// 4-byte magic ("PAR1" or "PARE"). Equivalently: with footerSize the
-// little-endian uint32 stored at offset size-8, data must be
-// file[size-(footerSize+8) : size].
-//
-// The WithDecryption option is required for encrypted or signed footers,
-// and is resolved at construction time like in ReadFooter; I/O related
-// options have no effect since no reads are performed.
-//
-// DecodeFooter does not retain data; it makes a private copy of the parts it
-// needs, and the caller remains free to reuse the slice.
-func DecodeFooter(data []byte, options ...FileOption) (*Footer, error) {
-	c, err := NewFileConfig(options...)
-	if err != nil {
-		return nil, err
-	}
-	if len(data) < 8 {
-		return nil, fmt.Errorf("decoding parquet footer: input of %d bytes is too short", len(data))
-	}
-	trailer := data[len(data)-8:]
-	magic := string(trailer[4:])
-	if magic != "PAR1" && magic != "PARE" {
-		return nil, fmt.Errorf("invalid magic footer of parquet file: %q", trailer[4:])
-	}
-	if footerSize := int64(binary.LittleEndian.Uint32(trailer[:4])); footerSize != int64(len(data)-8) {
-		return nil, fmt.Errorf("decoding parquet footer: input of %d bytes implies a footer of %d bytes, but the trailer records %d", len(data), len(data)-8, footerSize)
-	}
-	footer, err := newFooter(data[:len(data)-8], magic, c)
+	footer, _, err := readFooter(r, size, c, true)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +101,8 @@ func (f *Footer) Metadata() *format.FileMetaData { return &f.metadata }
 func (f *Footer) NumRows() int64 { return f.metadata.NumRows }
 
 // Size returns the size of the file the footer was read from, or 0 when the
-// size is unknown (footers constructed by DecodeFooter, which only sees the
-// footer bytes).
+// size is unknown (footers read from a bare footer section, which carries no
+// information about the rest of the file).
 func (f *Footer) Size() int64 { return f.size }
 
 // Lookup returns the value associated with the given key in the file
@@ -146,7 +114,7 @@ func (f *Footer) Lookup(key string) (value string, ok bool) {
 // Schema returns the schema of the file the footer was read from.
 //
 // The schema is shared by all callers and safe for concurrent use. For
-// footers returned by ReadFooter and DecodeFooter it was constructed and
+// footers returned by ReadFooter it was constructed and
 // validated when the footer was; for footers obtained from File.Footer it
 // is constructed lazily on first call.
 func (f *Footer) Schema() *Schema {
@@ -156,7 +124,7 @@ func (f *Footer) Schema() *Schema {
 
 // buildSchema constructs the schema from the footer metadata, validating the
 // schema tree in the process. The public footer constructors call it eagerly
-// so that a Footer obtained from ReadFooter or DecodeFooter is guaranteed to
+// so that a Footer obtained from ReadFooter is guaranteed to
 // carry a valid schema; footers created internally by OpenFile skip it
 // because OpenFile builds (and validates) its own file-bound column tree
 // from the same metadata.
@@ -177,25 +145,12 @@ func (f *Footer) buildSchema() error {
 // reads from the prefetched footer region when the OptimisticRead option is
 // enabled (and is r itself otherwise); OpenFile uses it to read the page
 // index without going back to the underlying reader.
-func readFooter(r io.ReaderAt, size int64, c *FileConfig) (*Footer, io.ReaderAt, error) {
-	if !c.SkipMagicBytes {
-		var headerMagic [4]byte
-		if _, err := readAt(r, headerMagic[:], 0); err != nil {
-			return nil, nil, fmt.Errorf("reading magic header of parquet file: %w", err)
-		}
-		switch string(headerMagic[:]) {
-		case "PAR1":
-			// plain or plaintext-footer-with-signature
-		case "PARE":
-			// encrypted footer
-			if c.Decryption == nil {
-				return nil, nil, fmt.Errorf("parquet file has encrypted footer (magic \"PARE\") but no DecryptionConfig was provided")
-			}
-		default:
-			return nil, nil, fmt.Errorf("invalid magic header of parquet file: %q", headerMagic[:])
-		}
-	}
-
+//
+// When allowBareFooter is true and the input is exactly footerSize+8 bytes,
+// it is treated as a bare footer section rather than a complete file: the
+// header magic check is skipped (there is no header) and the returned footer
+// records no file size.
+func readFooter(r io.ReaderAt, size int64, c *FileConfig, allowBareFooter bool) (*Footer, io.ReaderAt, error) {
 	if cast, ok := r.(interface{ SetMagicFooterSection(offset, length int64) }); ok {
 		cast.SetMagicFooterSection(size-8, 8)
 	}
@@ -226,6 +181,31 @@ func readFooter(r io.ReaderAt, size int64, c *FileConfig) (*Footer, io.ReaderAt,
 	}
 
 	footerSize := int64(binary.LittleEndian.Uint32(b[:4]))
+
+	// A complete file is always larger than footerSize+8: at minimum the
+	// 4-byte header magic precedes the footer section. An input of exactly
+	// footerSize+8 bytes is therefore a bare footer section (cached footer
+	// bytes), which has no header to check and no known file size.
+	bareFooter := allowBareFooter && size == footerSize+8
+
+	if !bareFooter && !c.SkipMagicBytes {
+		var headerMagic [4]byte
+		if _, err := readAt(r, headerMagic[:], 0); err != nil {
+			return nil, nil, fmt.Errorf("reading magic header of parquet file: %w", err)
+		}
+		switch string(headerMagic[:]) {
+		case "PAR1":
+			// plain or plaintext-footer-with-signature
+		case "PARE":
+			// encrypted footer
+			if c.Decryption == nil {
+				return nil, nil, fmt.Errorf("parquet file has encrypted footer (magic \"PARE\") but no DecryptionConfig was provided")
+			}
+		default:
+			return nil, nil, fmt.Errorf("invalid magic header of parquet file: %q", headerMagic[:])
+		}
+	}
+
 	footerData := []byte(nil)
 
 	if footerSize <= optimisticFooterSize {
@@ -243,6 +223,9 @@ func readFooter(r io.ReaderAt, size int64, c *FileConfig) (*Footer, io.ReaderAt,
 	footer, err := newFooter(footerData, footerMagic, c)
 	if err != nil {
 		return nil, nil, err
+	}
+	if !bareFooter {
+		footer.size = size
 	}
 	return footer, reader, nil
 }

--- a/footer.go
+++ b/footer.go
@@ -16,27 +16,22 @@ import (
 
 // A Footer is a decoded, validated parquet file footer.
 //
-// Footer values are immutable after construction and safe for concurrent use:
-// a single Footer may back any number of Files opened with the WithFooter
-// option, across goroutines, without synchronization. This makes Footer
-// suitable for caching: programs opening the same file repeatedly can read
-// the footer once with ReadFooter (from the file, or from cached raw footer
-// bytes) and amortize the decoding cost across opens.
+// Footer values are immutable after construction and safe for concurrent
+// use: a single Footer may back any number of Files opened with the
+// WithFooter option, across goroutines, without synchronization. This makes
+// Footer suitable for caching: programs opening the same file repeatedly
+// can read the footer once with ReadFooter and amortize the decoding cost
+// across opens.
 //
 // All footer normalization performed by OpenFile happens at construction
 // time: key/value metadata is sorted, row group ordinals are back-filled,
 // and encrypted column metadata is decrypted. Files opened with WithFooter
-// never write to the footer.
-//
-// A cached Footer retains the decoded metadata graph, one backing byte
-// buffer, and the schema (including a column tree with per-leaf slices
-// proportional to the number of row groups). The page index is not part of
-// the footer: files opened with WithFooter read it from the file unless
-// SkipPageIndex is used.
+// never write to the footer. The page index is not part of the footer:
+// files opened with WithFooter read it from the file unless SkipPageIndex
+// is used.
 type Footer struct {
 	metadata format.FileMetaData
-	data     []byte // backing buffer aliased by metadata strings and byte slices
-	size     int64  // size of the file the footer was read from, 0 if unknown
+	size     int64 // size of the file the footer was read from, 0 if unknown
 
 	// The schema is built eagerly by ReadFooter (which reports schema
 	// validation errors), and lazily through schemaOnce for
@@ -59,22 +54,18 @@ type Footer struct {
 // Options are interpreted the same way as OpenFile: WithDecryption is
 // required for files with encrypted or signed footers, SkipMagicBytes skips
 // the header magic check, and OptimisticRead and ReadBufferSize control how
-// the footer bytes are fetched. Decryption is resolved at construction time:
-// the footer (and the column metadata it contains) is decrypted here, and
-// files later opened from it inherit this decryption configuration
-// regardless of the options passed to OpenFile.
+// the footer bytes are fetched. The footer (and the column metadata it
+// contains) is decrypted here; files later opened from it inherit this
+// decryption configuration regardless of the options passed to OpenFile.
 //
 // ReadFooter also accepts a bare footer section — the last footerSize+8
 // bytes of a file, as cached by programs that store raw footer bytes
-// instead of decoded footers:
-//
-//	footer, err := parquet.ReadFooter(bytes.NewReader(blob), int64(len(blob)))
-//
-// The input is recognized as a bare footer when it is exactly footerSize+8
-// bytes (a complete file is always larger, since at least the 4-byte header
-// magic precedes the footer). In that case the header magic check does not
-// apply and the footer records no file size (see Size). ReadFooter does not
-// retain the input; it makes a private copy of the parts it needs.
+// instead of decoded footers. The input is recognized as a bare footer when
+// it is exactly footerSize+8 bytes (a complete file is always larger, since
+// at least the 4-byte header magic precedes the footer). In that case the
+// header magic check does not apply and the footer records no file size
+// (see Size). ReadFooter does not retain the input; it makes a private copy
+// of the parts it needs.
 func ReadFooter(r io.ReaderAt, size int64, options ...FileOption) (*Footer, error) {
 	c, err := NewFileConfig(options...)
 	if err != nil {
@@ -97,9 +88,6 @@ func ReadFooter(r io.ReaderAt, size int64, options ...FileOption) (*Footer, erro
 // all files backed by the footer and is a data race if any of them is in use
 // concurrently.
 func (f *Footer) Metadata() *format.FileMetaData { return &f.metadata }
-
-// NumRows returns the number of rows in the file.
-func (f *Footer) NumRows() int64 { return f.metadata.NumRows }
 
 // Size returns the size of the file the footer was read from, or 0 when the
 // size is unknown (footers read from a bare footer section, which carries no
@@ -204,15 +192,11 @@ func readFooter(r io.ReaderAt, size int64, c *FileConfig, allowBareFooter bool) 
 		if _, err := readAt(r, headerMagic[:], 0); err != nil {
 			return nil, nil, fmt.Errorf("reading magic header of parquet file: %w", err)
 		}
-		switch string(headerMagic[:]) {
-		case "PAR1":
-			// plain or plaintext-footer-with-signature
-		case "PARE":
-			// encrypted footer
-			if c.Decryption == nil {
-				return nil, nil, fmt.Errorf("parquet file has encrypted footer (magic \"PARE\") but no DecryptionConfig was provided")
-			}
-		default:
+		// "PAR1" is a plain (or plaintext-footer-with-signature) file,
+		// "PARE" an encrypted one; newFooter checks the decryption
+		// requirements from the footer magic, which also covers bare
+		// footers and SkipMagicBytes.
+		if m := string(headerMagic[:]); m != "PAR1" && m != "PARE" {
 			return nil, nil, fmt.Errorf("invalid magic header of parquet file: %q", headerMagic[:])
 		}
 	}
@@ -243,12 +227,33 @@ func readFooter(r io.ReaderAt, size int64, c *FileConfig, allowBareFooter bool) 
 	return footer, reader, nil
 }
 
+// aadParams extracts the AAD parameters from an encryption algorithm union.
+// The returned slices alias the buffer the algorithm was decoded from.
+func aadParams(algo format.EncryptionAlgorithm) (fileUnique, aadPrefix []byte) {
+	switch a := algo.Value.(type) {
+	case *format.AesGcmV1:
+		return a.AadFileUnique, a.AadPrefix
+	case *format.AesGcmCtrV1:
+		return a.AadFileUnique, a.AadPrefix
+	}
+	return nil, nil
+}
+
+// initDecryption records the decryption configuration carried over to files
+// opened from this footer. The AAD parameters may alias a transient decode
+// buffer, so they are cloned.
+func (f *Footer) initDecryption(c *DecryptionConfig, fileUnique, aadPrefix []byte) {
+	f.decryption = c
+	f.fileUnique = slices.Clone(fileUnique)
+	f.aadPrefix = slices.Clone(aadPrefix)
+}
+
 // newFooter decodes and normalizes a footer from the raw footer section
 // bytes (without the trailing size and magic). newFooter takes ownership of
-// data: the returned footer may retain it, so callers must not reuse or
-// mutate the slice. This spares footers larger than the prefetch buffer —
-// the exact case footer caching targets — from being allocated and copied
-// twice.
+// data: the decoded metadata retains it (strings and byte slices alias it),
+// so callers must not reuse or mutate the slice. This spares footers larger
+// than the prefetch buffer — the exact case footer caching targets — from
+// being allocated and copied twice.
 func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 	f := new(Footer)
 	protocol := new(thrift.CompactProtocol)
@@ -266,18 +271,7 @@ func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 		}
 		encFooterEnvelope := data[pr.BytesRead():]
 
-		// Extract AAD parameters from the encryption algorithm. The values
-		// alias data, which is not retained, so they are cloned below.
-		var fileUnique, aadPrefix []byte
-		switch algo := cryptoMeta.EncryptionAlgorithm.Value.(type) {
-		case *format.AesGcmV1:
-			fileUnique = algo.AadFileUnique
-			aadPrefix = algo.AadPrefix
-		case *format.AesGcmCtrV1:
-			fileUnique = algo.AadFileUnique
-			aadPrefix = algo.AadPrefix
-		}
-
+		fileUnique, aadPrefix := aadParams(cryptoMeta.EncryptionAlgorithm)
 		footerKey, err := c.Decryption.Keys.FooterKey(cryptoMeta.KeyMetadata)
 		if err != nil {
 			return nil, fmt.Errorf("retrieving footer key: %w", err)
@@ -294,21 +288,16 @@ func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 		if n := len(plainFooter) - pr.BytesRead(); n != 0 {
 			return nil, fmt.Errorf("reading parquet file metadata from decrypted footer: unexpected trailing bytes at the end of thrift input: %d", n)
 		}
-		f.data = plainFooter
-		f.decryption = c.Decryption
-		f.fileUnique = slices.Clone(fileUnique)
-		f.aadPrefix = slices.Clone(aadPrefix)
+		f.initDecryption(c.Decryption, fileUnique, aadPrefix)
 	} else {
-		// Decoded strings and byte slices alias the input, which the footer
-		// owns (see the function doc). Decode using a reader that tracks
-		// bytes consumed, so that we can detect a trailing 28-byte AES-GCM
-		// signature without treating it as trailing garbage.
-		f.data = data
-		pr := protocol.NewReaderFromBytes(f.data)
+		// Decode using a reader that tracks bytes consumed, so that a
+		// trailing 28-byte AES-GCM signature is detected instead of being
+		// treated as trailing garbage.
+		pr := protocol.NewReaderFromBytes(data)
 		if err := thrift.NewDecoder(pr).Decode(&f.metadata); err != nil {
 			return nil, fmt.Errorf("reading parquet file metadata: %w", err)
 		}
-		trailing := len(f.data) - pr.BytesRead()
+		trailing := len(data) - pr.BytesRead()
 		const sigLen = encNonceSize + encTagSize
 		switch {
 		case trailing == 0:
@@ -318,29 +307,16 @@ func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
 			if c.Decryption == nil {
 				return nil, fmt.Errorf("parquet file has a signed footer but no DecryptionConfig was provided")
 			}
-			var fileUnique, aadPrefix []byte
-			switch algo := f.metadata.EncryptionAlgorithm.Value.(type) {
-			case *format.AesGcmV1:
-				fileUnique = algo.AadFileUnique
-				aadPrefix = algo.AadPrefix
-			case *format.AesGcmCtrV1:
-				fileUnique = algo.AadFileUnique
-				aadPrefix = algo.AadPrefix
-			}
-			plainFooterBytes := f.data[:pr.BytesRead()]
-			sig := f.data[pr.BytesRead():]
-
+			fileUnique, aadPrefix := aadParams(f.metadata.EncryptionAlgorithm)
 			footerKey, err := c.Decryption.Keys.FooterKey(f.metadata.FooterSigningKeyMetadata)
 			if err != nil {
 				return nil, fmt.Errorf("retrieving footer signing key: %w", err)
 			}
 			footerAAD := makeAAD(aadPrefix, fileUnique, footerModule)
-			if err := verifyFooterSignature(footerKey, footerAAD, plainFooterBytes, sig); err != nil {
+			if err := verifyFooterSignature(footerKey, footerAAD, data[:pr.BytesRead()], data[pr.BytesRead():]); err != nil {
 				return nil, err
 			}
-			f.decryption = c.Decryption
-			f.fileUnique = slices.Clone(fileUnique)
-			f.aadPrefix = slices.Clone(aadPrefix)
+			f.initDecryption(c.Decryption, fileUnique, aadPrefix)
 		default:
 			return nil, fmt.Errorf("reading parquet file metadata: unexpected trailing bytes at the end of thrift input: %d", trailing)
 		}

--- a/footer.go
+++ b/footer.go
@@ -1,0 +1,381 @@
+package parquet
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sync"
+
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// A Footer is a decoded, validated parquet file footer.
+//
+// Footer values are immutable after construction and safe for concurrent use:
+// a single Footer may back any number of Files opened with the WithFooter
+// option, across goroutines, without synchronization. This makes Footer
+// suitable for caching: programs opening the same file repeatedly can read
+// the footer once with ReadFooter (or decode cached footer bytes with
+// DecodeFooter) and amortize the decoding cost across opens.
+//
+// All footer normalization performed by OpenFile happens at construction
+// time: key/value metadata is sorted, row group ordinals are back-filled,
+// and encrypted column metadata is decrypted. Files opened with WithFooter
+// never write to the footer.
+type Footer struct {
+	metadata format.FileMetaData
+	data     []byte // backing buffer aliased by metadata strings and byte slices
+
+	// Decryption state carried over to files opened from this footer;
+	// non-nil only when the file has encryption metadata.
+	decryption *DecryptionConfig
+	fileUnique []byte
+	aadPrefix  []byte
+
+	schemaOnce sync.Once
+	schema     *Schema
+}
+
+// ReadFooter reads and decodes the footer of the parquet file of the given
+// size in r. Only the footer is read; use OpenFile with the WithFooter
+// option to open the file for reading rows.
+//
+// Options are interpreted the same way as OpenFile: WithDecryption is
+// required for files with encrypted or signed footers, SkipMagicBytes skips
+// the header magic check, and OptimisticRead and ReadBufferSize control how
+// the footer bytes are fetched.
+func ReadFooter(r io.ReaderAt, size int64, options ...FileOption) (*Footer, error) {
+	c, err := NewFileConfig(options...)
+	if err != nil {
+		return nil, err
+	}
+	footer, _, err := readFooter(r, size, c)
+	return footer, err
+}
+
+// DecodeFooter decodes a parquet footer from bytes previously read from the
+// end of a parquet file, as cached by programs that store raw footer bytes
+// instead of decoded footers.
+//
+// The data must be the last footerSize+8 bytes of the file excluding the
+// final magic: the thrift-encoded footer (and trailing signature, if any)
+// followed by the 4-byte footer size and 4-byte magic ("PAR1" or "PARE").
+// Equivalently: with footerSize the little-endian uint32 stored at offset
+// size-8, data must be file[size-(footerSize+8) : size].
+//
+// DecodeFooter does not retain data; it makes a private copy of the parts it
+// needs, and the caller remains free to reuse the slice.
+func DecodeFooter(data []byte, options ...FileOption) (*Footer, error) {
+	c, err := NewFileConfig(options...)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 8 {
+		return nil, fmt.Errorf("decoding parquet footer: input of %d bytes is too short", len(data))
+	}
+	trailer := data[len(data)-8:]
+	magic := string(trailer[4:])
+	if magic != "PAR1" && magic != "PARE" {
+		return nil, fmt.Errorf("invalid magic footer of parquet file: %q", trailer[4:])
+	}
+	if footerSize := int64(binary.LittleEndian.Uint32(trailer[:4])); footerSize != int64(len(data)-8) {
+		return nil, fmt.Errorf("decoding parquet footer: input of %d bytes does not match footer size %d", len(data)-8, footerSize)
+	}
+	return newFooter(data[:len(data)-8], magic, c)
+}
+
+// Metadata returns the file metadata of the footer.
+//
+// The returned value is shared by all files opened from this footer and must
+// be treated as read-only; modifying it results in undefined behavior.
+func (f *Footer) Metadata() *format.FileMetaData { return &f.metadata }
+
+// NumRows returns the number of rows in the file.
+func (f *Footer) NumRows() int64 { return f.metadata.NumRows }
+
+// Lookup returns the value associated with the given key in the file
+// key/value metadata.
+func (f *Footer) Lookup(key string) (value string, ok bool) {
+	return lookupKeyValueMetadata(f.metadata.KeyValueMetadata, key)
+}
+
+// Schema returns the schema of the file the footer was read from.
+//
+// The schema is constructed lazily on first call and shared by subsequent
+// calls; like the footer it is safe for concurrent use.
+func (f *Footer) Schema() *Schema {
+	f.schemaOnce.Do(func() {
+		root, err := openColumns(nil, &f.metadata, nil, nil)
+		if err != nil {
+			// The schema was validated when the footer was constructed, so
+			// errors here indicate a bug rather than a malformed input.
+			panic(fmt.Errorf("parquet: constructing schema from footer: %w", err))
+		}
+		f.schema = NewSchema(root.Name(), root)
+	})
+	return f.schema
+}
+
+// readFooter reads the footer section of the parquet file of the given size
+// in r and constructs a Footer from it. The returned io.ReaderAt serves
+// reads from the prefetched footer region when the OptimisticRead option is
+// enabled (and is r itself otherwise); OpenFile uses it to read the page
+// index without going back to the underlying reader.
+func readFooter(r io.ReaderAt, size int64, c *FileConfig) (*Footer, io.ReaderAt, error) {
+	if !c.SkipMagicBytes {
+		var headerMagic [4]byte
+		if _, err := readAt(r, headerMagic[:], 0); err != nil {
+			return nil, nil, fmt.Errorf("reading magic header of parquet file: %w", err)
+		}
+		switch string(headerMagic[:]) {
+		case "PAR1":
+			// plain or plaintext-footer-with-signature
+		case "PARE":
+			// encrypted footer
+			if c.Decryption == nil {
+				return nil, nil, fmt.Errorf("parquet file has encrypted footer (magic \"PARE\") but no DecryptionConfig was provided")
+			}
+		default:
+			return nil, nil, fmt.Errorf("invalid magic header of parquet file: %q", headerMagic[:])
+		}
+	}
+
+	if cast, ok := r.(interface{ SetMagicFooterSection(offset, length int64) }); ok {
+		cast.SetMagicFooterSection(size-8, 8)
+	}
+
+	reader := r
+	optimisticRead := c.OptimisticRead
+	optimisticFooterSize := min(int64(c.ReadBufferSize), size)
+	if !optimisticRead || optimisticFooterSize < 8 {
+		optimisticFooterSize = 8
+	}
+	optimisticFooterData := make([]byte, optimisticFooterSize)
+	if optimisticRead {
+		reader = &optimisticFileReaderAt{
+			reader: r,
+			offset: size - optimisticFooterSize,
+			footer: optimisticFooterData,
+		}
+	}
+
+	if n, err := readAt(r, optimisticFooterData, size-optimisticFooterSize); n != len(optimisticFooterData) {
+		return nil, nil, fmt.Errorf("reading magic footer of parquet file: %w (read: %d)", err, n)
+	}
+	optimisticFooterSize -= 8
+	b := optimisticFooterData[optimisticFooterSize:]
+	footerMagic := string(b[4:])
+	if footerMagic != "PAR1" && footerMagic != "PARE" {
+		return nil, nil, fmt.Errorf("invalid magic footer of parquet file: %q", b[4:])
+	}
+
+	footerSize := int64(binary.LittleEndian.Uint32(b[:4]))
+	footerData := []byte(nil)
+
+	if footerSize <= optimisticFooterSize {
+		footerData = optimisticFooterData[optimisticFooterSize-footerSize : optimisticFooterSize]
+	} else {
+		footerData = make([]byte, footerSize)
+		if cast, ok := reader.(interface{ SetFooterSection(offset, length int64) }); ok {
+			cast.SetFooterSection(size-(footerSize+8), footerSize)
+		}
+		if _, err := readAt(reader, footerData, size-(footerSize+8)); err != nil {
+			return nil, nil, fmt.Errorf("reading footer of parquet file: %w", err)
+		}
+	}
+
+	footer, err := newFooter(footerData, footerMagic, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	return footer, reader, nil
+}
+
+// newFooter decodes and normalizes a footer from the raw footer section
+// bytes (without the trailing size and magic). newFooter does not retain
+// data.
+func newFooter(data []byte, magic string, c *FileConfig) (*Footer, error) {
+	f := new(Footer)
+	protocol := new(thrift.CompactProtocol)
+
+	if magic == "PARE" {
+		// Encrypted footer: data = FileCryptoMetaData (thrift) || encrypted footer module.
+		// Decode FileCryptoMetaData using a bytes-backed reader to count bytes consumed.
+		if c.Decryption == nil {
+			return nil, fmt.Errorf("parquet file has encrypted footer (magic \"PARE\") but no DecryptionConfig was provided")
+		}
+		pr := protocol.NewReaderFromBytes(data)
+		var cryptoMeta format.FileCryptoMetaData
+		if err := thrift.NewDecoder(pr).Decode(&cryptoMeta); err != nil {
+			return nil, fmt.Errorf("reading FileCryptoMetaData: %w", err)
+		}
+		encFooterEnvelope := data[pr.BytesRead():]
+
+		// Extract AAD parameters from the encryption algorithm. The values
+		// alias data, which is not retained, so they are cloned below.
+		var fileUnique, aadPrefix []byte
+		switch algo := cryptoMeta.EncryptionAlgorithm.Value.(type) {
+		case *format.AesGcmV1:
+			fileUnique = algo.AadFileUnique
+			aadPrefix = algo.AadPrefix
+		case *format.AesGcmCtrV1:
+			fileUnique = algo.AadFileUnique
+			aadPrefix = algo.AadPrefix
+		}
+
+		footerKey, err := c.Decryption.Keys.FooterKey(cryptoMeta.KeyMetadata)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving footer key: %w", err)
+		}
+		footerAAD := makeAAD(aadPrefix, fileUnique, footerModule)
+		plainFooter, err := decryptModule(footerKey, footerAAD, encFooterEnvelope)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting footer: %w", err)
+		}
+		pr = protocol.NewReaderFromBytes(plainFooter)
+		if err := thrift.NewDecoder(pr).Decode(&f.metadata); err != nil {
+			return nil, fmt.Errorf("reading parquet file metadata from decrypted footer: %w", err)
+		}
+		if n := len(plainFooter) - pr.BytesRead(); n != 0 {
+			return nil, fmt.Errorf("reading parquet file metadata from decrypted footer: unexpected trailing bytes at the end of thrift input: %d", n)
+		}
+		f.data = plainFooter
+		f.decryption = c.Decryption
+		f.fileUnique = slices.Clone(fileUnique)
+		f.aadPrefix = slices.Clone(aadPrefix)
+	} else {
+		// Decoded strings and byte slices alias the input, so make a private
+		// copy for the footer to own. Decode using a reader that tracks
+		// bytes consumed, so that we can detect a trailing 28-byte AES-GCM
+		// signature without treating it as trailing garbage.
+		f.data = bytes.Clone(data)
+		pr := protocol.NewReaderFromBytes(f.data)
+		if err := thrift.NewDecoder(pr).Decode(&f.metadata); err != nil {
+			return nil, fmt.Errorf("reading parquet file metadata: %w", err)
+		}
+		trailing := len(f.data) - pr.BytesRead()
+		const sigLen = encNonceSize + encTagSize
+		switch {
+		case trailing == 0:
+			// Plain, unsigned footer — nothing to do.
+		case trailing == sigLen:
+			// Plaintext footer with AES-GCM signature appended.
+			if c.Decryption == nil {
+				return nil, fmt.Errorf("parquet file has a signed footer but no DecryptionConfig was provided")
+			}
+			var fileUnique, aadPrefix []byte
+			switch algo := f.metadata.EncryptionAlgorithm.Value.(type) {
+			case *format.AesGcmV1:
+				fileUnique = algo.AadFileUnique
+				aadPrefix = algo.AadPrefix
+			case *format.AesGcmCtrV1:
+				fileUnique = algo.AadFileUnique
+				aadPrefix = algo.AadPrefix
+			}
+			plainFooterBytes := f.data[:pr.BytesRead()]
+			sig := f.data[pr.BytesRead():]
+
+			footerKey, err := c.Decryption.Keys.FooterKey(f.metadata.FooterSigningKeyMetadata)
+			if err != nil {
+				return nil, fmt.Errorf("retrieving footer signing key: %w", err)
+			}
+			footerAAD := makeAAD(aadPrefix, fileUnique, footerModule)
+			if err := verifyFooterSignature(footerKey, footerAAD, plainFooterBytes, sig); err != nil {
+				return nil, err
+			}
+			f.decryption = c.Decryption
+			f.fileUnique = fileUnique
+			f.aadPrefix = aadPrefix
+		default:
+			return nil, fmt.Errorf("reading parquet file metadata: unexpected trailing bytes at the end of thrift input: %d", trailing)
+		}
+	}
+
+	if len(f.metadata.Schema) == 0 {
+		return nil, ErrMissingRootColumn
+	}
+
+	// Normalization: everything below is the reason Footer values are safe
+	// to share between files — OpenFile never has to mutate the metadata
+	// because construction leaves it fully normalized.
+
+	// Files from writers that omit the optional Ordinal field have all
+	// zeros; back-fill sequential values so all downstream code (page-index
+	// lookup, AAD construction) can rely on rg.Ordinal == slice index.
+	if err := validateRowGroupOrdinals(f.metadata.RowGroups); err != nil {
+		return nil, err
+	}
+	if err := validateRowCounts(f.metadata.NumRows, f.metadata.RowGroups); err != nil {
+		return nil, err
+	}
+
+	// In plaintext-footer mode with encryption, column metadata is stored as
+	// EncryptedColumnMetadata. Decrypt it into MetaData before the footer is
+	// used — column index/offset index offsets live in MetaData and would
+	// otherwise be zero, silently losing the page index for every encrypted
+	// plaintext-footer file.
+	if f.decryption != nil {
+		if err := f.decryptAllColumnMetadata(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Lookup performs a binary search on the key/value metadata.
+	sortKeyValueMetadata(f.metadata.KeyValueMetadata)
+	return f, nil
+}
+
+// decryptAllColumnMetadata decrypts EncryptedColumnMetadata for every column
+// chunk in every row group, restoring ColumnChunk.MetaData so that
+// openColumns and schema construction see the full encoding/compression
+// info. Row group ordinals must have been normalized beforehand because they
+// are embedded in every AAD.
+func (f *Footer) decryptAllColumnMetadata() error {
+	for rgIdx := range f.metadata.RowGroups {
+		rg := &f.metadata.RowGroups[rgIdx]
+		for colIdx := range rg.Columns {
+			chunk := &rg.Columns[colIdx]
+			if len(chunk.EncryptedColumnMetadata) == 0 {
+				continue
+			}
+			var key []byte
+			switch crypto := chunk.CryptoMetadata.Value.(type) {
+			case *format.EncryptionWithFooterKey:
+				var err error
+				key, err = f.decryption.Keys.FooterKey(nil)
+				if err != nil {
+					return fmt.Errorf("resolving footer key for column metadata: %w", err)
+				}
+			case *format.EncryptionWithColumnKey:
+				var err error
+				key, err = f.decryption.Keys.ColumnKey(crypto.PathInSchema, crypto.KeyMetadata)
+				if err != nil {
+					// Only treat an explicit ErrKeyNotFound as non-fatal: the
+					// caller intentionally omitted this column's key.  Any other
+					// error (KMS failure, bad metadata, …) is propagated so the
+					// caller sees the real problem instead of silent zero data.
+					if errors.Is(err, ErrKeyNotFound) {
+						continue
+					}
+					return fmt.Errorf("resolving column key for column metadata: %w", err)
+				}
+			default:
+				continue
+			}
+			aad := makeAAD(f.aadPrefix, f.fileUnique, columnMetaDataModule, rg.Ordinal, int16(colIdx))
+			plain, err := decryptModule(key, aad, chunk.EncryptedColumnMetadata)
+			if err != nil {
+				return fmt.Errorf("decrypting column metadata: rowGroup=%d col=%d: %w", rg.Ordinal, colIdx, err)
+			}
+			compact := thrift.CompactProtocol{}
+			if err := thrift.Unmarshal(&compact, plain, &chunk.MetaData); err != nil {
+				return fmt.Errorf("decoding column metadata: rowGroup=%d col=%d: %w", rg.Ordinal, colIdx, err)
+			}
+		}
+	}
+	return nil
+}

--- a/footer_bench_test.go
+++ b/footer_bench_test.go
@@ -139,6 +139,10 @@ func BenchmarkOpenFooter(b *testing.B) {
 
 			// The zero-allocation transient decode path: what a pooled
 			// decoder pays per decode when re-decoding cached footer bytes.
+			// Not equivalent work to DecodeFooter above, which additionally
+			// validates the trailer, normalizes the metadata, and builds
+			// the schema; the delta between the two is mostly schema
+			// construction, not decoder overhead.
 			b.Run("FooterDecoder", func(b *testing.B) {
 				decoder := new(format.FooterDecoder)
 				payload := footerBytes[:len(footerBytes)-8]

--- a/footer_bench_test.go
+++ b/footer_bench_test.go
@@ -128,10 +128,13 @@ func BenchmarkOpenFooter(b *testing.B) {
 				}
 			})
 
-			b.Run("DecodeFooter", func(b *testing.B) {
+			// ReadFooter over cached bare footer bytes instead of the file.
+			b.Run("ReadFooter/bareFooter", func(b *testing.B) {
+				r := bytes.NewReader(footerBytes)
+				blobSize := int64(len(footerBytes))
 				b.ReportAllocs()
 				for b.Loop() {
-					if _, err := parquet.DecodeFooter(footerBytes); err != nil {
+					if _, err := parquet.ReadFooter(r, blobSize); err != nil {
 						b.Fatal(err)
 					}
 				}
@@ -139,7 +142,7 @@ func BenchmarkOpenFooter(b *testing.B) {
 
 			// The zero-allocation transient decode path: what a pooled
 			// decoder pays per decode when re-decoding cached footer bytes.
-			// Not equivalent work to DecodeFooter above, which additionally
+			// Not equivalent work to ReadFooter above, which additionally
 			// validates the trailer, normalizes the metadata, and builds
 			// the schema; the delta between the two is mostly schema
 			// construction, not decoder overhead.

--- a/footer_bench_test.go
+++ b/footer_bench_test.go
@@ -1,0 +1,154 @@
+package parquet_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// benchFooterShape describes a synthetic file used to benchmark footer
+// decoding at different footer sizes. Footer size grows with the number of
+// row groups and columns, not with the number of rows.
+type benchFooterShape struct {
+	rowGroups int
+	columns   int
+}
+
+func (s benchFooterShape) String() string {
+	return fmt.Sprintf("rowGroups=%d/columns=%d", s.rowGroups, s.columns)
+}
+
+var benchFooterShapes = []benchFooterShape{
+	{rowGroups: 1, columns: 10},
+	{rowGroups: 8, columns: 50},
+	{rowGroups: 32, columns: 200},
+}
+
+// generateBenchFile writes a parquet file with the given number of row
+// groups and columns. Half the columns are int64 and half are strings so
+// the footer carries realistic statistics.
+func generateBenchFile(tb testing.TB, shape benchFooterShape) []byte {
+	fields := make(parquet.Group, shape.columns)
+	for i := range shape.columns {
+		if i%2 == 0 {
+			fields[fmt.Sprintf("col%03d", i)] = parquet.Leaf(parquet.Int64Type)
+		} else {
+			fields[fmt.Sprintf("col%03d", i)] = parquet.String()
+		}
+	}
+	schema := parquet.NewSchema("bench", fields)
+
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf, schema)
+
+	const rowsPerGroup = 25
+	row := make(parquet.Row, shape.columns)
+	for g := range shape.rowGroups {
+		for r := range rowsPerGroup {
+			for i := range shape.columns {
+				if i%2 == 0 {
+					row[i] = parquet.Int64Value(int64(g*rowsPerGroup+r)).Level(0, 0, i)
+				} else {
+					row[i] = parquet.ByteArrayValue(fmt.Appendf(nil, "value-%03d-%05d", i, g*rowsPerGroup+r)).Level(0, 0, i)
+				}
+			}
+			if _, err := w.WriteRows([]parquet.Row{row}); err != nil {
+				tb.Fatal(err)
+			}
+		}
+		if err := w.Flush(); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// BenchmarkOpenFooter compares the cost of opening parquet files through the
+// different footer paths, across footer sizes and with the page index
+// enabled or disabled. The reader is fully in-memory, so the numbers isolate
+// CPU and allocation cost: this is the floor that a byte-caching setup (e.g.
+// caching footer bytes in memcached) cannot go below without WithFooter.
+func BenchmarkOpenFooter(b *testing.B) {
+	for _, shape := range benchFooterShapes {
+		data := generateBenchFile(b, shape)
+		size := int64(len(data))
+		footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
+		footerBytes := data[size-int64(footerSize)-8 : size]
+
+		footer, err := parquet.ReadFooter(bytes.NewReader(data), size)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		benchmarks := []struct {
+			name    string
+			options []parquet.FileOption
+		}{
+			{name: "OpenFile"},
+			{name: "OpenFile+SkipPageIndex", options: []parquet.FileOption{
+				parquet.SkipPageIndex(true), parquet.SkipBloomFilters(true),
+			}},
+			{name: "OpenFile+WithFooter", options: []parquet.FileOption{
+				parquet.WithFooter(footer),
+			}},
+			{name: "OpenFile+WithFooter+SkipPageIndex", options: []parquet.FileOption{
+				parquet.WithFooter(footer), parquet.SkipPageIndex(true), parquet.SkipBloomFilters(true),
+			}},
+		}
+
+		b.Run(shape.String(), func(b *testing.B) {
+			b.Logf("file size: %d bytes, footer size: %d bytes", size, footerSize)
+
+			for _, bench := range benchmarks {
+				b.Run(bench.name, func(b *testing.B) {
+					r := bytes.NewReader(data)
+					b.ReportAllocs()
+					for b.Loop() {
+						if _, err := parquet.OpenFile(r, size, bench.options...); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+
+			b.Run("ReadFooter", func(b *testing.B) {
+				r := bytes.NewReader(data)
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := parquet.ReadFooter(r, size); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+
+			b.Run("DecodeFooter", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := parquet.DecodeFooter(footerBytes); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+
+			// The zero-allocation transient decode path: what a pooled
+			// decoder pays per decode when re-decoding cached footer bytes.
+			b.Run("FooterDecoder", func(b *testing.B) {
+				decoder := new(format.FooterDecoder)
+				payload := footerBytes[:len(footerBytes)-8]
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, _, err := decoder.Decode(payload); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}

--- a/footer_test.go
+++ b/footer_test.go
@@ -3,6 +3,7 @@ package parquet_test
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -67,6 +68,12 @@ func assertFilesEquivalent(t *testing.T, base, withFooter *parquet.File) {
 			t.Errorf("lookup mismatch for key %q: %q (%t)", kv.Key, v, ok)
 		}
 	}
+	if !reflect.DeepEqual(base.ColumnIndexes(), withFooter.ColumnIndexes()) {
+		t.Error("column indexes mismatch between base open and open with footer")
+	}
+	if !reflect.DeepEqual(base.OffsetIndexes(), withFooter.OffsetIndexes()) {
+		t.Error("offset indexes mismatch between base open and open with footer")
+	}
 
 	baseRows := readAllFileRows(t, base)
 	withFooterRows := readAllFileRows(t, withFooter)
@@ -120,7 +127,34 @@ func TestOpenFileWithFooter(t *testing.T) {
 				t.Fatal(err)
 			}
 			assertFilesEquivalent(t, base, withFooter)
+
+			// A footer must support any number of sequential opens.
+			again, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(footer))
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFilesEquivalent(t, base, again)
 		})
+	}
+}
+
+// TestOpenFileWithFooterRejectsWrongSize checks that a footer read from a
+// file of a different size is rejected instead of producing a corrupt file.
+func TestOpenFileWithFooterRejectsWrongSize(t *testing.T) {
+	data, err := os.ReadFile("testdata/file.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(data))
+	footer, err := parquet.ReadFooter(bytes.NewReader(data), size)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if footer.Size() != size {
+		t.Errorf("footer.Size() = %d, want %d", footer.Size(), size)
+	}
+	if _, err := parquet.OpenFile(bytes.NewReader(data), size+1, parquet.WithFooter(footer)); err == nil {
+		t.Error("expected error opening a file with a footer read from a file of a different size")
 	}
 }
 
@@ -144,6 +178,9 @@ func TestDecodeFooter(t *testing.T) {
 			decoded, err := parquet.DecodeFooter(footerBytes)
 			if err != nil {
 				t.Fatal(err)
+			}
+			if decoded.Size() != 0 {
+				t.Errorf("decoded.Size() = %d, want 0 (unknown)", decoded.Size())
 			}
 			if b, w := marshalMetadata(t, read.Metadata()), marshalMetadata(t, decoded.Metadata()); !bytes.Equal(b, w) {
 				t.Error("metadata mismatch between ReadFooter and DecodeFooter")
@@ -204,7 +241,9 @@ func TestFooterSharedAcrossConcurrentOpens(t *testing.T) {
 				errs <- err
 				return
 			}
-			_ = footer.Schema() // exercise concurrent lazy schema construction
+			if footer.Schema() == nil {
+				errs <- errors.New("footer schema is nil")
+			}
 			rows := f.RowGroups()[0].Rows()
 			defer rows.Close()
 			buf := make([]parquet.Row, 32)

--- a/footer_test.go
+++ b/footer_test.go
@@ -219,19 +219,36 @@ func TestReadFooterFromBareFooter(t *testing.T) {
 	}
 }
 
+// sliceReaderAt serves reads by indexing a byte slice without validating
+// the offset, like a permissive custom io.ReaderAt implementation: a
+// negative offset panics. The io.ReaderAt contract does not require
+// rejecting negative offsets, so footer reading must validate untrusted
+// sizes before any offset arithmetic reaches the reader.
+type sliceReaderAt []byte
+
+func (s sliceReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	n := copy(p, s[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
 // TestReadFooterRejectsInvalidInput checks the input validation of
-// ReadFooter over invalid bare inputs.
+// ReadFooter over invalid bare inputs. The permissive reader turns a
+// missing bounds check into a panic instead of a reader error.
 func TestReadFooterRejectsInvalidInput(t *testing.T) {
 	for _, test := range []struct {
 		scenario string
 		input    string
 	}{
+		{scenario: "empty input", input: ""},
 		{scenario: "truncated input", input: "PAR1"},
 		{scenario: "invalid magic", input: "\x00\x00\x00\x00XXXX"},
 		{scenario: "footer size larger than input", input: "\xff\x00\x00\x00PAR1"},
 	} {
 		t.Run(test.scenario, func(t *testing.T) {
-			r := bytes.NewReader([]byte(test.input))
+			r := sliceReaderAt(test.input)
 			if _, err := parquet.ReadFooter(r, int64(len(test.input))); err == nil {
 				t.Error("expected error")
 			}

--- a/footer_test.go
+++ b/footer_test.go
@@ -176,9 +176,10 @@ func TestOpenFileWithFooterRejectsWrongSize(t *testing.T) {
 	}
 }
 
-// TestDecodeFooter checks that DecodeFooter over cached footer bytes is
-// equivalent to ReadFooter over the file.
-func TestDecodeFooter(t *testing.T) {
+// TestReadFooterFromBareFooter checks that ReadFooter over a bare footer
+// section (the last footerSize+8 bytes of a file, as cached by programs
+// that store raw footer bytes) is equivalent to ReadFooter over the file.
+func TestReadFooterFromBareFooter(t *testing.T) {
 	for _, path := range footerTestFiles(t) {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			data, err := os.ReadFile(path)
@@ -193,7 +194,7 @@ func TestDecodeFooter(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			decoded, err := parquet.DecodeFooter(footerBytes)
+			decoded, err := parquet.ReadFooter(bytes.NewReader(footerBytes), int64(len(footerBytes)))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -201,7 +202,7 @@ func TestDecodeFooter(t *testing.T) {
 				t.Errorf("decoded.Size() = %d, want 0 (unknown)", decoded.Size())
 			}
 			if b, w := marshalMetadata(t, read.Metadata()), marshalMetadata(t, decoded.Metadata()); !bytes.Equal(b, w) {
-				t.Error("metadata mismatch between ReadFooter and DecodeFooter")
+				t.Error("metadata mismatch between file and bare footer reads")
 			}
 			if b, w := read.Schema().String(), decoded.Schema().String(); b != w {
 				t.Errorf("schema mismatch:\nread: %s\ndecoded: %s", b, w)
@@ -218,17 +219,23 @@ func TestDecodeFooter(t *testing.T) {
 	}
 }
 
-// TestDecodeFooterRejectsInvalidInput checks the input validation of
-// DecodeFooter.
-func TestDecodeFooterRejectsInvalidInput(t *testing.T) {
-	if _, err := parquet.DecodeFooter([]byte("PAR1")); err == nil {
-		t.Error("expected error for truncated input")
-	}
-	if _, err := parquet.DecodeFooter([]byte("\x00\x00\x00\x00XXXX")); err == nil {
-		t.Error("expected error for invalid magic")
-	}
-	if _, err := parquet.DecodeFooter([]byte("\xff\x00\x00\x00PAR1")); err == nil {
-		t.Error("expected error for footer size mismatch")
+// TestReadFooterRejectsInvalidInput checks the input validation of
+// ReadFooter over invalid bare inputs.
+func TestReadFooterRejectsInvalidInput(t *testing.T) {
+	for _, test := range []struct {
+		scenario string
+		input    string
+	}{
+		{scenario: "truncated input", input: "PAR1"},
+		{scenario: "invalid magic", input: "\x00\x00\x00\x00XXXX"},
+		{scenario: "footer size larger than input", input: "\xff\x00\x00\x00PAR1"},
+	} {
+		t.Run(test.scenario, func(t *testing.T) {
+			r := bytes.NewReader([]byte(test.input))
+			if _, err := parquet.ReadFooter(r, int64(len(test.input))); err == nil {
+				t.Error("expected error")
+			}
+		})
 	}
 }
 
@@ -367,10 +374,10 @@ func TestFileFooter(t *testing.T) {
 	assertFilesEquivalent(t, base, reopened)
 }
 
-// TestDecodeFooterDoesNotRetainInput checks the documented ownership
-// contract: mutating the input slice after DecodeFooter returns must not
-// corrupt the footer.
-func TestDecodeFooterDoesNotRetainInput(t *testing.T) {
+// TestReadFooterDoesNotRetainInput checks the documented ownership
+// contract: mutating the bare footer bytes after ReadFooter returns must
+// not corrupt the footer.
+func TestReadFooterDoesNotRetainInput(t *testing.T) {
 	data, err := os.ReadFile("testdata/alltypes_tiny_pages_plain.parquet")
 	if err != nil {
 		t.Fatal(err)
@@ -379,7 +386,7 @@ func TestDecodeFooterDoesNotRetainInput(t *testing.T) {
 	footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
 	footerBytes := slices.Clone(data[size-int64(footerSize)-8 : size])
 
-	decoded, err := parquet.DecodeFooter(footerBytes)
+	decoded, err := parquet.ReadFooter(bytes.NewReader(footerBytes), int64(len(footerBytes)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -395,11 +402,11 @@ func TestDecodeFooterDoesNotRetainInput(t *testing.T) {
 	}
 }
 
-// TestDecodeFooterValidatesRowCounts checks that footer-level validation
-// runs at construction: ReadFooter and DecodeFooter are standalone APIs, so
-// inconsistent row counts must be rejected even though OpenFile would also
-// catch them later.
-func TestDecodeFooterValidatesRowCounts(t *testing.T) {
+// TestReadFooterValidatesRowCounts checks that footer-level validation
+// runs at construction: ReadFooter is a standalone API, so inconsistent
+// row counts must be rejected even though OpenFile would also catch them
+// later.
+func TestReadFooterValidatesRowCounts(t *testing.T) {
 	data, err := os.ReadFile("testdata/file.parquet")
 	if err != nil {
 		t.Fatal(err)
@@ -408,7 +415,7 @@ func TestDecodeFooterValidatesRowCounts(t *testing.T) {
 	footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
 	footerBytes := data[size-int64(footerSize)-8 : size]
 
-	valid, err := parquet.DecodeFooter(footerBytes)
+	valid, err := parquet.ReadFooter(bytes.NewReader(footerBytes), int64(len(footerBytes)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +428,7 @@ func TestDecodeFooterValidatesRowCounts(t *testing.T) {
 	corrupt = binary.LittleEndian.AppendUint32(corrupt, uint32(len(corrupt)))
 	corrupt = append(corrupt, "PAR1"...)
 
-	if _, err := parquet.DecodeFooter(corrupt); err == nil {
+	if _, err := parquet.ReadFooter(bytes.NewReader(corrupt), int64(len(corrupt))); err == nil {
 		t.Error("expected error decoding a footer with a negative row count")
 	}
 }
@@ -489,10 +496,10 @@ func TestFooterEncrypted(t *testing.T) {
 			}
 			assertFilesEquivalent(t, base, f)
 
-			// DecodeFooter over the raw footer region must work as well.
+			// ReadFooter over the raw footer region must work as well.
 			footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
 			footerBytes := data[size-int64(footerSize)-8 : size]
-			decoded, err := parquet.DecodeFooter(footerBytes, parquet.WithDecryption(keys))
+			decoded, err := parquet.ReadFooter(bytes.NewReader(footerBytes), int64(len(footerBytes)), parquet.WithDecryption(keys))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -501,7 +508,7 @@ func TestFooterEncrypted(t *testing.T) {
 				t.Fatal(err)
 			}
 			if got := readTypedRows(t, f2); !reflect.DeepEqual(got, rows) {
-				t.Errorf("rows mismatch after DecodeFooter: got %+v, want %+v", got, rows)
+				t.Errorf("rows mismatch after bare footer read: got %+v, want %+v", got, rows)
 			}
 		})
 	}

--- a/footer_test.go
+++ b/footer_test.go
@@ -1,0 +1,339 @@
+package parquet_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// footerTestFiles returns the paths of testdata files that open successfully
+// with the default options.
+func footerTestFiles(t *testing.T) []string {
+	paths, err := filepath.Glob("testdata/*.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := make([]string, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if _, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data))); err != nil {
+			continue
+		}
+		files = append(files, path)
+	}
+	return files
+}
+
+func marshalMetadata(t *testing.T, metadata *format.FileMetaData) []byte {
+	t.Helper()
+	b, err := thrift.Marshal(new(thrift.CompactProtocol), metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// assertFilesEquivalent checks that two open files expose the same schema,
+// metadata, row groups, and rows.
+func assertFilesEquivalent(t *testing.T, base, withFooter *parquet.File) {
+	t.Helper()
+
+	if b, w := base.Schema().String(), withFooter.Schema().String(); b != w {
+		t.Errorf("schema mismatch:\nbase: %s\nwith footer: %s", b, w)
+	}
+	if b, w := base.NumRows(), withFooter.NumRows(); b != w {
+		t.Errorf("num rows mismatch: %d != %d", b, w)
+	}
+	if b, w := marshalMetadata(t, base.Metadata()), marshalMetadata(t, withFooter.Metadata()); !bytes.Equal(b, w) {
+		t.Error("metadata mismatch after re-encoding")
+	}
+	if b, w := len(base.RowGroups()), len(withFooter.RowGroups()); b != w {
+		t.Fatalf("row group count mismatch: %d != %d", b, w)
+	}
+	for _, kv := range base.Metadata().KeyValueMetadata {
+		if v, ok := withFooter.Lookup(kv.Key); !ok || v != kv.Value {
+			t.Errorf("lookup mismatch for key %q: %q (%t)", kv.Key, v, ok)
+		}
+	}
+
+	baseRows := readAllFileRows(t, base)
+	withFooterRows := readAllFileRows(t, withFooter)
+	if !reflect.DeepEqual(baseRows, withFooterRows) {
+		t.Error("rows mismatch between base open and open with footer")
+	}
+}
+
+func readAllFileRows(t *testing.T, f *parquet.File) []parquet.Row {
+	t.Helper()
+	var rows []parquet.Row
+	for _, rg := range f.RowGroups() {
+		rr := rg.Rows()
+		buf := make([]parquet.Row, 64)
+		for {
+			n, err := rr.ReadRows(buf)
+			for _, row := range buf[:n] {
+				rows = append(rows, row.Clone())
+			}
+			if err != nil {
+				break
+			}
+		}
+		rr.Close()
+	}
+	return rows
+}
+
+// TestOpenFileWithFooter checks that opening a file from a pre-read footer
+// is equivalent to a regular open, for every testdata file.
+func TestOpenFileWithFooter(t *testing.T) {
+	for _, path := range footerTestFiles(t) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := bytes.NewReader(data)
+			size := int64(len(data))
+
+			base, err := parquet.OpenFile(r, size)
+			if err != nil {
+				t.Fatal(err)
+			}
+			footer, err := parquet.ReadFooter(r, size)
+			if err != nil {
+				t.Fatal(err)
+			}
+			withFooter, err := parquet.OpenFile(r, size, parquet.WithFooter(footer))
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFilesEquivalent(t, base, withFooter)
+		})
+	}
+}
+
+// TestDecodeFooter checks that DecodeFooter over cached footer bytes is
+// equivalent to ReadFooter over the file.
+func TestDecodeFooter(t *testing.T) {
+	for _, path := range footerTestFiles(t) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			size := int64(len(data))
+			footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
+			footerBytes := data[size-int64(footerSize)-8 : size]
+
+			read, err := parquet.ReadFooter(bytes.NewReader(data), size)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := parquet.DecodeFooter(footerBytes)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if b, w := marshalMetadata(t, read.Metadata()), marshalMetadata(t, decoded.Metadata()); !bytes.Equal(b, w) {
+				t.Error("metadata mismatch between ReadFooter and DecodeFooter")
+			}
+			if b, w := read.Schema().String(), decoded.Schema().String(); b != w {
+				t.Errorf("schema mismatch:\nread: %s\ndecoded: %s", b, w)
+			}
+
+			f, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(decoded))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if f.NumRows() != decoded.NumRows() {
+				t.Errorf("num rows mismatch: %d != %d", f.NumRows(), decoded.NumRows())
+			}
+		})
+	}
+}
+
+// TestDecodeFooterRejectsInvalidInput checks the input validation of
+// DecodeFooter.
+func TestDecodeFooterRejectsInvalidInput(t *testing.T) {
+	if _, err := parquet.DecodeFooter([]byte("PAR1")); err == nil {
+		t.Error("expected error for truncated input")
+	}
+	if _, err := parquet.DecodeFooter([]byte("\x00\x00\x00\x00XXXX")); err == nil {
+		t.Error("expected error for invalid magic")
+	}
+	if _, err := parquet.DecodeFooter([]byte("\xff\x00\x00\x00PAR1")); err == nil {
+		t.Error("expected error for footer size mismatch")
+	}
+}
+
+// TestFooterSharedAcrossConcurrentOpens opens many files concurrently from
+// one footer and verifies the footer is never mutated. Run with -race to
+// catch unsynchronized writes.
+func TestFooterSharedAcrossConcurrentOpens(t *testing.T) {
+	data, err := os.ReadFile("testdata/alltypes_tiny_pages_plain.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(data))
+	footer, err := parquet.ReadFooter(bytes.NewReader(data), size)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := marshalMetadata(t, footer.Metadata())
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 16)
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := bytes.NewReader(data)
+			f, err := parquet.OpenFile(r, size, parquet.WithFooter(footer))
+			if err != nil {
+				errs <- err
+				return
+			}
+			_ = footer.Schema() // exercise concurrent lazy schema construction
+			rows := f.RowGroups()[0].Rows()
+			defer rows.Close()
+			buf := make([]parquet.Row, 32)
+			if _, err := rows.ReadRows(buf); err != nil && err != io.EOF {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	if after := marshalMetadata(t, footer.Metadata()); !bytes.Equal(before, after) {
+		t.Error("footer metadata was mutated by concurrent opens")
+	}
+}
+
+// TestOpenFileWithFooterPerformsNoReads checks the documented contract of
+// WithFooter: combined with SkipPageIndex and SkipBloomFilters, OpenFile
+// performs no I/O.
+func TestOpenFileWithFooterPerformsNoReads(t *testing.T) {
+	data, err := os.ReadFile("testdata/file.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(data))
+	footer, err := parquet.ReadFooter(bytes.NewReader(data), size)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	counting := &countingReaderAt{ra: bytes.NewReader(data)}
+	if _, err := parquet.OpenFile(counting, size,
+		parquet.WithFooter(footer),
+		parquet.SkipPageIndex(true),
+		parquet.SkipBloomFilters(true),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if counting.reads != 0 {
+		t.Errorf("OpenFile with footer performed %d reads, want 0", counting.reads)
+	}
+}
+
+// TestFooterEncrypted checks ReadFooter/WithFooter against files with
+// encrypted footers (PARE) and signed plaintext footers.
+func TestFooterEncrypted(t *testing.T) {
+	rows := []encryptionTestRow{
+		{Name: "alpha", Value: 1},
+		{Name: "beta", Value: 2},
+		{Name: "gamma", Value: 3},
+	}
+	keys := &staticKeyRetriever{footerKey: aes128Key(0x11)}
+
+	for _, test := range []struct {
+		scenario        string
+		encryptedFooter bool
+	}{
+		{scenario: "encrypted footer", encryptedFooter: true},
+		{scenario: "signed plaintext footer", encryptedFooter: false},
+	} {
+		t.Run(test.scenario, func(t *testing.T) {
+			data := writeEncrypted(t, rows, &parquet.EncryptionConfig{
+				FooterKey:       keys.footerKey,
+				EncryptedFooter: test.encryptedFooter,
+			})
+			size := int64(len(data))
+
+			// Footer reads of encrypted files require a decryption config.
+			if _, err := parquet.ReadFooter(bytes.NewReader(data), size); err == nil {
+				t.Error("expected ReadFooter to fail without a DecryptionConfig")
+			}
+
+			footer, err := parquet.ReadFooter(bytes.NewReader(data), size, parquet.WithDecryption(keys))
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(footer))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := readTypedRows(t, f)
+			if !reflect.DeepEqual(got, rows) {
+				t.Errorf("rows mismatch: got %+v, want %+v", got, rows)
+			}
+
+			// DecodeFooter over the raw footer region must work as well.
+			footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
+			footerBytes := data[size-int64(footerSize)-8 : size]
+			decoded, err := parquet.DecodeFooter(footerBytes, parquet.WithDecryption(keys))
+			if err != nil {
+				t.Fatal(err)
+			}
+			f2, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(decoded))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := readTypedRows(t, f2); !reflect.DeepEqual(got, rows) {
+				t.Errorf("rows mismatch after DecodeFooter: got %+v, want %+v", got, rows)
+			}
+		})
+	}
+}
+
+func readTypedRows(t *testing.T, f *parquet.File) []encryptionTestRow {
+	t.Helper()
+	r := parquet.NewGenericReader[encryptionTestRow](f)
+	defer r.Close()
+	var out []encryptionTestRow
+	buf := make([]encryptionTestRow, 16)
+	for {
+		n, err := r.Read(buf)
+		out = append(out, buf[:n]...)
+		if err == io.EOF {
+			return out
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestReadFooterValidation checks that ReadFooter applies the same
+// validation as OpenFile.
+func TestReadFooterValidation(t *testing.T) {
+	data := []byte("not a parquet file")
+	if _, err := parquet.ReadFooter(bytes.NewReader(data), int64(len(data))); err == nil {
+		t.Error("expected error for invalid file")
+	}
+}

--- a/footer_test.go
+++ b/footer_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 
@@ -33,6 +34,12 @@ func footerTestFiles(t *testing.T) []string {
 			continue
 		}
 		files = append(files, path)
+	}
+	// Guard against silently shrinking coverage: if a regression makes many
+	// files fail the plain open above, the footer tests must fail loudly
+	// instead of adapting to the smaller file list.
+	if len(files) < 30 {
+		t.Fatalf("only %d testdata files opened successfully, expected at least 30", len(files))
 	}
 	return files
 }
@@ -73,6 +80,17 @@ func assertFilesEquivalent(t *testing.T, base, withFooter *parquet.File) {
 	}
 	if !reflect.DeepEqual(base.OffsetIndexes(), withFooter.OffsetIndexes()) {
 		t.Error("offset indexes mismatch between base open and open with footer")
+	}
+	for i, rg := range base.RowGroups() {
+		for j, cc := range rg.ColumnChunks() {
+			b := cc.BloomFilter()
+			w := withFooter.RowGroups()[i].ColumnChunks()[j].BloomFilter()
+			if (b == nil) != (w == nil) {
+				t.Errorf("bloom filter presence mismatch for row group %d column %d: base=%t withFooter=%t", i, j, b != nil, w != nil)
+			} else if b != nil && b.Size() != w.Size() {
+				t.Errorf("bloom filter size mismatch for row group %d column %d: %d != %d", i, j, b.Size(), w.Size())
+			}
+		}
 	}
 
 	baseRows := readAllFileRows(t, base)
@@ -265,9 +283,10 @@ func TestFooterSharedAcrossConcurrentOpens(t *testing.T) {
 
 // TestOpenFileWithFooterPerformsNoReads checks the documented contract of
 // WithFooter: combined with SkipPageIndex and SkipBloomFilters, OpenFile
-// performs no I/O.
+// performs no I/O. The test file must have a page index so that the skip
+// options are load-bearing, which the second open verifies.
 func TestOpenFileWithFooterPerformsNoReads(t *testing.T) {
-	data, err := os.ReadFile("testdata/file.parquet")
+	data, err := os.ReadFile("testdata/alltypes_tiny_pages_plain.parquet")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,6 +307,123 @@ func TestOpenFileWithFooterPerformsNoReads(t *testing.T) {
 	if counting.reads != 0 {
 		t.Errorf("OpenFile with footer performed %d reads, want 0", counting.reads)
 	}
+
+	// Sanity check that the skip options above are doing the work: the same
+	// open without them must read the page index from the file.
+	if _, err := parquet.OpenFile(counting, size, parquet.WithFooter(footer)); err != nil {
+		t.Fatal(err)
+	}
+	if counting.reads == 0 {
+		t.Error("OpenFile with footer and no skip options performed no reads; the zero-read assertion above is vacuous")
+	}
+}
+
+// TestOpenFileWithFooterRejectsZeroValue checks that a hand-constructed
+// zero-value footer is rejected with an error instead of a panic.
+func TestOpenFileWithFooterRejectsZeroValue(t *testing.T) {
+	data, err := os.ReadFile("testdata/file.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(data))
+	if _, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(new(parquet.Footer))); err == nil {
+		t.Error("expected error opening a file with a zero-value footer")
+	}
+}
+
+// TestFileFooter checks that the footer of an open file can be recovered
+// with File.Footer and reused to open the file again.
+func TestFileFooter(t *testing.T) {
+	data, err := os.ReadFile("testdata/alltypes_tiny_pages_plain.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(data))
+
+	base, err := parquet.OpenFile(bytes.NewReader(data), size)
+	if err != nil {
+		t.Fatal(err)
+	}
+	footer := base.Footer()
+	if footer == nil {
+		t.Fatal("File.Footer returned nil after a regular open")
+	}
+	if footer.Size() != size {
+		t.Errorf("footer.Size() = %d, want %d", footer.Size(), size)
+	}
+	if footer.Schema() == nil {
+		t.Error("footer.Schema() returned nil")
+	} else if b, w := base.Schema().String(), footer.Schema().String(); b != w {
+		t.Errorf("schema mismatch:\nfile: %s\nfooter: %s", b, w)
+	}
+
+	reopened, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(footer))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.Footer() != footer {
+		t.Error("File.Footer of a file opened with WithFooter is not the provided footer")
+	}
+	assertFilesEquivalent(t, base, reopened)
+}
+
+// TestDecodeFooterDoesNotRetainInput checks the documented ownership
+// contract: mutating the input slice after DecodeFooter returns must not
+// corrupt the footer.
+func TestDecodeFooterDoesNotRetainInput(t *testing.T) {
+	data, err := os.ReadFile("testdata/alltypes_tiny_pages_plain.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(data))
+	footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
+	footerBytes := slices.Clone(data[size-int64(footerSize)-8 : size])
+
+	decoded, err := parquet.DecodeFooter(footerBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := marshalMetadata(t, decoded.Metadata())
+	for i := range footerBytes {
+		footerBytes[i] = 0xff
+	}
+	if after := marshalMetadata(t, decoded.Metadata()); !bytes.Equal(before, after) {
+		t.Error("footer metadata corrupted after mutating the input buffer")
+	}
+	if decoded.Schema() == nil {
+		t.Error("footer schema is nil after mutating the input buffer")
+	}
+}
+
+// TestDecodeFooterValidatesRowCounts checks that footer-level validation
+// runs at construction: ReadFooter and DecodeFooter are standalone APIs, so
+// inconsistent row counts must be rejected even though OpenFile would also
+// catch them later.
+func TestDecodeFooterValidatesRowCounts(t *testing.T) {
+	data, err := os.ReadFile("testdata/file.parquet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(data))
+	footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
+	footerBytes := data[size-int64(footerSize)-8 : size]
+
+	valid, err := parquet.DecodeFooter(footerBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-encode the metadata with a negative total row count and rebuild
+	// the footer bytes around it.
+	metadata := *valid.Metadata()
+	metadata.NumRows = -1
+	corrupt := marshalMetadata(t, &metadata)
+	corrupt = binary.LittleEndian.AppendUint32(corrupt, uint32(len(corrupt)))
+	corrupt = append(corrupt, "PAR1"...)
+
+	if _, err := parquet.DecodeFooter(corrupt); err == nil {
+		t.Error("expected error decoding a footer with a negative row count")
+	}
 }
 
 // TestFooterEncrypted checks ReadFooter/WithFooter against files with
@@ -298,18 +434,30 @@ func TestFooterEncrypted(t *testing.T) {
 		{Name: "beta", Value: 2},
 		{Name: "gamma", Value: 3},
 	}
-	keys := &staticKeyRetriever{footerKey: aes128Key(0x11)}
+	nameKey := aes128Key(0x22)
+	keys := &staticKeyRetriever{
+		footerKey:  aes128Key(0x11),
+		columnKeys: map[string][]byte{"name": nameKey},
+	}
+	columnKeys := map[string][]byte{"name": nameKey}
+	aadPrefix := []byte("footer-test-prefix")
 
 	for _, test := range []struct {
 		scenario        string
 		encryptedFooter bool
+		columnKeys      map[string][]byte
+		aadPrefix       []byte
 	}{
 		{scenario: "encrypted footer", encryptedFooter: true},
 		{scenario: "signed plaintext footer", encryptedFooter: false},
+		{scenario: "encrypted footer with column keys and AAD prefix", encryptedFooter: true, columnKeys: columnKeys, aadPrefix: aadPrefix},
+		{scenario: "signed plaintext footer with column keys and AAD prefix", encryptedFooter: false, columnKeys: columnKeys, aadPrefix: aadPrefix},
 	} {
 		t.Run(test.scenario, func(t *testing.T) {
 			data := writeEncrypted(t, rows, &parquet.EncryptionConfig{
 				FooterKey:       keys.footerKey,
+				ColumnKeys:      test.columnKeys,
+				AadPrefix:       test.aadPrefix,
 				EncryptedFooter: test.encryptedFooter,
 			})
 			size := int64(len(data))
@@ -331,6 +479,15 @@ func TestFooterEncrypted(t *testing.T) {
 			if !reflect.DeepEqual(got, rows) {
 				t.Errorf("rows mismatch: got %+v, want %+v", got, rows)
 			}
+
+			// The footer-based open must be fully equivalent to a regular
+			// open with decryption, including the page index read from the
+			// decrypted column metadata.
+			base, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithDecryption(keys))
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFilesEquivalent(t, base, f)
 
 			// DecodeFooter over the raw footer region must work as well.
 			footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])

--- a/footer_test.go
+++ b/footer_test.go
@@ -120,8 +120,11 @@ func readAllFileRows(t *testing.T, f *parquet.File) []parquet.Row {
 	return rows
 }
 
-// TestOpenFileWithFooter checks that opening a file from a pre-read footer
-// is equivalent to a regular open, for every testdata file.
+// TestOpenFileWithFooter checks, for every testdata file, that opening the
+// file from a pre-read footer is equivalent to a regular open, and that
+// ReadFooter over a bare footer section (the last footerSize+8 bytes of the
+// file, as cached by programs that store raw footer bytes) is equivalent to
+// ReadFooter over the file.
 func TestOpenFileWithFooter(t *testing.T) {
 	for _, path := range footerTestFiles(t) {
 		t.Run(filepath.Base(path), func(t *testing.T) {
@@ -152,6 +155,31 @@ func TestOpenFileWithFooter(t *testing.T) {
 				t.Fatal(err)
 			}
 			assertFilesEquivalent(t, base, again)
+
+			// A bare footer section must decode to the same footer, minus
+			// the file size, which a bare section does not carry.
+			footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
+			footerBytes := data[size-int64(footerSize)-8 : size]
+			decoded, err := parquet.ReadFooter(bytes.NewReader(footerBytes), int64(len(footerBytes)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decoded.Size() != 0 {
+				t.Errorf("decoded.Size() = %d, want 0 (unknown)", decoded.Size())
+			}
+			if b, w := marshalMetadata(t, footer.Metadata()), marshalMetadata(t, decoded.Metadata()); !bytes.Equal(b, w) {
+				t.Error("metadata mismatch between file and bare footer reads")
+			}
+			if b, w := footer.Schema().String(), decoded.Schema().String(); b != w {
+				t.Errorf("schema mismatch:\nread: %s\ndecoded: %s", b, w)
+			}
+			f, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(decoded))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if f.NumRows() != decoded.Metadata().NumRows {
+				t.Errorf("num rows mismatch: %d != %d", f.NumRows(), decoded.Metadata().NumRows)
+			}
 		})
 	}
 }
@@ -173,49 +201,6 @@ func TestOpenFileWithFooterRejectsWrongSize(t *testing.T) {
 	}
 	if _, err := parquet.OpenFile(bytes.NewReader(data), size+1, parquet.WithFooter(footer)); err == nil {
 		t.Error("expected error opening a file with a footer read from a file of a different size")
-	}
-}
-
-// TestReadFooterFromBareFooter checks that ReadFooter over a bare footer
-// section (the last footerSize+8 bytes of a file, as cached by programs
-// that store raw footer bytes) is equivalent to ReadFooter over the file.
-func TestReadFooterFromBareFooter(t *testing.T) {
-	for _, path := range footerTestFiles(t) {
-		t.Run(filepath.Base(path), func(t *testing.T) {
-			data, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			size := int64(len(data))
-			footerSize := binary.LittleEndian.Uint32(data[size-8 : size-4])
-			footerBytes := data[size-int64(footerSize)-8 : size]
-
-			read, err := parquet.ReadFooter(bytes.NewReader(data), size)
-			if err != nil {
-				t.Fatal(err)
-			}
-			decoded, err := parquet.ReadFooter(bytes.NewReader(footerBytes), int64(len(footerBytes)))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if decoded.Size() != 0 {
-				t.Errorf("decoded.Size() = %d, want 0 (unknown)", decoded.Size())
-			}
-			if b, w := marshalMetadata(t, read.Metadata()), marshalMetadata(t, decoded.Metadata()); !bytes.Equal(b, w) {
-				t.Error("metadata mismatch between file and bare footer reads")
-			}
-			if b, w := read.Schema().String(), decoded.Schema().String(); b != w {
-				t.Errorf("schema mismatch:\nread: %s\ndecoded: %s", b, w)
-			}
-
-			f, err := parquet.OpenFile(bytes.NewReader(data), size, parquet.WithFooter(decoded))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if f.NumRows() != decoded.NumRows() {
-				t.Errorf("num rows mismatch: %d != %d", f.NumRows(), decoded.NumRows())
-			}
-		})
 	}
 }
 

--- a/format/footer.go
+++ b/format/footer.go
@@ -23,7 +23,6 @@ import (
 type FooterDecoder struct {
 	buf     []byte
 	meta    FileMetaData
-	primed  bool
 	reader  thrift.BytesReader
 	decoder *thrift.Decoder
 }
@@ -48,24 +47,17 @@ func (d *FooterDecoder) Decode(data []byte) (*FileMetaData, int, error) {
 	// would corrupt previously returned values in place. Resetting first
 	// keeps the "valid until next Decode" contract honest instead of
 	// leaving values that are subtly wrong.
-	if d.primed {
-		d.meta.Reset()
-	}
+	d.meta.Reset()
 	d.buf = append(d.buf[:0], data...)
 
 	if d.reader == nil {
-		d.reader = footerProtocol.NewReaderFromBytes(d.buf)
+		d.reader = footerProtocol.NewReaderFromBytes(nil)
 		d.decoder = thrift.NewDecoder(d.reader)
-	} else {
-		d.reader.ResetBytes(d.buf)
 	}
+	d.reader.ResetBytes(d.buf)
 
 	if err := d.decoder.Decode(&d.meta); err != nil {
-		// Leave the decoder marked primed: a partial decode may have
-		// written into d.meta, which must be cleared before the next use.
-		d.primed = true
 		return nil, 0, fmt.Errorf("decoding parquet footer: %w", err)
 	}
-	d.primed = true
 	return &d.meta, d.reader.BytesRead(), nil
 }

--- a/format/footer.go
+++ b/format/footer.go
@@ -16,7 +16,10 @@ import (
 //
 // A decoder never allocates for inputs whose shape fits the capacity
 // retained from previous decodes; larger or differently-shaped inputs grow
-// the retained state as needed.
+// the retained state as needed. The retained state never shrinks: one
+// unusually large footer sizes the decoder's buffer and metadata tree for
+// its remaining lifetime, so long-lived decoders dedicated to a single file
+// may prefer to be discarded after use instead of pooled.
 type FooterDecoder struct {
 	buf     []byte
 	meta    FileMetaData

--- a/format/footer.go
+++ b/format/footer.go
@@ -1,0 +1,68 @@
+package format
+
+import (
+	"fmt"
+
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+)
+
+// FooterDecoder decodes Parquet file footers (thrift compact protocol) with
+// zero steady-state allocations by retaining its input buffer and decoded
+// metadata across calls to Decode.
+//
+// The zero value is ready to use. FooterDecoder values must not be copied
+// after first use and are not safe for concurrent use; to amortize
+// allocations across goroutines, keep decoders in a sync.Pool.
+//
+// A decoder never allocates for inputs whose shape fits the capacity
+// retained from previous decodes; larger or differently-shaped inputs grow
+// the retained state as needed.
+type FooterDecoder struct {
+	buf     []byte
+	meta    FileMetaData
+	primed  bool
+	reader  thrift.BytesReader
+	decoder *thrift.Decoder
+}
+
+// protocol is stateless and shared by all decoders.
+var footerProtocol thrift.CompactProtocol
+
+// Decode parses the thrift-encoded footer in data and returns the decoded
+// metadata along with the number of bytes consumed. Trailing bytes after the
+// thrift payload (such as the 28-byte AES-GCM footer signature written by
+// encrypted-footer-signing writers) are not an error; callers can detect
+// them by comparing the consumed byte count to len(data).
+//
+// The returned metadata, and all strings and byte slices it references, are
+// owned by the decoder and remain valid only until the next call to Decode.
+// Callers that need the metadata to outlive the decoder must deep-copy it.
+//
+// Decode makes a private copy of data; the caller retains ownership of the
+// slice and may reuse it immediately.
+func (d *FooterDecoder) Decode(data []byte) (*FileMetaData, int, error) {
+	// The decoded metadata aliases the retained buffer, so the copy below
+	// would corrupt previously returned values in place. Resetting first
+	// keeps the "valid until next Decode" contract honest instead of
+	// leaving values that are subtly wrong.
+	if d.primed {
+		d.meta.Reset()
+	}
+	d.buf = append(d.buf[:0], data...)
+
+	if d.reader == nil {
+		d.reader = footerProtocol.NewReaderFromBytes(d.buf)
+		d.decoder = thrift.NewDecoder(d.reader)
+	} else {
+		d.reader.ResetBytes(d.buf)
+	}
+
+	if err := d.decoder.Decode(&d.meta); err != nil {
+		// Leave the decoder marked primed: a partial decode may have
+		// written into d.meta, which must be cleared before the next use.
+		d.primed = true
+		return nil, 0, fmt.Errorf("decoding parquet footer: %w", err)
+	}
+	d.primed = true
+	return &d.meta, d.reader.BytesRead(), nil
+}

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -1,10 +1,10 @@
 package format_test
 
 import (
+	"maps"
 	"path/filepath"
 	"reflect"
 	"slices"
-	"sort"
 	"testing"
 
 	"github.com/parquet-go/parquet-go/encoding/thrift"
@@ -31,15 +31,6 @@ func loadAllFooters(t testing.TB) map[string][]byte {
 	return footers
 }
 
-func sortedNames(footers map[string][]byte) []string {
-	names := make([]string, 0, len(footers))
-	for name := range footers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
-}
-
 func decodeFresh(t testing.TB, footer []byte) *format.FileMetaData {
 	protocol := &thrift.CompactProtocol{}
 	metadata := new(format.FileMetaData)
@@ -56,7 +47,7 @@ func TestFooterDecoderMatchesUnmarshal(t *testing.T) {
 	footers := loadAllFooters(t)
 	decoder := new(format.FooterDecoder)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		decoded, n, err := decoder.Decode(footer)
 		if err != nil {
@@ -72,28 +63,35 @@ func TestFooterDecoderMatchesUnmarshal(t *testing.T) {
 	}
 }
 
-// TestFooterDecoderReuse decodes every ordered pair of testdata footers
-// through a single FooterDecoder and checks the second result against a
-// fresh decode. This catches any state from the first decode leaking into
-// the second (i.e. fields missed by the Reset methods).
+// checkReusePair decodes first then second through a single FooterDecoder
+// and checks the second result against a fresh decode. This catches any
+// state from the first decode leaking into the second (i.e. fields missed
+// by the Reset methods).
+func checkReusePair(t *testing.T, firstName string, first []byte, secondName string, second []byte) {
+	t.Helper()
+	decoder := new(format.FooterDecoder)
+	if _, _, err := decoder.Decode(first); err != nil {
+		t.Fatalf("decoding %s: %v", firstName, err)
+	}
+	decoded, _, err := decoder.Decode(second)
+	if err != nil {
+		t.Fatalf("decoding %s after %s: %v", secondName, firstName, err)
+	}
+	if fresh := decodeFresh(t, second); !equalMetadata(decoded, fresh) {
+		t.Errorf("decoding %s after %s: metadata differs from fresh decode", secondName, firstName)
+	}
+}
+
+// TestFooterDecoderReuse checks every ordered pair of testdata footers
+// through checkReusePair.
 func TestFooterDecoderReuse(t *testing.T) {
 	footers := loadAllFooters(t)
-	names := sortedNames(footers)
+	names := slices.Sorted(maps.Keys(footers))
 
 	for _, first := range names {
 		t.Run(first, func(t *testing.T) {
 			for _, second := range names {
-				decoder := new(format.FooterDecoder)
-				if _, _, err := decoder.Decode(footers[first]); err != nil {
-					t.Fatalf("decoding %s: %v", first, err)
-				}
-				decoded, _, err := decoder.Decode(footers[second])
-				if err != nil {
-					t.Fatalf("decoding %s after %s: %v", second, first, err)
-				}
-				if fresh := decodeFresh(t, footers[second]); !equalMetadata(decoded, fresh) {
-					t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
-				}
+				checkReusePair(t, first, footers[first], second, footers[second])
 			}
 		})
 	}
@@ -105,7 +103,7 @@ func TestFooterDecoderInputOwnership(t *testing.T) {
 	footers := loadAllFooters(t)
 	decoder := new(format.FooterDecoder)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := slices.Clone(footers[name])
 		decoded, _, err := decoder.Decode(footer)
 		if err != nil {
@@ -125,7 +123,7 @@ func TestFooterDecoderInputOwnership(t *testing.T) {
 func TestFooterDecoderZeroAllocs(t *testing.T) {
 	footers := loadAllFooters(t)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		decoder := new(format.FooterDecoder)
 		if _, _, err := decoder.Decode(footer); err != nil {
@@ -342,17 +340,7 @@ func TestFooterDecoderReuseSynthetic(t *testing.T) {
 	footers := map[string][]byte{"maximal": maximal, "minimal": minimal}
 	for first, firstFooter := range footers {
 		for second, secondFooter := range footers {
-			decoder := new(format.FooterDecoder)
-			if _, _, err := decoder.Decode(firstFooter); err != nil {
-				t.Fatalf("decoding %s: %v", first, err)
-			}
-			decoded, _, err := decoder.Decode(secondFooter)
-			if err != nil {
-				t.Fatalf("decoding %s after %s: %v", second, first, err)
-			}
-			if fresh := decodeFresh(t, secondFooter); !equalMetadata(decoded, fresh) {
-				t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
-			}
+			checkReusePair(t, first, firstFooter, second, secondFooter)
 		}
 	}
 }
@@ -438,7 +426,7 @@ func TestFooterDecoderTrailingBytes(t *testing.T) {
 	footers := loadAllFooters(t)
 	decoder := new(format.FooterDecoder)
 
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		signed := make([]byte, 0, len(footer)+28)
 		signed = append(signed, footer...)
@@ -467,7 +455,7 @@ func TestFooterDecoderErrorRecovery(t *testing.T) {
 
 	// Truncated inputs fail partway through decoding, leaving partially
 	// populated metadata that the next Decode must fully reset.
-	for _, name := range sortedNames(footers) {
+	for _, name := range slices.Sorted(maps.Keys(footers)) {
 		footer := footers[name]
 		if _, _, err := decoder.Decode(footer[:len(footer)/2]); err == nil {
 			t.Fatalf("%s: expected error decoding truncated footer", name)
@@ -511,11 +499,6 @@ func equalMetadata(a, b *format.FileMetaData) bool {
 	return equalValue(reflect.ValueOf(a).Elem(), reflect.ValueOf(b).Elem())
 }
 
-// isNullType reports whether t has the shape of thrift.Null[T].
-func isNullType(t reflect.Type) bool {
-	return t.NumField() == 2 && t.Field(0).Name == "V" && t.Field(1).Name == "Valid"
-}
-
 func equalValue(a, b reflect.Value) bool {
 	if a.Type() != b.Type() {
 		return false
@@ -537,18 +520,6 @@ func equalValue(a, b reflect.Value) bool {
 		}
 		return true
 	case reflect.Struct:
-		// thrift.Null[T] values compare by validity first: when both are
-		// invalid, the inner value is unobservable and may contain stale
-		// data retained for reuse by Reset.
-		if isNullType(a.Type()) {
-			av, bv := a.FieldByName("Valid"), b.FieldByName("Valid")
-			if av.Bool() != bv.Bool() {
-				return false
-			}
-			if !av.Bool() {
-				return true
-			}
-		}
 		for i := range a.NumField() {
 			if !equalValue(a.Field(i), b.Field(i)) {
 				return false

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -381,6 +381,55 @@ func TestSchemaElementResetClearsGeospatialMembers(t *testing.T) {
 	}
 }
 
+// TestResetClearsCryptoUnionMembers pins the buffer-aliasing scrub of the
+// two retained crypto unions, mirroring the CRS handling above: a retained
+// EncryptionAlgorithm or CryptoMetadata member must not keep byte slices or
+// strings that alias the previous decode's input buffer.
+func TestResetClearsCryptoUnionMembers(t *testing.T) {
+	m := format.FileMetaData{
+		EncryptionAlgorithm: format.EncryptionAlgorithm{
+			Value: &format.AesGcmV1{
+				AadPrefix:       []byte("prefix"),
+				AadFileUnique:   []byte("unique"),
+				SupplyAadPrefix: true,
+			},
+		},
+	}
+	m.Reset()
+	if v, ok := m.EncryptionAlgorithm.Value.(*format.AesGcmV1); !ok {
+		t.Errorf("AesGcmV1 member allocation not retained by Reset")
+	} else if v.AadPrefix != nil || v.AadFileUnique != nil || v.SupplyAadPrefix {
+		t.Errorf("AesGcmV1 member not cleared by Reset: %+v", *v)
+	}
+
+	m = format.FileMetaData{
+		EncryptionAlgorithm: format.EncryptionAlgorithm{
+			Value: &format.AesGcmCtrV1{AadPrefix: []byte("prefix")},
+		},
+	}
+	m.Reset()
+	if v, ok := m.EncryptionAlgorithm.Value.(*format.AesGcmCtrV1); !ok {
+		t.Errorf("AesGcmCtrV1 member allocation not retained by Reset")
+	} else if v.AadPrefix != nil || v.AadFileUnique != nil || v.SupplyAadPrefix {
+		t.Errorf("AesGcmCtrV1 member not cleared by Reset: %+v", *v)
+	}
+
+	c := format.ColumnChunk{
+		CryptoMetadata: format.ColumnCryptoMetaData{
+			Value: &format.EncryptionWithColumnKey{
+				PathInSchema: thrift.Slice[string]{"a", "b"},
+				KeyMetadata:  []byte("key"),
+			},
+		},
+	}
+	c.Reset()
+	if v, ok := c.CryptoMetadata.Value.(*format.EncryptionWithColumnKey); !ok {
+		t.Errorf("EncryptionWithColumnKey member allocation not retained by Reset")
+	} else if v.PathInSchema != nil || v.KeyMetadata != nil {
+		t.Errorf("EncryptionWithColumnKey member not cleared by Reset: %+v", *v)
+	}
+}
+
 // TestFooterDecoderTrailingBytes checks the documented tolerance for
 // trailing bytes: signed plaintext footers carry a 28-byte signature after
 // the thrift payload, which Decode must not treat as an error, reporting the

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -1,0 +1,221 @@
+package format_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/encoding/thrift"
+	"github.com/parquet-go/parquet-go/format"
+)
+
+// loadAllFooters extracts the raw footer bytes of every readable plain
+// parquet file under ../testdata, keyed by file name.
+func loadAllFooters(t testing.TB) map[string][]byte {
+	paths, err := filepath.Glob(filepath.Join("..", "testdata", "*.parquet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	footers := make(map[string][]byte)
+	for _, path := range paths {
+		// Skips encrypted (PARE) and malformed files.
+		if footer, err := extractFooterBytes(path); err == nil {
+			footers[filepath.Base(path)] = footer
+		}
+	}
+	if len(footers) == 0 {
+		t.Skip("no parquet testdata files found")
+	}
+	return footers
+}
+
+func sortedNames(footers map[string][]byte) []string {
+	names := make([]string, 0, len(footers))
+	for name := range footers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func decodeFresh(t testing.TB, footer []byte) *format.FileMetaData {
+	protocol := &thrift.CompactProtocol{}
+	metadata := new(format.FileMetaData)
+	if err := thrift.Unmarshal(protocol, footer, metadata); err != nil {
+		t.Fatal(err)
+	}
+	return metadata
+}
+
+// TestFooterDecoderMatchesUnmarshal checks that FooterDecoder produces the
+// same result as a fresh thrift.Unmarshal for every testdata footer, and
+// that it consumes the entire input.
+func TestFooterDecoderMatchesUnmarshal(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		decoded, n, err := decoder.Decode(footer)
+		if err != nil {
+			t.Errorf("%s: %v", name, err)
+			continue
+		}
+		if n != len(footer) {
+			t.Errorf("%s: consumed %d bytes, want %d", name, n, len(footer))
+		}
+		if fresh := decodeFresh(t, footer); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: decoded metadata differs from fresh decode", name)
+		}
+	}
+}
+
+// TestFooterDecoderReuse decodes every ordered pair of testdata footers
+// through a single FooterDecoder and checks the second result against a
+// fresh decode. This catches any state from the first decode leaking into
+// the second (i.e. fields missed by the Reset methods).
+func TestFooterDecoderReuse(t *testing.T) {
+	footers := loadAllFooters(t)
+	names := sortedNames(footers)
+
+	for _, first := range names {
+		t.Run(first, func(t *testing.T) {
+			for _, second := range names {
+				decoder := new(format.FooterDecoder)
+				if _, _, err := decoder.Decode(footers[first]); err != nil {
+					t.Fatalf("decoding %s: %v", first, err)
+				}
+				decoded, _, err := decoder.Decode(footers[second])
+				if err != nil {
+					t.Fatalf("decoding %s after %s: %v", second, first, err)
+				}
+				if fresh := decodeFresh(t, footers[second]); !equalMetadata(decoded, fresh) {
+					t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
+				}
+			}
+		})
+	}
+}
+
+// TestFooterDecoderInputOwnership checks that the decoder copies its input:
+// clobbering the caller's buffer after Decode must not corrupt the result.
+func TestFooterDecoderInputOwnership(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	for _, name := range sortedNames(footers) {
+		footer := slices.Clone(footers[name])
+		decoded, _, err := decoder.Decode(footer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range footer {
+			footer[i] = 0xff
+		}
+		if fresh := decodeFresh(t, footers[name]); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: metadata corrupted after mutating the input buffer", name)
+		}
+	}
+}
+
+// TestFooterDecoderZeroAllocs checks the zero-allocation guarantee: after a
+// warmup decode, repeated decodes of the same footer must not allocate.
+func TestFooterDecoderZeroAllocs(t *testing.T) {
+	footers := loadAllFooters(t)
+
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		decoder := new(format.FooterDecoder)
+		if _, _, err := decoder.Decode(footer); err != nil {
+			t.Fatal(err)
+		}
+		allocs := testing.AllocsPerRun(10, func() {
+			if _, _, err := decoder.Decode(footer); err != nil {
+				t.Fatal(err)
+			}
+		})
+		if allocs != 0 {
+			t.Errorf("%s: %v allocs per decode, want 0", name, allocs)
+		}
+	}
+}
+
+func BenchmarkFooterDecoder(b *testing.B) {
+	footers := loadAllFooters(b)
+
+	for _, name := range []string{"trace.snappy.parquet", "nested_structs.rust.parquet", "alltypes_tiny_pages_plain.parquet"} {
+		footer, ok := footers[name]
+		if !ok {
+			continue
+		}
+		b.Run(name, func(b *testing.B) {
+			decoder := new(format.FooterDecoder)
+			b.SetBytes(int64(len(footer)))
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, _, err := decoder.Decode(footer); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// equalMetadata compares two FileMetaData values, treating nil and empty
+// slices as equal. The distinction is unavoidable when reusing decode
+// targets: truncated slices retain their backing arrays where a fresh
+// decode would leave the field nil.
+func equalMetadata(a, b *format.FileMetaData) bool {
+	return equalValue(reflect.ValueOf(a).Elem(), reflect.ValueOf(b).Elem())
+}
+
+// isNullType reports whether t has the shape of thrift.Null[T].
+func isNullType(t reflect.Type) bool {
+	return t.NumField() == 2 && t.Field(0).Name == "V" && t.Field(1).Name == "Valid"
+}
+
+func equalValue(a, b reflect.Value) bool {
+	if a.Type() != b.Type() {
+		return false
+	}
+	switch a.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() == b.IsNil()
+		}
+		return equalValue(a.Elem(), b.Elem())
+	case reflect.Slice:
+		if a.Len() != b.Len() {
+			return false
+		}
+		for i := range a.Len() {
+			if !equalValue(a.Index(i), b.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Struct:
+		// thrift.Null[T] values compare by validity first: when both are
+		// invalid, the inner value is unobservable and may contain stale
+		// data retained for reuse by Reset.
+		if isNullType(a.Type()) {
+			av, bv := a.FieldByName("Valid"), b.FieldByName("Valid")
+			if av.Bool() != bv.Bool() {
+				return false
+			}
+			if !av.Bool() {
+				return true
+			}
+		}
+		for i := range a.NumField() {
+			if !equalValue(a.Field(i), b.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		return a.Interface() == b.Interface()
+	}
+}

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -142,6 +142,30 @@ func TestFooterDecoderZeroAllocs(t *testing.T) {
 	}
 }
 
+// TestFooterDecoderErrorRecovery checks that a failed decode does not
+// poison the decoder: decoding a valid footer after an invalid input must
+// produce the same result as a fresh decode.
+func TestFooterDecoderErrorRecovery(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	// Truncated inputs fail partway through decoding, leaving partially
+	// populated metadata that the next Decode must fully reset.
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		if _, _, err := decoder.Decode(footer[:len(footer)/2]); err == nil {
+			t.Fatalf("%s: expected error decoding truncated footer", name)
+		}
+		decoded, _, err := decoder.Decode(footer)
+		if err != nil {
+			t.Fatalf("%s: decoding after a failed decode: %v", name, err)
+		}
+		if fresh := decodeFresh(t, footer); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: metadata differs from fresh decode after a failed decode", name)
+		}
+	}
+}
+
 func BenchmarkFooterDecoder(b *testing.B) {
 	footers := loadAllFooters(b)
 

--- a/format/footer_test.go
+++ b/format/footer_test.go
@@ -142,6 +142,273 @@ func TestFooterDecoderZeroAllocs(t *testing.T) {
 	}
 }
 
+// maximalFileMetaData returns a FileMetaData with every optional field
+// populated, including the ones no testdata footer exercises (sorting
+// columns, non-zero ordinals, file paths, crypto metadata, geospatial
+// statistics, geometry/geography logical types, ...). It anchors the reuse
+// tests below to the full type tree instead of whatever testdata contains.
+func maximalFileMetaData() *format.FileMetaData {
+	return &format.FileMetaData{
+		Version: 2,
+		Schema: thrift.Slice[format.SchemaElement]{
+			{
+				Name:        "root",
+				NumChildren: thrift.New(int32(2)),
+			},
+			{
+				Type:           thrift.New(format.ByteArray),
+				RepetitionType: thrift.New(format.Optional),
+				Name:           "geometry",
+				FieldID:        7,
+				LogicalType: format.LogicalType{
+					Value: &format.GeometryType{CRS: "EPSG:4326"},
+				},
+			},
+			{
+				Type:           thrift.New(format.ByteArray),
+				TypeLength:     thrift.New(int32(16)),
+				RepetitionType: thrift.New(format.Required),
+				Name:           "geography",
+				Scale:          thrift.New(int32(2)),
+				Precision:      thrift.New(int32(10)),
+				LogicalType: format.LogicalType{
+					Value: &format.GeographyType{CRS: "OGC:CRS84", Algorithm: 1},
+				},
+			},
+		},
+		NumRows: 3,
+		RowGroups: thrift.Slice[format.RowGroup]{
+			{
+				Columns: thrift.Slice[format.ColumnChunk]{
+					{
+						FilePath:   "part-0001.parquet",
+						FileOffset: 4,
+						MetaData: format.ColumnMetaData{
+							Type:                  format.ByteArray,
+							Encoding:              thrift.Slice[format.Encoding]{format.Plain},
+							PathInSchema:          thrift.Slice[string]{"geometry"},
+							Codec:                 format.Snappy,
+							NumValues:             3,
+							TotalUncompressedSize: 100,
+							TotalCompressedSize:   80,
+							KeyValueMetadata:      []format.KeyValue{{Key: "ck", Value: "cv"}},
+							DataPageOffset:        4,
+							IndexPageOffset:       8,
+							DictionaryPageOffset:  12,
+							Statistics: format.Statistics{
+								Max: []byte("z"), Min: []byte("a"),
+								NullCount: 1, DistinctCount: 2,
+								MaxValue: []byte("z"), MinValue: []byte("a"),
+							},
+							EncodingStats: []format.PageEncodingStats{
+								{PageType: format.DataPage, Encoding: format.Plain, Count: 1},
+							},
+							BloomFilterOffset: 16,
+							BloomFilterLength: 32,
+							SizeStatistics: format.SizeStatistics{
+								UnencodedByteArrayDataBytes: 7,
+								RepetitionLevelHistogram:    []int64{1, 2},
+								DefinitionLevelHistogram:    []int64{3, 4},
+							},
+							GeospatialStatistics: format.GeospatialStatistics{
+								BBox: format.BoundingBox{
+									XMin: 1, XMax: 2, YMin: 3, YMax: 4,
+									ZMin: thrift.New(5.0), ZMax: thrift.New(6.0),
+								},
+								GeoSpatialTypes: []int32{1},
+							},
+						},
+						OffsetIndexOffset: 20,
+						OffsetIndexLength: 4,
+						ColumnIndexOffset: 24,
+						ColumnIndexLength: 4,
+						CryptoMetadata: format.ColumnCryptoMetaData{
+							Value: &format.EncryptionWithColumnKey{
+								PathInSchema: []string{"geometry"},
+								KeyMetadata:  []byte("key-meta"),
+							},
+						},
+						EncryptedColumnMetadata: []byte("encrypted-blob"),
+					},
+				},
+				TotalByteSize: 100,
+				NumRows:       3,
+				SortingColumns: []format.SortingColumn{
+					{ColumnIdx: 0, Descending: true, NullsFirst: true},
+				},
+				FileOffset:          4,
+				TotalCompressedSize: 80,
+				Ordinal:             5,
+			},
+		},
+		KeyValueMetadata: []format.KeyValue{{Key: "k", Value: "v"}},
+		CreatedBy:        "synthetic-test",
+		ColumnOrders: []format.ColumnOrder{
+			{Value: &format.TypeDefinedOrder{}},
+			{Value: &format.TypeDefinedOrder{}},
+		},
+		EncryptionAlgorithm: format.EncryptionAlgorithm{
+			Value: &format.AesGcmV1{
+				AadPrefix:       []byte("prefix"),
+				AadFileUnique:   []byte("unique"),
+				SupplyAadPrefix: true,
+			},
+		},
+		FooterSigningKeyMetadata: []byte("signing-key"),
+	}
+}
+
+// The minimal* structs mirror the thrift field IDs of FileMetaData but
+// declare only the required fields, producing an input where every optional
+// field is genuinely absent. Marshaling a format.FileMetaData cannot produce
+// such an input for fields with writezero tags (e.g. RowGroup.Ordinal).
+type minimalColumnMetaData struct {
+	Type                  int32    `thrift:"1,required"`
+	Encoding              []int32  `thrift:"2,required"`
+	PathInSchema          []string `thrift:"3,required"`
+	Codec                 int32    `thrift:"4,required"`
+	NumValues             int64    `thrift:"5,required"`
+	TotalUncompressedSize int64    `thrift:"6,required"`
+	TotalCompressedSize   int64    `thrift:"7,required"`
+	DataPageOffset        int64    `thrift:"9,required"`
+}
+
+type minimalColumnChunk struct {
+	FileOffset int64                 `thrift:"2,required"`
+	MetaData   minimalColumnMetaData `thrift:"3,optional"`
+}
+
+type minimalRowGroup struct {
+	Columns       []minimalColumnChunk `thrift:"1,required"`
+	TotalByteSize int64                `thrift:"2,required"`
+	NumRows       int64                `thrift:"3,required"`
+}
+
+type minimalSchemaElement struct {
+	Type        int32  `thrift:"1,optional"`
+	Name        string `thrift:"4,required"`
+	NumChildren int32  `thrift:"5,optional"`
+}
+
+type minimalFileMetaData struct {
+	Version   int32                  `thrift:"1,required"`
+	Schema    []minimalSchemaElement `thrift:"2,required"`
+	NumRows   int64                  `thrift:"3,required"`
+	RowGroups []minimalRowGroup      `thrift:"4,required"`
+}
+
+// TestFooterDecoderReuseSynthetic decodes a footer with every optional field
+// populated and a footer with every optional field absent through the same
+// FooterDecoder, in both orders, and checks the second result against a
+// fresh decode. Unlike TestFooterDecoderReuse this does not depend on what
+// the testdata footers happen to contain, so it covers the Reset methods of
+// fields absent from all testdata (ordinals, sorting columns, file paths,
+// crypto metadata, geospatial types, ...).
+func TestFooterDecoderReuseSynthetic(t *testing.T) {
+	protocol := &thrift.CompactProtocol{}
+
+	maximal, err := thrift.Marshal(protocol, maximalFileMetaData())
+	if err != nil {
+		t.Fatal(err)
+	}
+	minimal, err := thrift.Marshal(protocol, &minimalFileMetaData{
+		Version: 1,
+		Schema: []minimalSchemaElement{
+			{Name: "root", NumChildren: 1},
+			{Type: int32(format.ByteArray), Name: "geometry"},
+		},
+		NumRows: 1,
+		RowGroups: []minimalRowGroup{{
+			Columns: []minimalColumnChunk{{
+				FileOffset: 4,
+				MetaData: minimalColumnMetaData{
+					Type:                  int32(format.ByteArray),
+					Encoding:              []int32{int32(format.Plain)},
+					PathInSchema:          []string{"geometry"},
+					NumValues:             1,
+					TotalUncompressedSize: 10,
+					TotalCompressedSize:   8,
+					DataPageOffset:        4,
+				},
+			}},
+			TotalByteSize: 10,
+			NumRows:       1,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	footers := map[string][]byte{"maximal": maximal, "minimal": minimal}
+	for first, firstFooter := range footers {
+		for second, secondFooter := range footers {
+			decoder := new(format.FooterDecoder)
+			if _, _, err := decoder.Decode(firstFooter); err != nil {
+				t.Fatalf("decoding %s: %v", first, err)
+			}
+			decoded, _, err := decoder.Decode(secondFooter)
+			if err != nil {
+				t.Fatalf("decoding %s after %s: %v", second, first, err)
+			}
+			if fresh := decodeFresh(t, secondFooter); !equalMetadata(decoded, fresh) {
+				t.Errorf("decoding %s after %s: metadata differs from fresh decode", second, first)
+			}
+		}
+	}
+}
+
+// TestSchemaElementResetClearsGeospatialMembers pins the CRS-clearing
+// behavior of SchemaElement.Reset directly: retained Geometry/Geography
+// union members must not keep strings that alias the previous decode's
+// input buffer.
+func TestSchemaElementResetClearsGeospatialMembers(t *testing.T) {
+	s := format.SchemaElement{
+		Name:        "geometry",
+		LogicalType: format.LogicalType{Value: &format.GeometryType{CRS: "EPSG:4326"}},
+	}
+	s.Reset()
+	if g, ok := s.LogicalType.Value.(*format.GeometryType); ok && *g != (format.GeometryType{}) {
+		t.Errorf("Geometry member not cleared by Reset: %+v", *g)
+	}
+
+	s = format.SchemaElement{
+		Name:        "geography",
+		LogicalType: format.LogicalType{Value: &format.GeographyType{CRS: "OGC:CRS84", Algorithm: 1}},
+	}
+	s.Reset()
+	if g, ok := s.LogicalType.Value.(*format.GeographyType); ok && *g != (format.GeographyType{}) {
+		t.Errorf("Geography member not cleared by Reset: %+v", *g)
+	}
+}
+
+// TestFooterDecoderTrailingBytes checks the documented tolerance for
+// trailing bytes: signed plaintext footers carry a 28-byte signature after
+// the thrift payload, which Decode must not treat as an error, reporting the
+// consumed byte count instead.
+func TestFooterDecoderTrailingBytes(t *testing.T) {
+	footers := loadAllFooters(t)
+	decoder := new(format.FooterDecoder)
+
+	for _, name := range sortedNames(footers) {
+		footer := footers[name]
+		signed := make([]byte, 0, len(footer)+28)
+		signed = append(signed, footer...)
+		for range 28 {
+			signed = append(signed, 0xa5)
+		}
+		decoded, n, err := decoder.Decode(signed)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if n != len(footer) {
+			t.Errorf("%s: consumed %d bytes, want %d", name, n, len(footer))
+		}
+		if fresh := decodeFresh(t, footer); !equalMetadata(decoded, fresh) {
+			t.Errorf("%s: metadata differs from fresh decode", name)
+		}
+	}
+}
+
 // TestFooterDecoderErrorRecovery checks that a failed decode does not
 // poison the decoder: decoding a valid footer after an invalid input must
 // produce the same result as a fresh decode.

--- a/format/parquet.go
+++ b/format/parquet.go
@@ -1143,15 +1143,22 @@ type RowGroup struct {
 	Ordinal int16 `thrift:"7,optional,writezero"`
 }
 
+// Reset clears r in place, retaining allocated capacity for reuse. Elements
+// of the retained slices are recursively cleared so that values from a
+// previous thrift decode cannot leak into the next one (the decoder only
+// writes fields present in its input).
 func (r *RowGroup) Reset() {
-	r.FileOffset = 0
-	r.NumRows = 0
-	r.TotalByteSize = 0
-	r.SortingColumns = r.SortingColumns[:0]
+	for i := range r.Columns {
+		r.Columns[i].Reset()
+	}
 	r.Columns = r.Columns[:0]
-	r.Ordinal = 0
 	r.TotalByteSize = 0
+	r.NumRows = 0
+	clear(r.SortingColumns)
+	r.SortingColumns = r.SortingColumns[:0]
+	r.FileOffset = 0
 	r.TotalCompressedSize = 0
+	r.Ordinal = 0
 }
 
 // Empty struct to signal the order defined by the physical or logical type.

--- a/format/reset.go
+++ b/format/reset.go
@@ -1,0 +1,132 @@
+package format
+
+// The Reset methods in this file clear values in place while retaining
+// allocated slice capacity, so that a value can be reused as the decode
+// target of multiple thrift deserializations without allocating on each
+// decode (see FooterDecoder).
+//
+// Because the thrift decoder only writes fields that are present in the
+// input, Reset must recursively clear the elements of retained slices;
+// otherwise fields decoded from a previous input would leak into the next
+// decoded value. Union fields are the exception: the decoder itself clears
+// unions absent from the input and zeroes reused members, so Reset retains
+// their member allocations for the next decode to reuse.
+//
+// Byte slice and string fields decoded from footers alias the input buffer
+// (they are replaced, never reused, by the decoder), so Reset sets them to
+// nil or empty instead of truncating, releasing references to the previous
+// input buffer.
+
+// Reset clears m in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+//
+// Note that after reuse, optional list fields that are absent from the
+// decoded input are left empty but non-nil, whereas decoding into a fresh
+// FileMetaData leaves them nil. Both states are semantically equivalent
+// (zero-length), but programs distinguishing nil from empty slices, or
+// re-encoding the value, can observe the difference.
+func (m *FileMetaData) Reset() {
+	m.Version = 0
+	for i := range m.Schema {
+		m.Schema[i].Reset()
+	}
+	m.Schema = m.Schema[:0]
+	m.NumRows = 0
+	for i := range m.RowGroups {
+		m.RowGroups[i].Reset()
+	}
+	m.RowGroups = m.RowGroups[:0]
+	clear(m.KeyValueMetadata)
+	m.KeyValueMetadata = m.KeyValueMetadata[:0]
+	m.CreatedBy = ""
+	m.ColumnOrders = m.ColumnOrders[:0]
+	// EncryptionAlgorithm is a union; its member allocation is retained
+	// for reuse by the next decode (see SchemaElement.Reset).
+	m.FooterSigningKeyMetadata = nil
+}
+
+// Reset clears s in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (s *SchemaElement) Reset() {
+	s.Type.Reset()
+	s.TypeLength.Reset()
+	s.RepetitionType.Reset()
+	s.Name = ""
+	s.NumChildren.Reset()
+	s.ConvertedType.Reset()
+	s.Scale.Reset()
+	s.Precision.Reset()
+	s.FieldID = 0
+	// The LogicalType union member is deliberately retained: when the
+	// element is decoded again, the thrift decoder reuses the member
+	// allocation if the input holds the same member type (zeroing its
+	// contents first), and clears the union if the field is absent from
+	// the input. Either way no stale state survives a decode.
+}
+
+// Reset clears c in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (c *ColumnChunk) Reset() {
+	c.FilePath = ""
+	c.FileOffset = 0
+	c.MetaData.Reset()
+	c.OffsetIndexOffset = 0
+	c.OffsetIndexLength = 0
+	c.ColumnIndexOffset = 0
+	c.ColumnIndexLength = 0
+	// CryptoMetadata is a union; its member allocation is retained for
+	// reuse by the next decode (see SchemaElement.Reset).
+	c.EncryptedColumnMetadata = nil
+}
+
+// Reset clears c in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (c *ColumnMetaData) Reset() {
+	c.Type = 0
+	c.Encoding = c.Encoding[:0]
+	clear(c.PathInSchema)
+	c.PathInSchema = c.PathInSchema[:0]
+	c.Codec = 0
+	c.NumValues = 0
+	c.TotalUncompressedSize = 0
+	c.TotalCompressedSize = 0
+	clear(c.KeyValueMetadata)
+	c.KeyValueMetadata = c.KeyValueMetadata[:0]
+	c.DataPageOffset = 0
+	c.IndexPageOffset = 0
+	c.DictionaryPageOffset = 0
+	c.Statistics.Reset()
+	clear(c.EncodingStats)
+	c.EncodingStats = c.EncodingStats[:0]
+	c.BloomFilterOffset = 0
+	c.BloomFilterLength = 0
+	c.SizeStatistics.Reset()
+	c.GeospatialStatistics.Reset()
+}
+
+// Reset clears s in place. The byte slice fields are set to nil rather than
+// truncated because decoded values alias the input buffer and are always
+// replaced, never appended to.
+func (s *Statistics) Reset() {
+	s.Max = nil
+	s.Min = nil
+	s.NullCount = 0
+	s.DistinctCount = 0
+	s.MaxValue = nil
+	s.MinValue = nil
+}
+
+// Reset clears s in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (s *SizeStatistics) Reset() {
+	s.UnencodedByteArrayDataBytes = 0
+	s.RepetitionLevelHistogram = s.RepetitionLevelHistogram[:0]
+	s.DefinitionLevelHistogram = s.DefinitionLevelHistogram[:0]
+}
+
+// Reset clears g in place, retaining allocated capacity for reuse in
+// subsequent thrift decodes.
+func (g *GeospatialStatistics) Reset() {
+	g.BBox = BoundingBox{}
+	g.GeoSpatialTypes = g.GeoSpatialTypes[:0]
+}

--- a/format/reset.go
+++ b/format/reset.go
@@ -62,6 +62,17 @@ func (s *SchemaElement) Reset() {
 	// allocation if the input holds the same member type (zeroing its
 	// contents first), and clears the union if the field is absent from
 	// the input. Either way no stale state survives a decode.
+	//
+	// The Geometry and Geography members are the exception: their CRS
+	// strings alias the decode input buffer, which the owner of this value
+	// may overwrite before the next decode. Clear their contents so no
+	// retained member holds a reference into a buffer with unrelated data.
+	switch m := s.LogicalType.Value.(type) {
+	case *GeometryType:
+		*m = GeometryType{}
+	case *GeographyType:
+		*m = GeographyType{}
+	}
 }
 
 // Reset clears c in place, retaining allocated capacity for reuse in

--- a/format/reset.go
+++ b/format/reset.go
@@ -15,7 +15,10 @@ package format
 // Byte slice and string fields decoded from footers alias the input buffer
 // (they are replaced, never reused, by the decoder), so Reset sets them to
 // nil or empty instead of truncating, releasing references to the previous
-// input buffer.
+// input buffer. This includes the contents of retained union members whose
+// fields alias the buffer: the member allocation is kept for the next
+// decode to reuse, but its contents are zeroed so no retained member holds
+// a reference into a buffer with unrelated data.
 
 // Reset clears m in place, retaining allocated capacity for reuse in
 // subsequent thrift decodes.
@@ -40,10 +43,7 @@ func (m *FileMetaData) Reset() {
 	m.KeyValueMetadata = m.KeyValueMetadata[:0]
 	m.CreatedBy = ""
 	m.ColumnOrders = m.ColumnOrders[:0]
-	// EncryptionAlgorithm is a union; its member allocation is retained
-	// for reuse by the next decode (see SchemaElement.Reset). The members'
-	// byte slices alias the decode input buffer, so their contents are
-	// cleared like the CRS strings of SchemaElement.
+	// Retained union member; scrub buffer-aliasing contents (see file header).
 	switch v := m.EncryptionAlgorithm.Value.(type) {
 	case *AesGcmV1:
 		*v = AesGcmV1{}
@@ -65,16 +65,8 @@ func (s *SchemaElement) Reset() {
 	s.Scale.Reset()
 	s.Precision.Reset()
 	s.FieldID = 0
-	// The LogicalType union member is deliberately retained: when the
-	// element is decoded again, the thrift decoder reuses the member
-	// allocation if the input holds the same member type (zeroing its
-	// contents first), and clears the union if the field is absent from
-	// the input. Either way no stale state survives a decode.
-	//
-	// The Geometry and Geography members are the exception: their CRS
-	// strings alias the decode input buffer, which the owner of this value
-	// may overwrite before the next decode. Clear their contents so no
-	// retained member holds a reference into a buffer with unrelated data.
+	// Retained union member; scrub the buffer-aliasing CRS strings of the
+	// Geometry and Geography members (see file header).
 	switch m := s.LogicalType.Value.(type) {
 	case *GeometryType:
 		*m = GeometryType{}
@@ -93,11 +85,7 @@ func (c *ColumnChunk) Reset() {
 	c.OffsetIndexLength = 0
 	c.ColumnIndexOffset = 0
 	c.ColumnIndexLength = 0
-	// CryptoMetadata is a union; its member allocation is retained for
-	// reuse by the next decode (see SchemaElement.Reset). The column-key
-	// member's path strings and key metadata alias the decode input
-	// buffer, so its contents are cleared like the CRS strings of
-	// SchemaElement.
+	// Retained union member; scrub buffer-aliasing contents (see file header).
 	if v, ok := c.CryptoMetadata.Value.(*EncryptionWithColumnKey); ok {
 		*v = EncryptionWithColumnKey{}
 	}
@@ -120,38 +108,17 @@ func (c *ColumnMetaData) Reset() {
 	c.DataPageOffset = 0
 	c.IndexPageOffset = 0
 	c.DictionaryPageOffset = 0
-	c.Statistics.Reset()
+	// Statistics byte slices alias the input buffer (replaced, never
+	// appended to), so zero the whole struct instead of truncating.
+	c.Statistics = Statistics{}
 	clear(c.EncodingStats)
 	c.EncodingStats = c.EncodingStats[:0]
 	c.BloomFilterOffset = 0
 	c.BloomFilterLength = 0
-	c.SizeStatistics.Reset()
-	c.GeospatialStatistics.Reset()
-}
-
-// Reset clears s in place. The byte slice fields are set to nil rather than
-// truncated because decoded values alias the input buffer and are always
-// replaced, never appended to.
-func (s *Statistics) Reset() {
-	s.Max = nil
-	s.Min = nil
-	s.NullCount = 0
-	s.DistinctCount = 0
-	s.MaxValue = nil
-	s.MinValue = nil
-}
-
-// Reset clears s in place, retaining allocated capacity for reuse in
-// subsequent thrift decodes.
-func (s *SizeStatistics) Reset() {
-	s.UnencodedByteArrayDataBytes = 0
-	s.RepetitionLevelHistogram = s.RepetitionLevelHistogram[:0]
-	s.DefinitionLevelHistogram = s.DefinitionLevelHistogram[:0]
-}
-
-// Reset clears g in place, retaining allocated capacity for reuse in
-// subsequent thrift decodes.
-func (g *GeospatialStatistics) Reset() {
-	g.BBox = BoundingBox{}
-	g.GeoSpatialTypes = g.GeoSpatialTypes[:0]
+	// The histograms and geospatial types retain capacity.
+	c.SizeStatistics.UnencodedByteArrayDataBytes = 0
+	c.SizeStatistics.RepetitionLevelHistogram = c.SizeStatistics.RepetitionLevelHistogram[:0]
+	c.SizeStatistics.DefinitionLevelHistogram = c.SizeStatistics.DefinitionLevelHistogram[:0]
+	c.GeospatialStatistics.BBox = BoundingBox{}
+	c.GeospatialStatistics.GeoSpatialTypes = c.GeospatialStatistics.GeoSpatialTypes[:0]
 }

--- a/format/reset.go
+++ b/format/reset.go
@@ -41,7 +41,15 @@ func (m *FileMetaData) Reset() {
 	m.CreatedBy = ""
 	m.ColumnOrders = m.ColumnOrders[:0]
 	// EncryptionAlgorithm is a union; its member allocation is retained
-	// for reuse by the next decode (see SchemaElement.Reset).
+	// for reuse by the next decode (see SchemaElement.Reset). The members'
+	// byte slices alias the decode input buffer, so their contents are
+	// cleared like the CRS strings of SchemaElement.
+	switch v := m.EncryptionAlgorithm.Value.(type) {
+	case *AesGcmV1:
+		*v = AesGcmV1{}
+	case *AesGcmCtrV1:
+		*v = AesGcmCtrV1{}
+	}
 	m.FooterSigningKeyMetadata = nil
 }
 
@@ -86,7 +94,13 @@ func (c *ColumnChunk) Reset() {
 	c.ColumnIndexOffset = 0
 	c.ColumnIndexLength = 0
 	// CryptoMetadata is a union; its member allocation is retained for
-	// reuse by the next decode (see SchemaElement.Reset).
+	// reuse by the next decode (see SchemaElement.Reset). The column-key
+	// member's path strings and key metadata alias the decode input
+	// buffer, so its contents are cleared like the CRS strings of
+	// SchemaElement.
+	if v, ok := c.CryptoMetadata.Value.(*EncryptionWithColumnKey); ok {
+		*v = EncryptionWithColumnKey{}
+	}
 	c.EncryptedColumnMetadata = nil
 }
 

--- a/reader.go
+++ b/reader.go
@@ -659,8 +659,14 @@ func makeLeafColumns(root *Column) []*Column {
 func makeFileRowGroups(file *File, columns []*Column) ([]FileRowGroup, error) {
 	rowGroups := file.metadata.RowGroups
 
-	if err := validateRowGroupOrdinals(rowGroups); err != nil {
-		return nil, err
+	// Row group ordinals are normalized when the footer is constructed (see
+	// newFooter) and by the writer, so this path only validates them: it
+	// must never write to metadata that may be shared with other files
+	// through a common Footer.
+	for i := range rowGroups {
+		if int(rowGroups[i].Ordinal) != i {
+			return nil, fmt.Errorf("row group ordinal %d at index %d does not match its position", rowGroups[i].Ordinal, i)
+		}
 	}
 	if err := validateRowCounts(file.metadata.NumRows, rowGroups); err != nil {
 		return nil, err

--- a/reader.go
+++ b/reader.go
@@ -689,7 +689,7 @@ func makeRowGroups(fileRowGroups []FileRowGroup) []RowGroup {
 	return rowGroups
 }
 
-func validateRowGroupOrdinals(rowGroups []format.RowGroup) error {
+func normalizeRowGroupOrdinals(rowGroups []format.RowGroup) error {
 	allZero := true
 	for _, rg := range rowGroups {
 		if rg.Ordinal != 0 {

--- a/writer.go
+++ b/writer.go
@@ -726,7 +726,7 @@ func (w *writerFileView) Root() *Column {
 
 func (w *writerFileView) RowGroups() []RowGroup {
 	columns := makeLeafColumns(w.Root())
-	file := &File{metadata: w.writer.fileMetaData, schema: w.schema}
+	file := &File{metadata: &w.writer.fileMetaData, schema: w.schema}
 	fileRowGroups, err := makeFileRowGroups(file, columns)
 	if err != nil {
 		return nil


### PR DESCRIPTION
## Summary

**Stacked on #556** — the first 3 commits are that PR; review the last 4 here.

This adds a public API for decoding a parquet footer once and sharing it across many opens, for programs that open the same files repeatedly (query engines, object-store readers) and want to cache footers without re-paying the decode or growing GC load:

- **`parquet.Footer`**: an immutable, validated, decoded footer. Safe for concurrent use: a single `Footer` can back any number of open files across goroutines with no synchronization. All normalization `OpenFile` needs (key/value metadata sort, row-group ordinal back-fill, encrypted column metadata decryption, schema validation) happens at construction, so opening a file from a footer never writes to it.
- **`ReadFooter(r, size, options...)`**: reads and decodes just the footer (honoring `OptimisticRead`, `SkipMagicBytes`, `WithDecryption`). It also accepts a bare footer section — the last `footerSize+8` bytes of a file, as cached by programs that store raw footer bytes — recognized when the input is exactly `footerSize+8` bytes (a complete file is always larger); in that case the header magic check is skipped and no file size is recorded.
- **`WithFooter(footer)`** file option: `OpenFile` skips all footer I/O and decoding, and inherits decryption state from the footer. Combined with `SkipPageIndex` and `SkipBloomFilters`, the open performs **zero reads**.
- **`File.Footer()`**: recovers the footer `OpenFile` decoded, so the open-then-cache workflow doesn't pay a second read+decode.

Misuse is designed to fail loudly: zero-value footers are rejected, `ReadFooter` records the file size and `OpenFile` refuses a footer whose size disagrees, encrypted footers require the `DecryptionConfig` at construction, and all sharing/read-only contracts are documented.

Internally, `OpenFile` is restructured around the same code path (`File.metadata` becomes a pointer to the footer's metadata), and footer normalization moved from open time to construction time; behavior of existing open paths is unchanged (verified by equivalence tests over all testdata files, including encrypted and signed-footer files).

## Benchmarks

In-memory readers, synthetic files (I/O excluded; the relative cost of footer decoding is what's being measured). `BenchmarkOpenFooter`, rowGroups=32 / columns=200:

| open path | time/op | allocs/op |
|---|---|---|
| OpenFile (default) | ~6.2 ms | ~59k |
| OpenFile skip page index + blooms | ~2.4 ms | ~33k |
| OpenFile + WithFooter | ~3.9 ms | ~26k |
| OpenFile + WithFooter + skips | **~0.14 ms** | **~0.6k** |

## Testing

- Open-equivalence over all testdata files: schema, re-encoded metadata, key/value lookup, column/offset indexes, bloom filters, and all rows compared between a regular open and a `WithFooter` open (plus sequential double-opens from one footer).
- Bare-footer equivalence over all testdata files: `ReadFooter` over the cached footer bytes compared against `ReadFooter` over the file.
- Concurrent shared-footer test (16 goroutines opening and reading from one footer) run under `-race`, with a before/after metadata snapshot proving the open path never mutates the footer.
- Encrypted footers ("PARE"), signed plaintext footers, column keys, and AAD prefixes through `ReadFooter` (over files and bare footer bytes), checked for full equivalence against `OpenFile` with `WithDecryption`.
- Zero-I/O contract verified with a counting reader (including a control asserting the skip options are load-bearing), bare-footer input-ownership and validation tests, wrong-size and zero-value footer rejection.

Made with [Cursor](https://cursor.com)
