### PR TITLE
perf(merge): replace heap with loser tree in mergedRowReader

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -507,14 +507,12 @@ func mergeRowReaders[T RowReader](rows []T, compare func(Row, Row) int) RowReade
 		}
 	default:
 		buffers := make([]bufferedRowReader, len(rows))
-		readers := make([]*bufferedRowReader, len(rows))
 		for i, r := range rows {
 			buffers[i].rows = r
-			readers[i] = &buffers[i]
 		}
 		return &mergedRowReader{
 			compare: compare,
-			readers: readers,
+			buffers: buffers,
 		}
 	}
 }
@@ -630,39 +628,54 @@ func (m *mergedRowReader2) ReadRows(rows []Row) (n int, err error) {
 	return n, nil
 }
 
+// mergedRowReader merges k buffered row readers using a tournament tree of
+// losers, which performs ~log2(k) comparisons per row instead of the ~2*log2(k)
+// required to sift down a binary min-heap.
+//
+// The tree is laid out as the first k positions of a 2k binary heap: internal
+// node i stores the loser of the game played at that position, identified by
+// the index of its buffer, and the leaf for buffer i sits at implicit position
+// k+i. The overall winner is kept out of the tree in the winner field, and its
+// leaf position in winnerLeaf. Advancing the merge replays the games on the
+// path from the winner's leaf to the root, comparing the new head of the
+// winner against the losers stored along the way. Exhausted readers are
+// represented by a negative value which loses every game it plays.
 type mergedRowReader struct {
 	compare     func(Row, Row) int
-	readers     []*bufferedRowReader
+	buffers     []bufferedRowReader
+	losers      []int32
+	count       int
+	winner      int32
+	winnerLeaf  int32
 	initialized bool
 }
 
 func (m *mergedRowReader) initialize() error {
-	for i, r := range m.readers {
-		switch err := r.read(); err {
+	k := len(m.buffers)
+	m.losers = make([]int32, k)
+	m.count = k
+
+	leaves := make([]int32, k)
+	for i := range leaves {
+		leaves[i] = int32(i)
+	}
+
+	for i := range m.buffers {
+		switch err := m.buffers[i].read(); err {
 		case nil:
 		case io.EOF:
-			m.readers[i] = nil
+			leaves[i] = -1
+			m.count--
 		default:
-			m.readers = nil
+			m.count = 0
 			return err
 		}
 	}
 
-	n := 0
-	for _, r := range m.readers {
-		if r != nil {
-			m.readers[n] = r
-			n++
-		}
+	if m.count > 0 {
+		m.winner = m.playInitialGames(0, leaves)
+		m.winnerLeaf = int32(k) + m.winner
 	}
-
-	clear := m.readers[n:]
-	for i := range clear {
-		clear[i] = nil
-	}
-
-	m.readers = m.readers[:n]
-	m.heapInit()
 	return nil
 }
 
@@ -675,88 +688,96 @@ func (m *mergedRowReader) ReadRows(rows []Row) (n int, err error) {
 		}
 	}
 
-	for n < len(rows) && len(m.readers) != 0 {
-		r := m.readers[0]
-		if r.empty() { // This readers buffer has been exhausted, repopulate it.
-			if err := r.read(); err != nil {
-				if err == io.EOF {
-					m.heapPop()
-					continue
+	for n < len(rows) && m.count != 0 {
+		c := &m.buffers[m.winner]
+
+		if c.empty() { // This reader's buffer has been exhausted, repopulate it.
+			switch err := c.read(); err {
+			case nil:
+			case io.EOF:
+				m.winner = -1
+				m.count--
+				if m.count == 0 {
+					break
 				}
+			default:
 				return n, err
-			} else {
-				if !m.heapDown(0, len(m.readers)) { // heap.Fix
-					m.heapUp(0)
-				}
-				continue
 			}
+			// The winner's head changed (or the winner was exhausted), replay
+			// the games on the path from its leaf to the root to determine the
+			// new winner.
+			m.replayGames()
+			continue
 		}
 
-		rows[n] = append(rows[n][:0], r.head()...)
+		rows[n] = append(rows[n][:0], c.head()...)
 		n++
 
-		if !r.next() {
+		if !c.next() {
 			return n, nil
 		}
-		if !m.heapDown(0, len(m.readers)) { // heap.Fix
-			m.heapUp(0)
-		}
+		m.replayGames()
 	}
 
-	if len(m.readers) == 0 {
+	if m.count == 0 {
 		err = io.EOF
 	}
 
 	return n, err
 }
 
-func (m *mergedRowReader) heapInit() {
-	n := len(m.readers)
-	for i := n/2 - 1; i >= 0; i-- {
-		m.heapDown(i, n)
+// playInitialGames recursively plays the tournament rooted at position i,
+// storing the loser of each game at the internal node where it was played,
+// and returns the winner of the subtree.
+func (m *mergedRowReader) playInitialGames(i int32, leaves []int32) int32 {
+	k := int32(len(m.buffers))
+	if i >= k { // leaf or out of bounds
+		if i -= k; int(i) < len(leaves) {
+			return leaves[i]
+		}
+		return -1
 	}
+	n1 := m.playInitialGames(2*i+1, leaves)
+	n2 := m.playInitialGames(2*i+2, leaves)
+	loser, winner := m.playGame(n1, n2)
+	m.losers[i] = loser
+	return winner
 }
 
-func (m *mergedRowReader) heapPop() {
-	n := len(m.readers) - 1
-	m.heapSwap(0, n)
-	m.heapDown(0, n)
-	m.readers = m.readers[:n]
+func (m *mergedRowReader) playGame(n1, n2 int32) (loser, winner int32) {
+	if n1 < 0 {
+		return n1, n2
+	}
+	if n2 < 0 {
+		return n2, n1
+	}
+	if m.compare(m.buffers[n1].head(), m.buffers[n2].head()) < 0 {
+		return n2, n1
+	}
+	return n1, n2
 }
 
-func (m *mergedRowReader) heapUp(j int) {
-	for {
-		i := (j - 1) / 2 // parent
-		if i == j || !(m.compare(m.readers[j].head(), m.readers[i].head()) < 0) {
+// replayGames walks the path from the current winner's leaf to the root,
+// playing the winner against the losers stored along the way and exchanging
+// them when they win, then records the new overall winner.
+func (m *mergedRowReader) replayGames() {
+	winner := m.winner
+	for offset := (m.winnerLeaf - 1) / 2; ; offset = (offset - 1) / 2 {
+		player := m.losers[offset]
+
+		if player >= 0 {
+			if winner < 0 || m.compare(m.buffers[player].head(), m.buffers[winner].head()) < 0 {
+				m.losers[offset] = winner
+				winner = player
+			}
+		}
+
+		if offset == 0 {
 			break
 		}
-		m.heapSwap(i, j)
-		j = i
 	}
-}
-
-func (m *mergedRowReader) heapDown(i0, n int) bool {
-	i := i0
-	for {
-		j1 := 2*i + 1
-		if j1 >= n || j1 < 0 { // j1 < 0 after int overflow
-			break
-		}
-		j := j1 // left child
-		if j2 := j1 + 1; j2 < n && m.compare(m.readers[j2].head(), m.readers[j1].head()) < 0 {
-			j = j2 // = 2*i + 2  // right child
-		}
-		if !(m.compare(m.readers[j].head(), m.readers[i].head()) < 0) {
-			break
-		}
-		m.heapSwap(i, j)
-		i = j
-	}
-	return i > i0
-}
-
-func (m *mergedRowReader) heapSwap(i, j int) {
-	m.readers[i], m.readers[j] = m.readers[j], m.readers[i]
+	m.winner = winner
+	m.winnerLeaf = int32(len(m.buffers)) + winner
 }
 
 type bufferedRowReader struct {

--- a/merge_test.go
+++ b/merge_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/parquet-go/parquet-go/format"
@@ -3344,5 +3345,129 @@ func TestMergeRowGroupsMultipleSequentialOverlappingSegments(t *testing.T) {
 	expected := []int64{1, 3, 4, 5, 6, 10, 12, 15, 20}
 	if !slices.Equal(got, expected) {
 		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
+// sliceRowReader is a minimal in-memory RowReader used to benchmark the k-way
+// merge algorithm in isolation from parquet page decoding.
+type sliceRowReader struct {
+	rows []parquet.Row
+	off  int
+}
+
+func (r *sliceRowReader) ReadRows(rows []parquet.Row) (n int, err error) {
+	for n < len(rows) && r.off < len(r.rows) {
+		rows[n] = append(rows[n][:0], r.rows[r.off]...)
+		n++
+		r.off++
+	}
+	if n == 0 {
+		return 0, io.EOF
+	}
+	return n, nil
+}
+
+func TestMergeRowReaders(t *testing.T) {
+	compare := func(a, b parquet.Row) int {
+		return parquet.Int64Type.Compare(a[0], b[0])
+	}
+
+	prng := rand.New(rand.NewSource(1))
+
+	for _, numReaders := range []int{2, 3, 4, 5, 7, 8, 16, 31, 64} {
+		t.Run(fmt.Sprintf("readers=%d", numReaders), func(t *testing.T) {
+			for trial := range 10 {
+				expect := make([]int64, 0, numReaders*100)
+				readers := make([]parquet.RowReader, numReaders)
+
+				for i := range readers {
+					n := prng.Intn(100)
+					if trial%3 == 0 && i%2 == 0 {
+						n = 0 // exercise readers that are empty from the start
+					}
+					values := make([]int64, n)
+					for j := range values {
+						values[j] = int64(prng.Intn(50)) // small domain to produce duplicates
+					}
+					slices.Sort(values)
+					rows := make([]parquet.Row, n)
+					for j, v := range values {
+						rows[j] = parquet.Row{parquet.Int64Value(v).Level(0, 0, 0)}
+					}
+					readers[i] = &sliceRowReader{rows: rows}
+					expect = append(expect, values...)
+				}
+				slices.Sort(expect)
+
+				merge := parquet.MergeRowReaders(readers, compare)
+				got := make([]int64, 0, len(expect))
+				rbuf := make([]parquet.Row, 7) // small buffer to exercise buffer boundaries
+				for {
+					n, err := merge.ReadRows(rbuf)
+					for _, row := range rbuf[:n] {
+						got = append(got, row[0].Int64())
+					}
+					if err != nil {
+						if !errors.Is(err, io.EOF) {
+							t.Fatal(err)
+						}
+						break
+					}
+				}
+
+				if !slices.Equal(got, expect) {
+					t.Fatalf("trial %d: merged output mismatch: got %d rows, want %d rows\ngot:  %v\nwant: %v",
+						trial, len(got), len(expect), got, expect)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMergeRowReaders(b *testing.B) {
+	const rowsPerReader = 10_000
+
+	compare := func(a, b parquet.Row) int {
+		return parquet.Int64Type.Compare(a[0], b[0])
+	}
+
+	for _, numReaders := range []int{2, 3, 4, 8, 16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("readers=%d", numReaders), func(b *testing.B) {
+			// Interleave values across readers so the merge alternates between
+			// inputs on every row, maximizing the number of comparisons.
+			readers := make([]sliceRowReader, numReaders)
+			for i := range readers {
+				rows := make([]parquet.Row, rowsPerReader)
+				for j := range rows {
+					rows[j] = parquet.Row{parquet.Int64Value(int64(j*numReaders+i)).Level(0, 0, 0)}
+				}
+				readers[i].rows = rows
+			}
+
+			rbuf := make([]parquet.Row, benchmarkRowsPerStep)
+			totalRows := int64(0)
+
+			start := time.Now()
+			for b.Loop() {
+				rowReaders := make([]parquet.RowReader, numReaders)
+				for i := range readers {
+					readers[i].off = 0
+					rowReaders[i] = &readers[i]
+				}
+				merge := parquet.MergeRowReaders(rowReaders, compare)
+				for {
+					n, err := merge.ReadRows(rbuf)
+					totalRows += int64(n)
+					if err != nil {
+						if !errors.Is(err, io.EOF) {
+							b.Fatal(err)
+						}
+						break
+					}
+				}
+			}
+			seconds := time.Since(start).Seconds()
+			b.ReportMetric(float64(totalRows)/seconds, "row/s")
+		})
 	}
 }


### PR DESCRIPTION
## What

Replaces the binary min-heap in `mergedRowReader` with a tournament tree of losers, ported from [kway-go](https://github.com/achille-roussel/kway-go). The `k=2` fast path (`mergedRowReader2`) and everything upstream (segment detection, dedup) are unchanged.

## Why

A loser tree advances the merge by replaying only the games on the path from the winner's leaf to the root, comparing the new head against the losers stored along the way. That is exactly ⌈log₂(k)⌉ comparisons per row, versus ~2·log₂(k) for a heap sift-down (measured with a counting comparator: 7.00 vs 12.03 comparisons/row at k=128, 1.67 vs 2.00 at k=3).

## How

- The tree stores only `losers []int32` (buffer indices). The leaf position of buffer *i* is implicitly `k+i`, so no node structs are needed; `-1` marks an exhausted reader and loses every game it plays.
- The refill protocol is preserved from the heap version: an exhausted buffer is never refilled after rows were produced in the same `ReadRows` call (returned `Value`s may reference page data), so the reader returns early and refills + replays on re-entry.

## Benchmarks

New `BenchmarkMergeRowReaders` isolating the merge core with interleaved inputs (worst case for a k-way merge), Apple M4 Max, benchstat n=6:

| readers | heap row/s | loser tree row/s | delta |
|---|---|---|---|
| 3 | 51.6M | 51.7M | ~ |
| 4 | 42.0M | 45.8M | +9% |
| 8 | 27.1M | 34.8M | +29% |
| 16 | 18.4M | 27.7M | +50% |
| 32 | 14.3M | 23.1M | +62% |
| 64 | 11.8M | 19.6M | +67% |
| 128 | 9.2M | 16.7M | +81% |

End-to-end `BenchmarkMergeRowGroups` at groups=3: STRING +6%, AddressBook +3.4%, INT64 -9%. The INT64 case regresses because the replay loop does a fixed amount of per-level bookkeeping that the heap's early-exit sift-down avoids when comparisons are very cheap and k is tiny — profiling confirms the tree still performs fewer comparisons there. We accept this: merges with more inputs or more expensive comparators (multi-column, strings) all improve, and a per-k hybrid would keep ~100 lines of duplicated heap logic.

## Testing

- New randomized `TestMergeRowReaders` covering empty readers, duplicate values, and odd reader counts against a sorted-concatenation oracle.
- Full suite passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)