### PR TITLE
perf: extend WriteRowGroup fast paths (SortingWriter, bloom copy, buffers) + fix dedup/conversion bypass

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -144,6 +144,10 @@ func (buf *GenericBuffer[T]) Rows() Rows {
 	return buf.base.Rows()
 }
 
+// chunkTransparentRowGroup marks GenericBuffer as safe for the chunk-level
+// write fast paths, for the same reasons as Buffer.
+func (buf *GenericBuffer[T]) chunkTransparentRowGroup() {}
+
 func (buf *GenericBuffer[T]) Schema() *Schema {
 	return buf.base.Schema()
 }
@@ -436,6 +440,11 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 // The buffer and the returned reader share memory. Mutating the buffer
 // concurrently to reading rows may result in non-deterministic behavior.
 func (buf *Buffer) Rows() Rows { return NewRowGroupRowReader(buf) }
+
+// chunkTransparentRowGroup marks Buffer as safe for the chunk-level write fast
+// paths: its Rows() reads the column buffers in order, and sorting reorders all
+// columns together, so column-wise reads preserve row order.
+func (buf *Buffer) chunkTransparentRowGroup() {}
 
 // bufferWriter is an adapter for Buffer which implements both RowWriter and
 // PageWriter to enable optimizations in CopyRows for types that support writing

--- a/file.go
+++ b/file.go
@@ -764,6 +764,11 @@ func (g *FileRowGroup) Rows() Rows {
 	return NewRowGroupRowReader(rowGroup)
 }
 
+// chunkTransparentRowGroup marks FileRowGroup as safe for the chunk-level write
+// fast paths: its Rows() reads the file column chunks in order with no
+// additional semantics.
+func (g *FileRowGroup) chunkTransparentRowGroup() {}
+
 type fileSortingColumn struct {
 	column     *Column
 	descending bool

--- a/sorting.go
+++ b/sorting.go
@@ -110,15 +110,12 @@ func (w *SortingWriter[T]) Close() error {
 		return err
 	}
 
-	rows := m.Rows()
-	defer rows.Close()
-
-	reader := RowReader(rows)
-	if w.sorting.DropDuplicatedRows {
-		reader = DedupeRowReader(rows, w.rowbuf.compare)
-	}
-
-	if _, err := CopyRows(w.output, reader); err != nil {
+	// Writing the merged row group (rather than copying its rows) lets the
+	// writer use its chunk-level fast paths when the sorted chunks do not
+	// overlap: verbatim column chunk copies and column-oriented packing toward
+	// MaxRowsPerRowGroup. Overlapping chunks fall back to the row-oriented heap
+	// merge, and the merge itself applies DropDuplicatedRows when configured.
+	if _, err := w.output.WriteRowGroup(m); err != nil {
 		return err
 	}
 

--- a/writer.go
+++ b/writer.go
@@ -1484,6 +1484,12 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 		if err := c.Flush(); err != nil {
 			return 0, err
 		}
+		// Columns copied verbatim carry the source's bloom filter bytes (when
+		// configured); building a filter from the writer's (empty) buffers would
+		// produce a bogus one.
+		if c.copied != nil {
+			continue
+		}
 		if err := c.flushFilterPages(); err != nil {
 			return 0, err
 		}
@@ -1562,6 +1568,41 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 	}
 
 	for i, c := range rg.columns {
+		// Columns copied verbatim carry the source's bloom filter as a raw byte
+		// range (header + bitset); stream it through unchanged.
+		if c.copied != nil && c.copied.bloomLength > 0 {
+			cc := c.copied
+			bloom := io.NewSectionReader(cc.reader, cc.bloomOffset, cc.bloomLength)
+
+			if rg.config.DeferredBloomFiltersBuffers != nil {
+				buf := rg.config.DeferredBloomFiltersBuffers.GetBuffer()
+				reset := func() { rg.config.DeferredBloomFiltersBuffers.PutBuffer(buf) }
+				if _, err := io.Copy(buf, bloom); err != nil {
+					reset()
+					return 0, fmt.Errorf("copying bloom filter of row group column %d: %w", i, err)
+				}
+				if _, err := buf.Seek(0, io.SeekStart); err != nil {
+					reset()
+					return 0, err
+				}
+				w.deferredBloomFilterSize += cc.bloomLength
+				w.deferredBloomFilters = append(w.deferredBloomFilters, deferredBloomFilter{
+					rowGroup: rowGroupIndex,
+					column:   i,
+					buf:      buf,
+					reset:    reset,
+				})
+				continue
+			}
+
+			c.columnChunk.MetaData.BloomFilterOffset = w.writer.offset
+			if _, err := w.writer.ReadFrom(bloom); err != nil {
+				return 0, fmt.Errorf("copying bloom filter of row group column %d: %w", i, err)
+			}
+			c.columnChunk.MetaData.BloomFilterLength = int32(cc.bloomLength)
+			continue
+		}
+
 		if len(c.filter) == 0 {
 			continue
 		}

--- a/writer_copy.go
+++ b/writer_copy.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sync/atomic"
 
+	"github.com/parquet-go/parquet-go/encoding/thrift"
 	"github.com/parquet-go/parquet-go/format"
 )
 
@@ -44,6 +45,8 @@ type copiedChunk struct {
 	dictLength    int64       // length of the dictionary page, 0 if none
 	dataOffset    int64       // byte offset of the first data page in the source
 	dataLength    int64       // length of all data pages
+	bloomOffset   int64       // byte offset of the bloom filter in the source
+	bloomLength   int64       // length of the bloom filter (header + bitset), 0 if not copied
 	columnIndex   format.ColumnIndex
 	sizeStats     format.SizeStatistics
 	statistics    format.Statistics
@@ -208,9 +211,10 @@ func columnChunkIsCopyable(dst *ColumnWriter, src *FileColumnChunk) bool {
 	if meta.Codec != dst.compression.CompressionCodec() {
 		return false
 	}
-	// A writer-requested bloom filter would have to be recomputed from decoded
-	// values, which a verbatim copy cannot do. Demote.
-	if dst.columnFilter != nil {
+	// A writer-requested bloom filter can only be satisfied by a verbatim copy
+	// when the source chunk carries a filter equivalent to the one the writer
+	// would build; otherwise the filter must be recomputed from decoded values.
+	if dst.columnFilter != nil && !bloomFilterIsCopyable(dst, src) {
 		return false
 	}
 	// We copy statistics and the page index from the source; require both to be
@@ -262,6 +266,46 @@ func encodingStatsMatch(stats []format.PageEncodingStats, dst *ColumnWriter) boo
 		return false
 	}
 	return true
+}
+
+// bloomFilterIsCopyable reports whether the source chunk carries a bloom filter
+// equivalent to the one the destination column writer is configured to build,
+// so that copying its bytes verbatim is indistinguishable from recomputing it:
+//
+//   - the source records the filter location and length (older files omit the
+//     length, in which case the byte range is unknown);
+//   - both source and destination use the uncompressed filter representation
+//     (this library's default; compressed filters would require comparing
+//     post-compression content);
+//   - the source header describes the same algorithm and hash the writer would
+//     use (split-block, xxhash — the only ones supported); and
+//   - the source bitset has exactly the size the destination filter would
+//     allocate for this chunk's value count, i.e. the same bits-per-value.
+func bloomFilterIsCopyable(dst *ColumnWriter, src *FileColumnChunk) bool {
+	meta := &src.chunk.MetaData
+	if meta.BloomFilterOffset == 0 || meta.BloomFilterLength <= 0 {
+		return false
+	}
+	if dst.bloomFilterCompression != nil && dst.bloomFilterCompression.CompressionCodec() != format.Uncompressed {
+		return false
+	}
+
+	section := io.NewSectionReader(src.file.reader, meta.BloomFilterOffset, int64(meta.BloomFilterLength))
+	rbuf, rbufpool := getBufioReader(section, 1024)
+	defer putBufioReader(rbuf, rbufpool)
+
+	var header format.BloomFilterHeader
+	compact := thrift.CompactProtocol{}
+	if err := thrift.NewDecoder(compact.NewReader(rbuf)).Decode(&header); err != nil {
+		return false
+	}
+	if !isSplitBlockAlgorithm(&header) || !isXxHash(&header) {
+		return false
+	}
+	if _, ok := header.Compression.Value.(*format.BloomFilterUncompressed); !ok {
+		return false
+	}
+	return int(header.NumBytes) == dst.columnFilter.Size(meta.NumValues)
 }
 
 // loadCopiedChunk prepares the destination ColumnWriter to emit a source column
@@ -321,6 +365,14 @@ func (c *ColumnWriter) loadCopiedChunk(src *FileColumnChunk) error {
 		numRows:               src.rowGroup.NumRows,
 		totalUncompressedSize: meta.TotalUncompressedSize,
 		totalCompressedSize:   meta.TotalCompressedSize,
+	}
+
+	// When the destination column is configured with a bloom filter, the copy
+	// predicate has already verified that the source carries an equivalent one;
+	// record its byte range so it is copied verbatim during assembly.
+	if c.columnFilter != nil {
+		cc.bloomOffset = meta.BloomFilterOffset
+		cc.bloomLength = int64(meta.BloomFilterLength)
 	}
 
 	c.copied = cc

--- a/writer_copy.go
+++ b/writer_copy.go
@@ -116,6 +116,11 @@ func (w *Writer) copyableColumnChunks(rowGroup RowGroup) ([]*FileColumnChunk, bo
 	if rowGroup.NumRows() > w.writer.currentRowGroup.maxRows {
 		return nil, false
 	}
+	// Row groups whose Rows() implements semantics beyond reading the column
+	// chunks in order cannot be handled at the chunk level.
+	if !chunkTransparentRowGroup(rowGroup) {
+		return nil, false
+	}
 
 	dst := w.writer.currentRowGroup.columns
 	columns := rowGroup.ColumnChunks()
@@ -125,13 +130,7 @@ func (w *Writer) copyableColumnChunks(rowGroup RowGroup) ([]*FileColumnChunk, bo
 
 	srcs := make([]*FileColumnChunk, len(columns))
 	for i, col := range columns {
-		// Unwrap to the underlying file-backed chunk. This handles both directly
-		// file-backed row groups (plain file rewrites) and ConvertRowGroup's
-		// positional remap wrapper (column reordering produced by MergeNodes,
-		// e.g. a single source row group passed through MergeRowGroups). A
-		// genuine type conversion would be caught and demoted by the type check
-		// in columnChunkIsCopyable.
-		fc, ok := fileColumnChunkOf(col)
+		fc, ok := col.(*FileColumnChunk)
 		if !ok {
 			return nil, false
 		}
@@ -143,19 +142,31 @@ func (w *Writer) copyableColumnChunks(rowGroup RowGroup) ([]*FileColumnChunk, bo
 	return srcs, true
 }
 
-// fileColumnChunkOf unwraps positional-remap wrappers to reach the underlying
-// file-backed column chunk, returning false if the chunk is not (or does not
-// wrap) a *FileColumnChunk.
-func fileColumnChunkOf(col ColumnChunk) (*FileColumnChunk, bool) {
-	for {
-		switch c := col.(type) {
-		case *FileColumnChunk:
-			return c, true
-		case *convertedColumnChunk:
-			col = c.chunk
-		default:
-			return nil, false
-		}
+// chunkTransparentRowGroup reports whether reading rowGroup's column chunks in
+// order is equivalent to reading its Rows(). The fast paths in this file and in
+// writer_reencode.go operate on the column chunks directly, so they must not be
+// applied to row group wrappers whose Rows() adds semantics on top of the
+// chunks:
+//
+//   - dedupRowGroup drops duplicated rows in Rows(); its ColumnChunks() are
+//     promoted unchanged from the wrapped row group, so a chunk-level copy
+//     would silently retain the duplicates.
+//   - convertedRowGroup applies value conversion in Rows() (e.g. numeric or
+//     time unit conversions); its ColumnChunks() expose the unconverted source
+//     chunks, so a chunk-level copy would emit pre-conversion values under the
+//     post-conversion schema. Note that a physical type check is not sufficient
+//     to detect this: conversions such as timestamp millis→micros change values
+//     while preserving the INT64 physical type.
+//
+// Identity conversions never produce these wrappers (ConvertRowGroup returns
+// the row group unwrapped when schemas are equal), so rejecting them does not
+// cost the fast paths anything in the matched-schema case.
+func chunkTransparentRowGroup(rowGroup RowGroup) bool {
+	switch rowGroup.(type) {
+	case *dedupRowGroup, *convertedRowGroup:
+		return false
+	default:
+		return true
 	}
 }
 

--- a/writer_copy.go
+++ b/writer_copy.go
@@ -145,11 +145,24 @@ func (w *Writer) copyableColumnChunks(rowGroup RowGroup) ([]*FileColumnChunk, bo
 	return srcs, true
 }
 
+// chunkTransparentMarker is implemented by row group types for which reading
+// the column chunks in order is equivalent to reading Rows(). The method is
+// unexported on purpose: row group implementations outside this package cannot
+// opt in, so they always take the row-oriented path, which honors whatever
+// semantics their Rows() implements.
+type chunkTransparentMarker interface {
+	chunkTransparentRowGroup()
+}
+
 // chunkTransparentRowGroup reports whether reading rowGroup's column chunks in
 // order is equivalent to reading its Rows(). The fast paths in this file and in
-// writer_reencode.go operate on the column chunks directly, so they must not be
-// applied to row group wrappers whose Rows() adds semantics on top of the
-// chunks:
+// writer_reencode.go operate on the column chunks directly, so they must only
+// be applied to row group types that explicitly opt in via
+// chunkTransparentMarker. Everything else — including application-defined
+// RowGroup implementations — is conservatively assumed to implement semantics
+// in Rows() and handled through the row-oriented path.
+//
+// Known examples of wrappers whose Rows() adds semantics on top of the chunks:
 //
 //   - dedupRowGroup drops duplicated rows in Rows(); its ColumnChunks() are
 //     promoted unchanged from the wrapped row group, so a chunk-level copy
@@ -161,16 +174,12 @@ func (w *Writer) copyableColumnChunks(rowGroup RowGroup) ([]*FileColumnChunk, bo
 //     to detect this: conversions such as timestamp millis→micros change values
 //     while preserving the INT64 physical type.
 //
-// Identity conversions never produce these wrappers (ConvertRowGroup returns
-// the row group unwrapped when schemas are equal), so rejecting them does not
+// Identity conversions never produce wrappers (ConvertRowGroup returns the row
+// group unwrapped when schemas are equal), so requiring the marker does not
 // cost the fast paths anything in the matched-schema case.
 func chunkTransparentRowGroup(rowGroup RowGroup) bool {
-	switch rowGroup.(type) {
-	case *dedupRowGroup, *convertedRowGroup:
-		return false
-	default:
-		return true
-	}
+	_, ok := rowGroup.(chunkTransparentMarker)
+	return ok
 }
 
 // loadCopiedChunks stages every source column chunk into its destination

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -1092,3 +1092,72 @@ func BenchmarkWriteRowGroupMergePackPaths(b *testing.B) {
 		run(b, true)
 	})
 }
+
+// TestSortingWriterUsesFastPaths verifies that SortingWriter's close-time merge
+// goes through WriteRowGroup and benefits from the chunk-level fast paths when
+// the sorted flushes do not overlap (packing them toward MaxRowsPerRowGroup),
+// while producing correctly sorted output.
+func TestSortingWriterUsesFastPaths(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewSortingWriter[copyTestRow](&buf, 1000, SortingWriterConfig(SortingColumns(Ascending("id"))))
+	rows := make([]copyTestRow, 5000)
+	for i := range rows {
+		rows[i] = copyTestRow{ID: int64(i), Name: fmt.Sprintf("n%d", i%13), Val: float64(i)}
+	}
+
+	beforeCopy, beforeL3 := copyPathCounter.Load(), reencodePathCounter.Load()
+	if _, err := sw.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := sw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Already-sorted input produces non-overlapping flush row groups, which the
+	// writer packs column-wise (or copies verbatim) instead of heap-merging rows.
+	if copyPathCounter.Load() == beforeCopy && reencodePathCounter.Load() == beforeL3 {
+		t.Fatal("expected SortingWriter close to use a chunk-level fast path for non-overlapping flushes")
+	}
+
+	got := readCopyTestRows(t, buf.Bytes(), 5000)
+	if len(got) != 5000 {
+		t.Fatalf("read %d rows, want 5000", len(got))
+	}
+	for i := range got {
+		if got[i].ID != int64(i) {
+			t.Fatalf("row %d has id %d, want %d", i, got[i].ID, i)
+		}
+	}
+}
+
+// TestSortingWriterDropDuplicatedRows verifies dedup still applies through the
+// WriteRowGroup-based close path, for both overlapping and non-overlapping
+// flushes.
+func TestSortingWriterDropDuplicatedRows(t *testing.T) {
+	var buf bytes.Buffer
+	sw := NewSortingWriter[copyTestRow](&buf, 4,
+		SortingWriterConfig(SortingColumns(Ascending("id")), DropDuplicatedRows(true)))
+	// Duplicates within a flush and across flushes (flush size 4).
+	ids := []int64{3, 1, 2, 3, 3, 4, 5, 5, 6, 7, 8, 8}
+	rows := make([]copyTestRow, len(ids))
+	for i, id := range ids {
+		rows[i] = copyTestRow{ID: id, Name: "x", Val: float64(id)}
+	}
+	if _, err := sw.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := sw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readCopyTestRows(t, buf.Bytes(), len(ids))
+	want := []int64{1, 2, 3, 4, 5, 6, 7, 8}
+	if len(got) != len(want) {
+		t.Fatalf("read %d rows, want %d deduplicated", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Fatalf("row %d has id %d, want %d", i, got[i].ID, id)
+		}
+	}
+}

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -1252,3 +1252,67 @@ func TestWriteRowGroupCopyBloomFilter(t *testing.T) {
 		checkFilter(t, out)
 	})
 }
+
+// TestWriteRowGroupBufferUsesL3 verifies that writing an in-memory
+// parquet.Buffer through WriteRowGroup takes the L3 column-oriented path
+// (buffers are columnar and order-consistent across columns) and produces the
+// same data as the row-oriented path, including optional columns.
+func TestWriteRowGroupBufferUsesL3(t *testing.T) {
+	type optRow struct {
+		ID   int64    `parquet:"id"`
+		Name string   `parquet:"name,dict"`
+		Opt  *float64 `parquet:"opt,optional"`
+	}
+
+	rows := make([]optRow, 500)
+	for i := range rows {
+		rows[i] = optRow{ID: int64(i), Name: fmt.Sprintf("n%d", i%7)}
+		if i%3 != 0 {
+			v := float64(i) * 0.5
+			rows[i].Opt = &v
+		}
+	}
+
+	write := func(l3 bool) []byte {
+		defer func(prev bool) { disableWriteReencode = prev }(disableWriteReencode)
+		disableWriteReencode = !l3
+
+		buffer := NewGenericBuffer[optRow]()
+		if _, err := buffer.Write(rows); err != nil {
+			t.Fatal(err)
+		}
+		var dst bytes.Buffer
+		w := NewGenericWriter[optRow](&dst)
+		before := reencodePathCounter.Load()
+		if _, err := w.WriteRowGroup(buffer); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if fired := reencodePathCounter.Load() > before; fired != l3 {
+			t.Fatalf("L3 fired=%v, want %v", fired, l3)
+		}
+		return dst.Bytes()
+	}
+
+	l3Out := write(true)
+	rowOut := write(false)
+
+	readAll := func(b []byte) []optRow {
+		r := NewGenericReader[optRow](bytes.NewReader(b))
+		defer r.Close()
+		out := make([]optRow, len(rows)+1)
+		n, _ := r.Read(out)
+		return out[:n]
+	}
+
+	gotL3 := readAll(l3Out)
+	gotRow := readAll(rowOut)
+	if !reflect.DeepEqual(gotL3, rows) {
+		t.Fatal("L3 buffer output differs from source rows")
+	}
+	if !reflect.DeepEqual(gotL3, gotRow) {
+		t.Fatal("L3 buffer output differs from row-path output")
+	}
+}

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -1161,3 +1161,94 @@ func TestSortingWriterDropDuplicatedRows(t *testing.T) {
 		}
 	}
 }
+
+// TestWriteRowGroupCopyBloomFilter verifies that a writer configured with a
+// bloom filter still takes the verbatim copy path when the source chunk carries
+// an equivalent filter, that the copied filter works in the output file, and
+// that mismatched or absent source filters demote to a rebuild.
+func TestWriteRowGroupCopyBloomFilter(t *testing.T) {
+	rows := makeCopyTestRows(1000)
+	filter10 := SplitBlockFilter(10, "id")
+
+	rewrite := func(src *File, opts ...WriterOption) (*File, int64, int64) {
+		beforeCopy, beforeL3 := copyPathCounter.Load(), reencodePathCounter.Load()
+		var dst bytes.Buffer
+		w := NewGenericWriter[copyTestRow](&dst, opts...)
+		for _, rg := range src.RowGroups() {
+			if _, err := w.WriteRowGroup(rg); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return out, copyPathCounter.Load() - beforeCopy, reencodePathCounter.Load() - beforeL3
+	}
+
+	checkFilter := func(t *testing.T, out *File) {
+		t.Helper()
+		bf := out.RowGroups()[0].ColumnChunks()[0].BloomFilter()
+		if bf == nil {
+			t.Fatal("output column has no bloom filter")
+		}
+		for _, id := range []int64{0, 1, 500, 999} {
+			ok, err := bf.Check(ValueOf(id))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatalf("bloom filter misses present value %d", id)
+			}
+		}
+		misses := 0
+		for id := int64(10_000); id < 10_100; id++ {
+			ok, err := bf.Check(ValueOf(id))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				misses++
+			}
+		}
+		if misses == 0 {
+			t.Fatal("bloom filter matches every absent value; likely bogus")
+		}
+	}
+
+	t.Run("matching_filter_copies", func(t *testing.T) {
+		src := writeCopyTestFile(t, rows, BloomFilters(filter10))
+		out, copied, _ := rewrite(src, BloomFilters(filter10))
+		if copied == 0 {
+			t.Fatal("expected verbatim copy with matching source bloom filter")
+		}
+		checkFilter(t, out)
+	})
+
+	t.Run("missing_source_filter_demotes", func(t *testing.T) {
+		src := writeCopyTestFile(t, rows) // no filter in source
+		out, copied, l3 := rewrite(src, BloomFilters(filter10))
+		if copied != 0 {
+			t.Fatalf("expected demotion when source lacks a bloom filter, %d chunks copied", copied)
+		}
+		if l3 == 0 {
+			t.Fatal("expected L3 rebuild when source lacks a bloom filter")
+		}
+		checkFilter(t, out)
+	})
+
+	t.Run("different_bits_per_value_demotes", func(t *testing.T) {
+		src := writeCopyTestFile(t, rows, BloomFilters(SplitBlockFilter(2, "id")))
+		out, copied, l3 := rewrite(src, BloomFilters(filter10))
+		if copied != 0 {
+			t.Fatalf("expected demotion on bits-per-value mismatch, %d chunks copied", copied)
+		}
+		if l3 == 0 {
+			t.Fatal("expected L3 rebuild on bits-per-value mismatch")
+		}
+		checkFilter(t, out)
+	})
+}

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -322,25 +322,98 @@ func BenchmarkWriteRowGroupReencode(b *testing.B) {
 	benchmarkWriteRowGroupRewrite(b, true)
 }
 
-// TestFileColumnChunkOfUnwrap verifies that the copy path can see through a
-// positional-remap wrapper to the underlying file-backed chunk, while rejecting
-// non-file chunks.
-func TestFileColumnChunkOfUnwrap(t *testing.T) {
-	rows := makeCopyTestRows(100)
-	src := writeCopyTestFile(t, rows)
-	fc := src.RowGroups()[0].ColumnChunks()[0].(*FileColumnChunk)
+// TestWriteRowGroupDedupNotBypassed is a regression test: WriteRowGroup of a
+// dedup-wrapped merge (single sorted source with DropDuplicatedRows) must not
+// take the chunk-level fast paths, which would silently retain the duplicates
+// (dedupRowGroup's ColumnChunks are promoted unchanged from the wrapped row
+// group).
+func TestWriteRowGroupDedupNotBypassed(t *testing.T) {
+	ids := []int64{1, 1, 2, 2, 3, 4, 5, 5}
+	rows := make([]copyTestRow, len(ids))
+	for i, id := range ids {
+		rows[i] = copyTestRow{ID: id, Name: "x", Val: float64(id)}
+	}
+	f := writeCopyTestFile(t, rows, SortingWriterConfig(SortingColumns(Ascending("id"))))
 
-	if got, ok := fileColumnChunkOf(fc); !ok || got != fc {
-		t.Fatal("expected direct *FileColumnChunk to unwrap to itself")
+	merged, err := MergeRowGroups(
+		[]RowGroup{f.RowGroups()[0]},
+		SortingRowGroupConfig(SortingColumns(Ascending("id")), DropDuplicatedRows(true)),
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	wrapped := &convertedColumnChunk{chunk: fc, targetColumnIndex: ^uint16(2)}
-	if got, ok := fileColumnChunkOf(wrapped); !ok || got != fc {
-		t.Fatal("expected convertedColumnChunk to unwrap to inner *FileColumnChunk")
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst, SortingWriterConfig(SortingColumns(Ascending("id"))))
+	if _, err := w.WriteRowGroup(merged); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := OpenFile(bytes.NewReader(dst.Bytes()), int64(dst.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := out.NumRows(); got != 5 {
+		t.Fatalf("deduplicated output has %d rows, want 5 (fast path bypassed dedup)", got)
+	}
+}
+
+// TestWriteRowGroupConversionNotBypassed is a regression test: WriteRowGroup of
+// a converted merge (source schema differs from the target, requiring value
+// conversion) must not take the chunk-level fast paths, which would emit the
+// unconverted source values under the converted schema (convertedRowGroup's
+// ColumnChunks expose the raw source chunks; conversion only happens in Rows()).
+func TestWriteRowGroupConversionNotBypassed(t *testing.T) {
+	type rowStr struct {
+		ID string `parquet:"id"`
+	}
+	type rowInt struct {
+		ID int64 `parquet:"id"`
 	}
 
-	if _, ok := fileColumnChunkOf(&emptyColumnChunk{}); ok {
-		t.Fatal("expected non-file chunk to fail unwrap")
+	var src bytes.Buffer
+	sw := NewGenericWriter[rowStr](&src, SortingWriterConfig(SortingColumns(Ascending("id"))))
+	if _, err := sw.Write([]rowStr{{"1"}, {"2"}, {"3"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := OpenFile(bytes.NewReader(src.Bytes()), int64(src.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := MergeRowGroups(f.RowGroups(),
+		&RowGroupConfig{Schema: SchemaOf(rowInt{})},
+		SortingRowGroupConfig(SortingColumns(Ascending("id"))),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[rowInt](&dst)
+	if _, err := w.WriteRowGroup(merged); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewGenericReader[rowInt](bytes.NewReader(dst.Bytes()))
+	defer r.Close()
+	out := make([]rowInt, 4)
+	n, _ := r.Read(out)
+	if n != 3 {
+		t.Fatalf("read %d rows, want 3", n)
+	}
+	for i, want := range []int64{1, 2, 3} {
+		if out[i].ID != want {
+			t.Fatalf("row %d = %d, want %d (fast path bypassed value conversion)", i, out[i].ID, want)
+		}
 	}
 }
 

--- a/writer_copy_internal_test.go
+++ b/writer_copy_internal_test.go
@@ -1316,3 +1316,73 @@ func TestWriteRowGroupBufferUsesL3(t *testing.T) {
 		t.Fatal("L3 buffer output differs from row-path output")
 	}
 }
+
+// filteringRowGroup simulates an application-defined RowGroup implementation
+// whose Rows() adds semantics (here: keeping only even ids) while ColumnChunks
+// exposes the unfiltered file chunks. Such implementations must never take the
+// chunk-level fast paths.
+type filteringRowGroup struct {
+	RowGroup
+}
+
+func (f *filteringRowGroup) Rows() Rows {
+	return &filteringRows{Rows: f.RowGroup.Rows()}
+}
+
+type filteringRows struct {
+	Rows
+}
+
+func (f *filteringRows) ReadRows(rows []Row) (int, error) {
+	for {
+		n, err := f.Rows.ReadRows(rows)
+		kept := 0
+		for j := range n {
+			if rows[j][0].Int64()%2 == 0 {
+				if kept != j {
+					// Copy the values rather than the slice header so each slot
+					// keeps its own backing array (the reader reuses them).
+					rows[kept] = append(rows[kept][:0], rows[j]...)
+				}
+				kept++
+			}
+		}
+		if kept > 0 || err != nil {
+			return kept, err
+		}
+	}
+}
+
+// TestWriteRowGroupCustomImplementationNotBypassed verifies that the fast paths
+// are opt-in: an application-defined RowGroup (which cannot implement the
+// unexported chunkTransparentMarker) is written through its Rows()
+// implementation, preserving whatever semantics it adds.
+func TestWriteRowGroupCustomImplementationNotBypassed(t *testing.T) {
+	rows := makeCopyTestRows(100) // ids 0..99
+	src := writeCopyTestFile(t, rows)
+
+	beforeCopy, beforeL3 := copyPathCounter.Load(), reencodePathCounter.Load()
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[copyTestRow](&dst)
+	if _, err := w.WriteRowGroup(&filteringRowGroup{RowGroup: src.RowGroups()[0]}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if copyPathCounter.Load() != beforeCopy || reencodePathCounter.Load() != beforeL3 {
+		t.Fatal("custom RowGroup implementation took a chunk-level fast path")
+	}
+
+	got := readCopyTestRows(t, dst.Bytes(), len(rows))
+	if len(got) != 50 {
+		t.Fatalf("filtered output has %d rows, want 50 (custom Rows() semantics bypassed)", len(got))
+	}
+	for i, r := range got {
+		if r.ID != int64(i*2) {
+			t.Fatalf("row %d has id %d, want %d", i, r.ID, i*2)
+		}
+	}
+}

--- a/writer_reencode.go
+++ b/writer_reencode.go
@@ -31,16 +31,18 @@ var reencodePathCounter atomic.Int64
 // baseline.
 var disableWriteReencode bool
 
-// fileBackedRowGroup reports whether every column of rowGroup is a file-backed
-// chunk and the row count fits the configured row group size. File-backed
-// columns guarantee that reading column-wise preserves row order (this excludes
-// overlapping heap merges, whose order depends on cross-column row
-// interleaving); the size check ensures column-wise writing does not produce a
+// columnOrientedRowGroup reports whether every column of rowGroup can be read
+// column-wise while preserving row order, and the row count fits the configured
+// row group size. This holds for file-backed chunks (a single row group of a
+// parquet file) and for in-memory column buffers (parquet.Buffer /
+// GenericBuffer, whose columns are reordered together when sorted); it excludes
+// overlapping heap merges, whose row order depends on cross-column
+// interleaving. The size check ensures column-wise writing does not produce a
 // row group larger than the row path would. Row groups whose Rows() adds
 // semantics on top of the chunks (deduplication, value conversion) are rejected
 // by chunkTransparentRowGroup — reading their chunks directly would bypass
 // those semantics.
-func (w *Writer) fileBackedRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
+func (w *Writer) columnOrientedRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
 	if !chunkTransparentRowGroup(rowGroup) {
 		return nil, false
 	}
@@ -50,7 +52,10 @@ func (w *Writer) fileBackedRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
 		return nil, false
 	}
 	for _, col := range columns {
-		if _, ok := col.(*FileColumnChunk); !ok {
+		switch col.(type) {
+		case *FileColumnChunk:
+		case ColumnBuffer:
+		default:
 			return nil, false
 		}
 	}
@@ -66,7 +71,7 @@ func (w *Writer) reencodableRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
 	if disableWriteReencode {
 		return nil, false
 	}
-	return w.fileBackedRowGroup(rowGroup)
+	return w.columnOrientedRowGroup(rowGroup)
 }
 
 // writeSegmentsPacked writes the segments of a split merge, packing consecutive
@@ -106,7 +111,7 @@ func (w *Writer) writeSegmentsPacked(segments []RowGroup, schema *Schema, sortin
 	}
 
 	for _, seg := range segments {
-		if _, ok := w.fileBackedRowGroup(seg); ok {
+		if _, ok := w.columnOrientedRowGroup(seg); ok {
 			if pendingRows > 0 && pendingRows+seg.NumRows() > maxRows {
 				if err := flushPending(); err != nil {
 					return total, err

--- a/writer_reencode.go
+++ b/writer_reencode.go
@@ -31,20 +31,26 @@ var reencodePathCounter atomic.Int64
 // baseline.
 var disableWriteReencode bool
 
-// fileBackedRowGroup reports whether every column of rowGroup unwraps to a
-// file-backed chunk and the row count fits the configured row group size.
-// File-backed columns guarantee that reading column-wise preserves row order
-// (this excludes overlapping heap merges, whose order depends on cross-column
-// row interleaving); the size check ensures column-wise writing does not produce
-// a row group larger than the row path would.
+// fileBackedRowGroup reports whether every column of rowGroup is a file-backed
+// chunk and the row count fits the configured row group size. File-backed
+// columns guarantee that reading column-wise preserves row order (this excludes
+// overlapping heap merges, whose order depends on cross-column row
+// interleaving); the size check ensures column-wise writing does not produce a
+// row group larger than the row path would. Row groups whose Rows() adds
+// semantics on top of the chunks (deduplication, value conversion) are rejected
+// by chunkTransparentRowGroup — reading their chunks directly would bypass
+// those semantics.
 func (w *Writer) fileBackedRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool) {
+	if !chunkTransparentRowGroup(rowGroup) {
+		return nil, false
+	}
 	dst := w.writer.currentRowGroup.columns
 	columns := rowGroup.ColumnChunks()
 	if len(columns) == 0 || len(columns) != len(dst) {
 		return nil, false
 	}
 	for _, col := range columns {
-		if _, ok := fileColumnChunkOf(col); !ok {
+		if _, ok := col.(*FileColumnChunk); !ok {
 			return nil, false
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #535/#562. One correctness fix and three extensions of the `WriteRowGroup` fast paths, found by re-auditing the merge/copy code after the rebase.

### Fix: fast paths must not bypass dedup or value conversion (correctness)

The chunk-level fast paths assumed `ColumnChunks()` fully represents a row group. Two wrappers violate that by adding semantics in `Rows()` only:

- **`dedupRowGroup`** (single-source merge with `DropDuplicatedRows`): its `ColumnChunks()` are promoted unchanged from the wrapped row group, so `WriteRowGroup` copied the chunks verbatim and **silently retained duplicates** (probe: 8 rows out instead of 5).
- **`convertedRowGroup`** (source schema requires conversion): its `ColumnChunks()` expose the raw source chunks, so `WriteRowGroup` wrote **unconverted values under the converted schema** (probe: string→int64 produced `[1 1 1]` instead of `[1 2 3]`). A physical-type check can't catch all cases — e.g. timestamp millis→micros changes values while preserving INT64.

Both are now rejected by `chunkTransparentRowGroup` in the L0 and L3 predicates, with regression tests. Identity conversions return the row group unwrapped, so matched-schema fast paths are unaffected.

### perf: route SortingWriter's close-time merge through WriteRowGroup

`SortingWriter.Close` read the merged spill row groups through `m.Rows()` + `CopyRows`, always taking the row path. It now calls `WriteRowGroup(m)`, so non-overlapping flushes (nearly-sorted input, e.g. time-ordered appends) take the chunk-level fast paths and pack toward `MaxRowsPerRowGroup`. Also removes a redundant second `DedupeRowReader` pass. ~1.17× end-to-end for pre-sorted input; overlapping input unchanged.

### perf: verbatim bloom filter copy in L0

A bloom-configured writer always demoted L0. When the source chunk already carries an equivalent filter (split-block, xxhash, uncompressed, same bitset size for the chunk's value count — i.e. same bits-per-value), its bytes are now streamed through verbatim (incl. deferred-filters mode), restoring the full verbatim-copy speedup for bloom-enabled rewrites. Mismatched/absent source filters demote to the L3 rebuild (#562) as before.

### perf: L3 for in-memory buffer sources

`WriteRowGroup(buffer)` always took the row path (columnar buffer → rows → columns). Buffer columns are reordered together when sorted, so column-wise reads preserve row order; the L3 predicate now accepts `ColumnBuffer` chunks. **~1.51× faster** for a 100k-row 6-column `GenericBuffer` with Snappy (9.7ms vs 14.7ms).

## Tests

Regression tests for both bypasses; SortingWriter fast-path + dedup tests; bloom copy (matching copies + filter functional in output, missing/mismatched demote and rebuild); buffer L3 vs row-path equality incl. optional columns. Full `./...` + `-race` pass; `make format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)