### PR TITLE
fix: MergeRowGroups produces unsorted output for descending sorting columns

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -222,18 +222,26 @@ func rowGroupRangeOfSortedColumns(rg RowGroup, schema *Schema, sorting []Sorting
 			return nil, nil, fmt.Errorf("column index not available for sorting column %s", sortingColumnPath)
 		}
 
-		// Since data is sorted by sorting columns, we can efficiently get min/max:
-		// - Min value = min of first non-null page
-		// - Max value = max of last non-null page
+		// Since data is sorted by sorting columns, we can bound the first and
+		// last rows of the row group from the first and last non-null pages of
+		// the column index. The bounds are expressed in sort order: when the
+		// column is sorted in descending order, the first row holds the
+		// largest value and the last row holds the smallest one, so the page
+		// statistics to read are inverted.
 		numPages := columnIndex.NumPages()
+		descending := sortingColumn.Descending()
 
-		// Find first non-null page for min value
-		var globalMin Value
+		// Bound the first row in sort order from the first non-null page
+		var firstValue Value
 		var found bool
 		for pageIdx := range numPages {
 			if !columnIndex.NullPage(pageIdx) {
-				if minValue := columnIndex.MinValue(pageIdx); !minValue.IsNull() {
-					globalMin, found = minValue, true
+				value := columnIndex.MinValue(pageIdx)
+				if descending {
+					value = columnIndex.MaxValue(pageIdx)
+				}
+				if !value.IsNull() {
+					firstValue, found = value, true
 					break
 				}
 			}
@@ -242,20 +250,24 @@ func rowGroupRangeOfSortedColumns(rg RowGroup, schema *Schema, sorting []Sorting
 			return nil, nil, fmt.Errorf("no valid pages found in column index for column %s", sortingColumnPath)
 		}
 
-		// Find last non-null page for max value
-		var globalMax Value
+		// Bound the last row in sort order from the last non-null page
+		var lastValue Value
 		for pageIdx := numPages - 1; pageIdx >= 0; pageIdx-- {
 			if !columnIndex.NullPage(pageIdx) {
-				if maxValue := columnIndex.MaxValue(pageIdx); !maxValue.IsNull() {
-					globalMax = maxValue
+				value := columnIndex.MaxValue(pageIdx)
+				if descending {
+					value = columnIndex.MinValue(pageIdx)
+				}
+				if !value.IsNull() {
+					lastValue = value
 					break
 				}
 			}
 		}
 
 		// Set the min/max values with proper levels
-		minValues[sortingColumnIndex] = globalMin.Level(0, 1, sortingColumnIndex)
-		maxValues[sortingColumnIndex] = globalMax.Level(0, 1, sortingColumnIndex)
+		minValues[sortingColumnIndex] = firstValue.Level(0, 1, sortingColumnIndex)
+		maxValues[sortingColumnIndex] = lastValue.Level(0, 1, sortingColumnIndex)
 	}
 
 	minRow = Row(minValues)

--- a/merge_test.go
+++ b/merge_test.go
@@ -3471,3 +3471,84 @@ func BenchmarkMergeRowReaders(b *testing.B) {
 		})
 	}
 }
+
+// TestMergeRowGroupsDescendingSortingColumns is a regression test for
+// https://github.com/parquet-go/parquet-go/issues/564: the non-overlapping
+// segment optimization computed row group bounds in value order, which
+// inverted the first/last rows of row groups sorted in descending order.
+func TestMergeRowGroupsDescendingSortingColumns(t *testing.T) {
+	type Record struct {
+		Value int64 `parquet:"value"`
+	}
+
+	sortingOptions := []parquet.RowGroupOption{
+		parquet.SortingRowGroupConfig(
+			parquet.SortingColumns(
+				parquet.Descending("value"),
+			),
+		),
+	}
+
+	t.Run("overlapping", func(t *testing.T) {
+		// Group1: [40,20,10] overlaps Group2: [20]
+		group1 := fileRowGroup(sortedRowGroup(sortingOptions, Record{40}, Record{20}, Record{10}))
+		group2 := fileRowGroup(sortedRowGroup(sortingOptions, Record{20}))
+
+		merged, err := parquet.MergeRowGroups([]parquet.RowGroup{group1, group2}, sortingOptions...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rows := merged.Rows()
+		defer rows.Close()
+
+		got := readAllInt64Values(t, rows)
+		expected := []int64{40, 20, 20, 10}
+		if !slices.Equal(got, expected) {
+			t.Errorf("got %v, want %v", got, expected)
+		}
+	})
+
+	t.Run("non-overlapping", func(t *testing.T) {
+		// Group1: [20,10] and Group2: [40,30] do not overlap; the merged
+		// output must start with the segment holding the largest values.
+		group1 := fileRowGroup(sortedRowGroup(sortingOptions, Record{20}, Record{10}))
+		group2 := fileRowGroup(sortedRowGroup(sortingOptions, Record{40}, Record{30}))
+
+		merged, err := parquet.MergeRowGroups([]parquet.RowGroup{group1, group2}, sortingOptions...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rows := merged.Rows()
+		defer rows.Close()
+
+		got := readAllInt64Values(t, rows)
+		expected := []int64{40, 30, 20, 10}
+		if !slices.Equal(got, expected) {
+			t.Errorf("got %v, want %v", got, expected)
+		}
+	})
+
+	t.Run("chained overlap", func(t *testing.T) {
+		// Group1: [50,30,10] overlaps Group2: [40,20] which overlaps
+		// Group3: [15,5]; Group1 and Group3 also overlap through Group2.
+		group1 := fileRowGroup(sortedRowGroup(sortingOptions, Record{50}, Record{30}, Record{10}))
+		group2 := fileRowGroup(sortedRowGroup(sortingOptions, Record{40}, Record{20}))
+		group3 := fileRowGroup(sortedRowGroup(sortingOptions, Record{15}, Record{5}))
+
+		merged, err := parquet.MergeRowGroups([]parquet.RowGroup{group1, group2, group3}, sortingOptions...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rows := merged.Rows()
+		defer rows.Close()
+
+		got := readAllInt64Values(t, rows)
+		expected := []int64{50, 40, 30, 20, 15, 10, 5}
+		if !slices.Equal(got, expected) {
+			t.Errorf("got %v, want %v", got, expected)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #564

## Problem

Merging row groups sorted on a descending column produced unsorted output. The reproduction from the issue (two row groups `[40,20,10]` and `[20]` sorted by `Descending("points")`) yielded `20 40 20 10` instead of `40 20 20 10`. Ascending columns were unaffected.

## Root cause

The non-overlapping row group optimization in `MergeRowGroups` computes each row group's first/last row bounds from the column index, and always used the **min value of the first page** as the first-row bound and the **max value of the last page** as the last-row bound. That is only correct for ascending order: for a descending sorting column, the first row in sort order holds the *largest* value and the last row the *smallest*, so the bounds were inverted. The overlap detector (which compares bounds with the sort-order-aware compare function) then concluded that overlapping row groups were disjoint and concatenated them instead of heap-merging.

## Fix

`rowGroupRangeOfSortedColumns` now reads the first page's **max** value and the last page's **min** value when the sorting column is descending, so the bounds are always expressed in sort order. The bounds remain conservative for secondary sorting columns, since the first/last rows of a sorted row group always live in the first/last pages.

## Testing

- Added `TestMergeRowGroupsDescendingSortingColumns` with overlapping, non-overlapping, and chained-overlap subtests; the overlapping cases failed before the fix with exactly the output reported in the issue.
- Ran the issue's reproduction program verbatim against the fix — it now prints `40 20 20 10`.
- `go test -race ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)