### PR TITLE
feat: Recurse the `list` tag through nested slices implicitly

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1080,7 +1080,15 @@ func makeNodeOf(path []string, t reflect.Type, name string, tags parquetTags, ta
 					if t == reflect.TypeFor[json.RawMessage]() {
 						throwInvalidTag(t, name, option)
 					}
-					element := makeNodeOf(append(path, "list", "element"), t.Elem(), t.Name(), tags.getListElementNodeTags(), tagReplacements)
+					elementTags := tags.getListElementNodeTags()
+					if elem := t.Elem(); elem.Kind() == reflect.Slice && elem.Elem().Kind() != reflect.Uint8 && !strings.Contains(elementTags.parquet, "list") {
+						// A nested slice under a list is itself a list: recurse the
+						// list option implicitly so any nesting depth is expressible
+						// with a single `list` tag on the field. An explicit
+						// parquet-element tag still takes precedence.
+						elementTags.parquet += ",list"
+					}
+					element := makeNodeOf(append(path, "list", "element"), t.Elem(), t.Name(), elementTags, tagReplacements)
 					setNode(element)
 					setList()
 				default:

--- a/schema_test.go
+++ b/schema_test.go
@@ -352,6 +352,38 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+		// Test that nested slices under a `list` tag become LIST at every
+		// level implicitly, with no explicit parquet-element tag needed.
+		{
+			value: new(struct {
+				Matrix [][]int32   `parquet:"matrix,list"`
+				Cube   [][][]int64 `parquet:"cube,list"`
+			}),
+			print: `message {
+	required group matrix (LIST) {
+		repeated group list {
+			required group element (LIST) {
+				repeated group list {
+					required int32 element (INT(32,true));
+				}
+			}
+		}
+	}
+	required group cube (LIST) {
+		repeated group list {
+			required group element (LIST) {
+				repeated group list {
+					required group element (LIST) {
+						repeated group list {
+							required int64 element (INT(64,true));
+						}
+					}
+				}
+			}
+		}
+	}
+}`,
+		},
 		{
 			value: new(struct {
 				A [16]byte `parquet:",uuid"`
@@ -537,6 +569,53 @@ func TestSchemaOf(t *testing.T) {
 				t.Errorf("\nexpected:\n\n%s\n\nfound:\n\n%s\n", test.print, s)
 			}
 		})
+	}
+}
+
+// Nested slices tagged `list` round-trip exactly at every depth, including
+// the empty-inner shapes that distinguish LIST from bare repetition.
+func TestNestedSliceListRoundTrip(t *testing.T) {
+	type Row struct {
+		Matrix [][]int32   `parquet:"matrix,list"`
+		Cube   [][][]int64 `parquet:"cube,list"`
+	}
+	rows := []Row{
+		{
+			Matrix: [][]int32{{1, 2}, {}, {3}},
+			Cube:   [][][]int64{{{1}, {2, 3}}, {{4, 5, 6}}},
+		},
+		{
+			Matrix: [][]int32{},
+			Cube:   [][][]int64{{}},
+		},
+		{
+			Matrix: [][]int32{{}},
+			Cube:   [][][]int64{{{}}},
+		},
+	}
+
+	buf := new(bytes.Buffer)
+	w := parquet.NewGenericWriter[Row](buf)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	r := parquet.NewGenericReader[Row](bytes.NewReader(buf.Bytes()))
+	got := make([]Row, len(rows))
+	n, err := r.Read(got)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read: %v", err)
+	}
+	if n != len(rows) {
+		t.Fatalf("read %d rows, want %d", n, len(rows))
+	}
+	for i := range rows {
+		if !reflect.DeepEqual(rows[i], got[i]) {
+			t.Errorf("row %d mismatch:\nwant %+v\ngot  %+v", i, rows[i], got[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

The struct-tag grammar tops out at one level of `LIST` nesting.
`list` marks the field, `parquet-element` configures its elements one level down, and that’s where
it ends. `parquet-element-element` doesn’t exist.

- `Cube [][][]int64` blows up.
  Every tag combination either panics `SchemaOf` with
  `unhandled nested slice on parquet schema without list tag`, or, if you write
  `parquet:"cube,list" parquet-element:",list"`, the innermost level falls back to bare repetition
  and reads come back corrupt: `reflect.Set: value of type int64 is not assignable to type []int64`.
- `Matrix [][]int64` panics too, even with a plain `parquet:"matrix,list"`. The untagged inner slice
  runs into the same wall.

Building the node by hand prints and encodes perfectly fine:
`parquet.List(parquet.List(parquet.List(parquet.Int(64))))`. Thus this reveals there’s no limitation
of the schema model as it is entirely in the struct-tag reflection layer.

## Change

In the `list` case of `makeNodeOf`: if a list’s element is itself a slice (not `[]byte`) and its
tags don’t set an explicit `list` option, carry the `list` option down implicitly.
That lets one `parquet:"name,list"` cover `LIST` at every depth.
An explicit `parquet-element` tag still wins where you write one.

About six lines in `schema.go`. No API change.

## Backward compatibility

No changes require any backwards compatibility, the net result of all changes is that what used to
panic, now doesn’t, and what used to break or otherwise fail to cleanly round-trip now does.
Explicitly-tagged elements, i.e. any form of `parquet-element:"..."`, are unaffected, and same thing
for byte slices and `json.RawMessage`.

## Tests

- `TestSchemaOf` picks up a table case covering `[][]int32` and `[][][]int64`: a single `list` tag
  derives fully-nested `LIST` groups.
- `TestNestedSliceListRoundTrip` does an exact write/read round trip at both depths through
  `GenericWriter`/`GenericReader`, including the empty-inner shapes (`[[]]`, `[[[]]]`) that tell
  `LIST` apart from bare repetition.
- Full suite is green (`go test .`).
