### PR TITLE
fix: don't panic reading FIXED_LEN_BYTE_ARRAY decimal into []byte field

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -2,11 +2,13 @@ package parquet_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -1155,4 +1157,83 @@ func TestIssue522(t *testing.T) {
 			t.Errorf("row %d: Opt = %q, want %q", i, *got.Opt, want)
 		}
 	}
+}
+
+// TestIssue566ByteSliceDecimalRead reproduces issue #566: reading a
+// FIXED_LEN_BYTE_ARRAY decimal column into a []byte or [N]byte struct field
+// used to panic with "reflect.Set: value of type *big.Float is not assignable
+// to type []uint8" because decimalType.AssignValue unconditionally converted
+// the value to *big.Float. Byte destinations must receive the raw big-endian
+// two's-complement bytes, as they did before v0.28.0.
+func TestIssue566ByteSliceDecimalRead(t *testing.T) {
+	type writeRow struct {
+		ID [16]byte `parquet:"id,decimal(6:38)"`
+	}
+
+	// Encode integer 480 as decimal(38,6): unscaled = 480 * 10^6,
+	// stored big-endian in the upper 8 bytes of a 16-byte array.
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], 480_000_000)
+
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[writeRow](&buf)
+	if _, err := w.Write([]writeRow{{ID: id}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("byte slice", func(t *testing.T) {
+		type row struct {
+			ID []byte `parquet:"id,decimal(6:38)"`
+		}
+		r := parquet.NewGenericReader[row](bytes.NewReader(buf.Bytes()))
+		defer r.Close()
+		rows := make([]row, 1)
+		n, err := r.Read(rows)
+		if n != 1 || (err != nil && err != io.EOF) {
+			t.Fatalf("unexpected read result: n=%d err=%v", n, err)
+		}
+		if !bytes.Equal(rows[0].ID, id[:]) {
+			t.Errorf("ID = %x, want %x", rows[0].ID, id)
+		}
+	})
+
+	t.Run("byte array", func(t *testing.T) {
+		type row struct {
+			ID [16]byte `parquet:"id,decimal(6:38)"`
+		}
+		r := parquet.NewGenericReader[row](bytes.NewReader(buf.Bytes()))
+		defer r.Close()
+		rows := make([]row, 1)
+		n, err := r.Read(rows)
+		if n != 1 || (err != nil && err != io.EOF) {
+			t.Fatalf("unexpected read result: n=%d err=%v", n, err)
+		}
+		if rows[0].ID != id {
+			t.Errorf("ID = %x, want %x", rows[0].ID, id)
+		}
+	})
+
+	t.Run("big float", func(t *testing.T) {
+		r := parquet.NewGenericReader[any](bytes.NewReader(buf.Bytes()))
+		defer r.Close()
+		rows := make([]any, 1)
+		n, err := r.Read(rows)
+		if n != 1 || (err != nil && err != io.EOF) {
+			t.Fatalf("unexpected read result: n=%d err=%v", n, err)
+		}
+		row, ok := rows[0].(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected row type: %T", rows[0])
+		}
+		f, ok := row["id"].(*big.Float)
+		if !ok {
+			t.Fatalf("expected *big.Float, got %T", row["id"])
+		}
+		if v, _ := f.Float64(); v != 480 {
+			t.Errorf("id = %v, want 480", v)
+		}
+	})
 }

--- a/type_decimal.go
+++ b/type_decimal.go
@@ -77,6 +77,14 @@ func (t *decimalType) AssignValue(dst reflect.Value, src Value) error {
 		if t.Type.Kind() != ByteArray && t.Type.Kind() != FixedLenByteArray {
 			return nil
 		}
+		switch dst.Kind() {
+		case reflect.Slice, reflect.Array, reflect.String:
+			// Destinations like []byte, [N]byte, or string receive the raw
+			// big-endian two's-complement representation of the decimal
+			// value, as they did when decimalType inherited AssignValue
+			// from its underlying byte array type.
+			return t.Type.AssignValue(dst, src)
+		}
 		data := src.ByteArray()
 		val := new(big.Int)
 		if len(data) > 0 && data[0]&0x80 != 0 {
@@ -98,7 +106,13 @@ func (t *decimalType) AssignValue(dst reflect.Value, src Value) error {
 		scaleFactor := new(big.Float).SetPrec(prec)
 		scaleFactor.SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(t.decimal.Scale)), nil))
 		f.Quo(f, scaleFactor)
-		dst.Set(reflect.ValueOf(f))
+		switch dst.Kind() {
+		case reflect.Float32, reflect.Float64:
+			v, _ := f.Float64()
+			dst.SetFloat(v)
+		default:
+			dst.Set(reflect.ValueOf(f))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #566

## Problem

PR #451 added `decimalType.AssignValue`, which unconditionally converts `ByteArray`/`FixedLenByteArray` decimal values to `*big.Float` and assigns the result with `reflect.Set`. When the destination Go struct field is `[]byte` (or `[N]byte`), the assignment panics:

```
reflect.Set: value of type *big.Float is not assignable to type []uint8
```

Before v0.28.0 these destinations worked because `decimalType` inherited `AssignValue` from its underlying byte array type, which copies the raw bytes.

## Fix

In the byte-array branch of `decimalType.AssignValue`, switch on the destination kind:

- `[]byte`, `[N]byte`, and `string` destinations delegate to the underlying type's `AssignValue` and receive the raw big-endian two's-complement bytes, restoring the pre-v0.28.0 behavior.
- `float32`/`float64` destinations receive the scaled value via `f.Float64()` instead of panicking, mirroring the `Int32`/`Int64` branches which already convert for float destinations.
- All other destinations (e.g. `map[string]any`) keep the `*big.Float` conversion added by #451.

## Testing

Added `TestIssue566ByteSliceDecimalRead`, which writes the issue's reproducer (480 encoded as decimal(38,6) in a 16-byte fixed array) and reads it back into a `[]byte` field, a `[16]byte` field, and `map[string]any` (asserting the `*big.Float` path still yields 480). The `[]byte` subtest panicked before the fix. Full `go test ./...` passes.

The issue's cases 2 and 3 (`*big.Float` struct fields) fail at schema construction — a separate gap in struct field mapping, not part of this regression — and are left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)