### PR TITLE
perf(writer): enable L3 merge path for writers with bloom filters

### DIFF
--- a/writer_copy.go
+++ b/writer_copy.go
@@ -67,12 +67,14 @@ type orderedRowGroupSegments interface {
 }
 
 // splittableCopyableSegments returns the writable segments of rowGroup when it
-// is a segmented row group and at least one segment can be copied verbatim. The
-// writer then emits one output row group per segment so the copyable ones take
-// the fast path. Splitting is gated on copy-eligibility so that pure re-encode
-// merges keep their existing output structure.
+// is a segmented row group and at least one segment can be written through an
+// optimized segment path. The writer then emits packed output row groups so
+// copyable single segments can take the L0 fast path and multi-segment batches
+// can take the L3 column-oriented packing path. Splitting is gated on
+// optimization eligibility so that pure re-encode merges keep their existing
+// output structure.
 func (w *Writer) splittableCopyableSegments(rowGroup RowGroup) ([]RowGroup, bool) {
-	if disableWriteCopy {
+	if disableWriteCopy && disableWriteReencode {
 		return nil, false
 	}
 	v, ok := rowGroup.(orderedRowGroupSegments)
@@ -85,6 +87,9 @@ func (w *Writer) splittableCopyableSegments(rowGroup RowGroup) ([]RowGroup, bool
 	}
 	for _, seg := range segments {
 		if _, ok := w.copyableColumnChunks(seg); ok {
+			return segments, true
+		}
+		if _, ok := w.reencodableRowGroup(seg); ok {
 			return segments, true
 		}
 	}

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -27,7 +27,7 @@ func makeCopyTestRows(n int) []copyTestRow {
 	return rows
 }
 
-func writeCopyTestFile(t *testing.T, rows []copyTestRow, opts ...WriterOption) *File {
+func writeCopyTestFile(t testing.TB, rows []copyTestRow, opts ...WriterOption) *File {
 	t.Helper()
 	var buf bytes.Buffer
 	w := NewGenericWriter[copyTestRow](&buf, opts...)
@@ -572,7 +572,7 @@ func BenchmarkWriteRowGroupReencodeWide(b *testing.B) {
 // buildIDFile writes a single-row-group file whose rows are sorted by id. The
 // caller must pass ids in ascending order. Other fields are derived from id so
 // that the fully-sorted sequence of rows is uniquely determined by the id set.
-func buildIDFile(t *testing.T, ids []int64) *File {
+func buildIDFile(t testing.TB, ids []int64) *File {
 	t.Helper()
 	rows := make([]copyTestRow, len(ids))
 	for i, id := range ids {
@@ -944,4 +944,78 @@ func TestWriteRowGroupMergePacksWithBloomFilters(t *testing.T) {
 			t.Fatalf("row %d has id %d, want %d", i, r.ID, i)
 		}
 	}
+}
+
+// BenchmarkWriteRowGroupMergePackPaths compares the row-oriented packed merge
+// path against the optimized column-oriented packed merge path for the same
+// scenario as TestWriteRowGroupMergePacksWithBloomFilters:
+//
+//   - many small sorted, non-overlapping file-backed row groups
+//   - destination packs them into larger row groups
+//   - destination rebuilds a bloom filter for "id"
+//
+// "rowpath" disables both write fast paths, so WriteRowGroup(merged) falls back
+// to reading merged.Rows() and writing rows. "columnpack" leaves the fast paths
+// enabled, so ordered segments are packed column-by-column.
+func BenchmarkWriteRowGroupMergePackPaths(b *testing.B) {
+	const (
+		numFiles = 20
+		perFile  = 1_000
+		maxRows  = 5_000
+	)
+
+	files := make([]*File, numFiles)
+	for i := range files {
+		files[i] = buildIDFile(b, idSeq(int64(i*perFile), int64(i*perFile+perFile-1)))
+	}
+
+	rowGroups := make([]RowGroup, numFiles)
+	for i, f := range files {
+		rowGroups[i] = f.RowGroups()[0]
+	}
+
+	merged, err := MergeRowGroups(
+		rowGroups,
+		SortingRowGroupConfig(SortingColumns(Ascending("id"))),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	writerOptions := []WriterOption{
+		SortingWriterConfig(SortingColumns(Ascending("id"))),
+		MaxRowsPerRowGroup(maxRows),
+		BloomFilters(SplitBlockFilter(10, "id")),
+	}
+
+	run := func(b *testing.B, fastPaths bool) {
+		defer func(copyDisabled, reencodeDisabled bool) {
+			disableWriteCopy = copyDisabled
+			disableWriteReencode = reencodeDisabled
+		}(disableWriteCopy, disableWriteReencode)
+
+		disableWriteCopy = !fastPaths
+		disableWriteReencode = !fastPaths
+
+		b.ReportAllocs()
+		b.SetBytes(int64(numFiles * perFile))
+		b.ResetTimer()
+
+		for b.Loop() {
+			w := NewGenericWriter[copyTestRow](io.Discard, writerOptions...)
+			if _, err := w.WriteRowGroup(merged); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.Run("rowpath", func(b *testing.B) {
+		run(b, false)
+	})
+	b.Run("columnpack", func(b *testing.B) {
+		run(b, true)
+	})
 }

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -851,3 +851,97 @@ func TestWriteRowGroupMergePacksToMaxRows(t *testing.T) {
 		}
 	}
 }
+
+// TestWriteRowGroupMergePacksWithBloomFilters verifies that a merge of many
+// small, sorted, non-overlapping row groups can still enter the segment-packing
+// path when L0 copy is disabled by destination bloom filters. The packed output
+// should consolidate several input row groups into fewer larger output row
+// groups, rebuild bloom filters, and use the L3 column-oriented re-encode path
+// instead of falling back to the row-oriented merged reader path.
+func TestWriteRowGroupMergePacksWithBloomFilters(t *testing.T) {
+	const numFiles, perFile = 20, 100
+
+	files := make([]*File, numFiles)
+	for i := range files {
+		files[i] = buildIDFile(t, idSeq(int64(i*perFile), int64(i*perFile+perFile-1)))
+	}
+
+	rgs := make([]RowGroup, numFiles)
+	for i, f := range files {
+		rgs[i] = f.RowGroups()[0]
+	}
+
+	merged, err := MergeRowGroups(
+		rgs,
+		SortingRowGroupConfig(SortingColumns(Ascending("id"))),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	beforeCopy := copyPathCounter.Load()
+	beforeReencode := reencodePathCounter.Load()
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](
+		&dst,
+		SortingWriterConfig(SortingColumns(Ascending("id"))),
+		MaxRowsPerRowGroup(500),
+		BloomFilters(SplitBlockFilter(10, "id")),
+	)
+	if _, err := w.WriteRowGroup(merged); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if copied := copyPathCounter.Load() - beforeCopy; copied != 0 {
+		t.Fatalf("expected bloom filters to disable L0 copy, but copied %d column chunks", copied)
+	}
+	if reencoded := reencodePathCounter.Load() - beforeReencode; reencoded == 0 {
+		t.Fatal("expected packed merge with bloom filters to use the L3 re-encode path")
+	}
+
+	out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(out.RowGroups()); got != 4 {
+		t.Fatalf("output row groups = %d, want 4 packed groups of 500 rows", got)
+	}
+	if got := out.NumRows(); got != numFiles*perFile {
+		t.Fatalf("output row count = %d, want %d", got, numFiles*perFile)
+	}
+
+	for i, rg := range out.RowGroups() {
+		if rg.NumRows() > 500 {
+			t.Fatalf("row group %d has %d rows, exceeds MaxRowsPerRowGroup=500", i, rg.NumRows())
+		}
+		filter := rg.ColumnChunks()[0].BloomFilter()
+		if filter == nil {
+			t.Fatalf("row group %d id column has no bloom filter", i)
+		}
+
+		rowBase := int64(i * 500)
+		for _, id := range []int64{rowBase, rowBase + rg.NumRows()/2, rowBase + rg.NumRows() - 1} {
+			ok, err := filter.Check(ValueOf(id))
+			if err != nil {
+				t.Fatalf("checking bloom filter for id=%d: %v", id, err)
+			}
+			if !ok {
+				t.Fatalf("bloom filter for row group %d returned false for present id=%d", i, id)
+			}
+		}
+	}
+
+	got := readCopyTestRows(t, dst.Bytes(), numFiles*perFile)
+	if len(got) != numFiles*perFile {
+		t.Fatalf("read %d rows, want %d", len(got), numFiles*perFile)
+	}
+	for i, r := range got {
+		if r.ID != int64(i) {
+			t.Fatalf("row %d has id %d, want %d", i, r.ID, i)
+		}
+	}
+}


### PR DESCRIPTION
Continuation of https://github.com/parquet-go/parquet-go/pull/535.

## Summary
Optimises non-overlapping merge writes so L3 column-oriented packing can be used even when L0 copy is disabled, e.g. when rebuilding bloom filters. This allows many small sorted row groups to be packed into larger output row groups without falling back to the row-oriented merge path.

Also adds coverage and benchmarking for the packed merge path, including bloom-filter rebuilds and a row-path vs column-pack comparison. See benchmark output below.

## Testing
- Added merge packing test with bloom filters
- Added benchmark for row-oriented vs column-oriented merge packing


```
goos: darwin
goarch: arm64
pkg: github.com/parquet-go/parquet-go
cpu: Apple M4 Pro
BenchmarkWriteRowGroupMergePackPaths
BenchmarkWriteRowGroupMergePackPaths/rowpath
BenchmarkWriteRowGroupMergePackPaths/rowpath-14         	     798	   1402731 ns/op	  14.26 MB/s	  797643 B/op	    1834 allocs/op
BenchmarkWriteRowGroupMergePackPaths/columnpack
BenchmarkWriteRowGroupMergePackPaths/columnpack-14      	    1216	   1027480 ns/op	  19.47 MB/s	 1989330 B/op	    1157 allocs/op
```