### PR TITLE
perf(merge): row-range overlap refinement

### DIFF
--- a/docs/merge-copy-optimization.md
+++ b/docs/merge-copy-optimization.md
@@ -415,3 +415,39 @@ workload, but its benefit is workload-dependent and its peak memory scales with
 the worker count (decompressed column working sets held concurrently). It was
 left out for now to keep L3 simple and allocation-light; it can be added later as
 an opt-in `WriterConfig` knob if a concrete workload justifies it.
+
+### Row-range overlap refinement (DONE)
+
+Overlap was previously classified at whole-row-group granularity: one row of
+overlap condemned both row groups to the row-by-row merge in full. Overlapping
+segments are now refined (`merge_refine.go`) with a key-space sweep over the
+exact row group bounds: stretches covered by a single row group are sliced off
+as **row-range views** (`row_range.go`) that stream through the column-oriented
+write paths, leaving only the truly overlapping stretches for the loser-tree
+merge.
+
+Key design points:
+
+- **Lone-only cuts.** Cuts are only applied to the row group that is alone in a
+  stretch of key space, validated against the exact bounds of the others.
+  Page-granular cuts of *different* row groups at one nominal key land at
+  different actual keys and could reorder rows across regions; lone-only cuts
+  guarantee region concatenation preserves sorted order.
+- **Page-granular planning.** Cut positions come from the first sorting
+  column's column/offset indexes (descending-aware); no page is decoded during
+  planning. Missing indexes or null pages disable slicing for that row group
+  only. Lone stretches under 1024 rows stay merged (`minStreamedRegionRows`).
+- **Contract.** Sorted output, per-source row order, same multiset. The
+  interleaving of equal keys across row groups may differ from the unrefined
+  merge (it already differs between merge arities), so refinement is skipped
+  under `DropDuplicatedRows`, where tie order decides which duplicate survives.
+- **Exact bloom filters without demotion.** Range views of repeated columns
+  only know an upper bound of their value count; the writer skips filter
+  preallocation for inexact counts and lets `flushFilterPages` build the filter
+  post hoc from the values actually written.
+
+Benchmarks (8 files × 20k rows, ~2% boundary overlap chain, 4KB source pages):
+write 22.9ms → 11.6ms (**~1.9×**, 2.5× less memory); read 11.4ms → 9.5ms
+(~1.2× — the loser-tree run detection already made disjoint merging cheap;
+the write side gains more because streamed regions skip row assembly
+entirely). Full-overlap and sliver-heavy workloads are unchanged.

--- a/merge.go
+++ b/merge.go
@@ -84,18 +84,38 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 	dropDuplicatedRows := config.Sorting.DropDuplicatedRows
 
 	// Optimization: detect non-overlapping row groups and create segments
+	makeMerged := func(rowGroups []RowGroup) RowGroup {
+		merged := &mergedRowGroup{
+			compare:            mergedCompare,
+			dropDuplicatedRows: dropDuplicatedRows,
+		}
+		merged.init(schema, mergedSortingColumns, rowGroups)
+		return merged
+	}
+
 	rowGroupSegments := make([]RowGroup, 0)
 	for segment := range overlappingRowGroups(mergedRowGroups, schema, mergedSortingColumns, mergedCompare) {
 		if len(segment) == 1 {
-			rowGroupSegments = append(rowGroupSegments, segment[0])
-		} else {
-			merged := &mergedRowGroup{
-				compare:            mergedCompare,
-				dropDuplicatedRows: dropDuplicatedRows,
-			}
-			merged.init(schema, mergedSortingColumns, segment)
-			rowGroupSegments = append(rowGroupSegments, merged)
+			rowGroupSegments = append(rowGroupSegments, segment[0].rowGroup)
+			continue
 		}
+		// Refine partially overlapping segments: stretches of key space
+		// covered by a single row group are sliced off as row-range views,
+		// leaving only the truly overlapping stretches for the merge. Not
+		// applied when dropping duplicated rows: which physical row of an
+		// equal-key run survives depends on the interleaving of ties across
+		// row groups, which refinement does not preserve.
+		if !dropDuplicatedRows && !disableMergeRefinement {
+			if refined := refineSegment(newRefineTargets(segment, schema, mergedSortingColumns), mergedCompare, makeMerged); refined != nil {
+				rowGroupSegments = append(rowGroupSegments, refined...)
+				continue
+			}
+		}
+		rowGroups := make([]RowGroup, len(segment))
+		for i := range segment {
+			rowGroups[i] = segment[i].rowGroup
+		}
+		rowGroupSegments = append(rowGroupSegments, makeMerged(rowGroups))
 	}
 
 	if len(rowGroupSegments) == 1 {
@@ -120,18 +140,20 @@ func MergeRowGroups(rowGroups []RowGroup, options ...RowGroupOption) (RowGroup, 
 	}, nil
 }
 
+// rowGroupRange associates a row group with the bounds of its sorting columns
+// (nil when the bounds could not be determined).
+type rowGroupRange struct {
+	rowGroup RowGroup
+	minRow   Row
+	maxRow   Row
+}
+
 // overlappingRowGroups analyzes row groups to find non-overlapping segments
 // Returns groups of row groups where each group either:
 // 1. Contains a single non-overlapping row group (can be concatenated)
 // 2. Contains multiple overlapping row groups (need to be merged)
-func overlappingRowGroups(rowGroups []RowGroup, schema *Schema, sorting []SortingColumn, compare func(Row, Row) int) iter.Seq[[]RowGroup] {
-	return func(yield func([]RowGroup) bool) {
-		type rowGroupRange struct {
-			rowGroup RowGroup
-			minRow   Row
-			maxRow   Row
-		}
-
+func overlappingRowGroups(rowGroups []RowGroup, schema *Schema, sorting []SortingColumn, compare func(Row, Row) int) iter.Seq[[]rowGroupRange] {
+	return func(yield func([]rowGroupRange) bool) {
 		rowGroupRanges := make([]rowGroupRange, 0, len(rowGroups))
 		for _, rg := range rowGroups {
 			if rg.NumRows() == 0 {
@@ -139,7 +161,13 @@ func overlappingRowGroups(rowGroups []RowGroup, schema *Schema, sorting []Sortin
 			}
 			minRow, maxRow, err := rowGroupRangeOfSortedColumns(rg, schema, sorting)
 			if err != nil {
-				yield(rowGroups)
+				// Bounds unavailable: yield all row groups as a single segment
+				// with nil bounds, which the caller merges without refinement.
+				all := make([]rowGroupRange, len(rowGroups))
+				for i, rg := range rowGroups {
+					all[i] = rowGroupRange{rowGroup: rg}
+				}
+				yield(all)
 				return
 			}
 			rowGroupRanges = append(rowGroupRanges, rowGroupRange{
@@ -152,7 +180,7 @@ func overlappingRowGroups(rowGroups []RowGroup, schema *Schema, sorting []Sortin
 			return
 		}
 		if len(rowGroupRanges) == 1 {
-			yield([]RowGroup{rowGroupRanges[0].rowGroup})
+			yield(rowGroupRanges[:1])
 			return
 		}
 
@@ -162,29 +190,26 @@ func overlappingRowGroups(rowGroups []RowGroup, schema *Schema, sorting []Sortin
 		})
 
 		// Detect overlapping segments
-		currentSegment := []RowGroup{rowGroupRanges[0].rowGroup}
+		segmentStart := 0
 		currentMax := rowGroupRanges[0].maxRow
 
-		for _, rr := range rowGroupRanges[1:] {
+		for i, rr := range rowGroupRanges[1:] {
 			if compare(rr.minRow, currentMax) <= 0 {
-				// Overlapping - add to current segment and extend max if necessary
-				currentSegment = append(currentSegment, rr.rowGroup)
+				// Overlapping - extend max if necessary
 				if compare(rr.maxRow, currentMax) > 0 {
 					currentMax = rr.maxRow
 				}
 			} else {
 				// Non-overlapping - yield current segment
-				if !yield(currentSegment) {
+				if !yield(rowGroupRanges[segmentStart : i+1]) {
 					return
 				}
-				currentSegment = []RowGroup{rr.rowGroup}
+				segmentStart = i + 1
 				currentMax = rr.maxRow
 			}
 		}
 
-		if len(currentSegment) > 0 {
-			yield(currentSegment)
-		}
+		yield(rowGroupRanges[segmentStart:])
 	}
 }
 

--- a/merge_refine.go
+++ b/merge_refine.go
@@ -1,0 +1,365 @@
+package parquet
+
+import (
+	"slices"
+	"sort"
+)
+
+// This file refines overlapping merge segments: when sorted row groups overlap
+// only in part of their key ranges (e.g. time-ordered files overlapping around
+// their boundaries), the stretches of key space covered by a single row group
+// do not need to be merged row by row — they can be sliced off as row-range
+// views (see row_range.go) and read or written through the column-oriented
+// paths, leaving only the truly overlapping stretches for the loser-tree merge.
+//
+// Cuts are only ever applied to the row group that is alone in a stretch of
+// key space (a "lone stretch"), and are validated against the exact
+// row-group-level min/max keys of the other row groups. This avoids a subtle
+// hazard: page-granular cuts of different row groups at a common boundary key
+// land at different actual keys, which could reorder rows across regions.
+// Cutting only the lone row group — with the rows of its boundary pages pushed
+// into the adjacent merged region — guarantees that every row of a region
+// compares at most equal to every row of the following regions, so
+// concatenating the regions preserves sorted order. Ties across row groups
+// always land in merged regions, whose loser-tree resolves them.
+//
+// The refined plan is equivalent to the full merge as a sorted sequence: the
+// same multiset of rows, with each input row group's rows in their original
+// relative order. The interleaving of rows with equal sort keys across row
+// groups may differ from the unrefined merge (as it already does between merge
+// arities), which is why refinement is not applied when dropping duplicated
+// rows: which physical row of an equal-key run survives deduplication depends
+// on that interleaving.
+
+// disableMergeRefinement forces overlapping segments through the unrefined
+// merge. It exists only so tests and benchmarks can compare refined plans
+// against the reference behavior.
+var disableMergeRefinement bool
+
+// minStreamedRegionRows is the minimum number of rows a lone stretch must span
+// to be worth slicing out of the merge. Below this, the overhead of an extra
+// segment (a seek per column, a row group boundary when writing) outweighs the
+// merge work saved, so the stretch stays in the adjacent merged region.
+const minStreamedRegionRows = 1024
+
+// refineTarget describes one row group of an overlapping segment for the
+// planner. minRow and maxRow are the exact bounds of the sorting columns, as
+// computed by rowGroupRangeOfSortedColumns. cutAbove and cutBelow are
+// conservative page-granular row lookups on the first sorting column; either
+// may be nil when the row group does not support them, in which case the row
+// group is never sliced.
+type refineTarget struct {
+	rowGroup RowGroup
+	minRow   Row
+	maxRow   Row
+	numRows  int64
+
+	// cutAbove returns the smallest row index such that every row at or after
+	// it has a sort key strictly greater than key, rounded down to a page
+	// boundary of the first sorting column (the rows of the page containing
+	// key stay below the cut).
+	cutAbove func(key Row) int64
+
+	// cutBelow returns the largest row index such that every row before it
+	// has a sort key strictly less than key, rounded down to a page boundary
+	// of the first sorting column (the rows of the page containing key stay
+	// at or above the cut).
+	cutBelow func(key Row) int64
+}
+
+// newRefineTargets builds the planner inputs for one overlapping segment. It
+// returns nil when the segment cannot be refined at all (bounds unavailable).
+// Individual row groups whose page index does not support cut lookups get nil
+// cut functions and are never sliced, but still participate in the plan.
+func newRefineTargets(segment []rowGroupRange, schema *Schema, sorting []SortingColumn) []refineTarget {
+	if len(sorting) == 0 {
+		return nil
+	}
+
+	// Locate the leaf column of the first sorting column; cuts are computed on
+	// its page bounds only. (Strict inequality on the first sort column implies
+	// strict inequality on the full sorting tuple, so cuts remain conservative
+	// for multi-column sorts.)
+	sortingColumnIndex := -1
+	sortingColumnPath := columnPath(sorting[0].Path())
+	for columnIndex, path := range schema.Columns() {
+		if slices.Equal(path, sortingColumnPath) {
+			sortingColumnIndex = columnIndex
+			break
+		}
+	}
+	if sortingColumnIndex < 0 {
+		return nil
+	}
+	descending := sorting[0].Descending()
+
+	targets := make([]refineTarget, len(segment))
+	for i, rr := range segment {
+		if rr.minRow == nil || rr.maxRow == nil {
+			return nil
+		}
+		targets[i] = refineTarget{
+			rowGroup: rr.rowGroup,
+			minRow:   rr.minRow,
+			maxRow:   rr.maxRow,
+			numRows:  rr.rowGroup.NumRows(),
+		}
+		targets[i].cutAbove, targets[i].cutBelow = newCutLookups(rr.rowGroup, sortingColumnIndex, descending)
+	}
+	return targets
+}
+
+// newCutLookups builds the page-granular row cut lookups for the sorting leaf
+// column of a row group, or (nil, nil) when the page index does not support
+// them (missing column or offset index, or null pages in the sorting column,
+// whose position in the sort order is not knowable from the index).
+func newCutLookups(rg RowGroup, columnIndex int, descending bool) (cutAbove, cutBelow func(Row) int64) {
+	chunks := rg.ColumnChunks()
+	if columnIndex >= len(chunks) {
+		return nil, nil
+	}
+	chunk := chunks[columnIndex]
+	columnType := chunk.Type()
+
+	ci, err := chunk.ColumnIndex()
+	if err != nil || ci == nil || ci.NumPages() == 0 {
+		return nil, nil
+	}
+	oi, err := chunk.OffsetIndex()
+	if err != nil || oi == nil || oi.NumPages() != ci.NumPages() {
+		return nil, nil
+	}
+	numPages := ci.NumPages()
+	for p := range numPages {
+		if ci.NullPage(p) {
+			return nil, nil
+		}
+	}
+	numRows := rg.NumRows()
+
+	// In-order page bounds: the first value of a page in sort order is its
+	// minimum for ascending sorts and its maximum for descending sorts.
+	earliest := ci.MinValue
+	latest := ci.MaxValue
+	if descending {
+		earliest, latest = latest, earliest
+	}
+	// orderCompare orders values by the sort direction.
+	orderCompare := func(a, b Value) int {
+		return compareValues(a, b, columnType, descending)
+	}
+	pageEnd := func(p int) int64 {
+		if p+1 < numPages {
+			return oi.FirstRowIndex(p + 1)
+		}
+		return numRows
+	}
+
+	// cutAbove: end of the last page whose earliest value is at or before key
+	// (every row from the cut on belongs to a later page, whose values are all
+	// strictly after key).
+	cutAbove = func(key Row) int64 {
+		kv := key[columnIndex]
+		if kv.IsNull() {
+			return numRows // no safe cut: the slice comes out empty
+		}
+		p := sort.Search(numPages, func(p int) bool {
+			return orderCompare(earliest(p), kv) > 0
+		})
+		if p == 0 {
+			return 0
+		}
+		return pageEnd(p - 1)
+	}
+
+	// cutBelow: start of the first page whose latest value is at or after key
+	// (every row before the cut belongs to an earlier page, whose values are
+	// all strictly before key).
+	cutBelow = func(key Row) int64 {
+		kv := key[columnIndex]
+		if kv.IsNull() {
+			return 0 // no safe cut: the slice comes out empty
+		}
+		p := sort.Search(numPages, func(p int) bool {
+			return orderCompare(latest(p), kv) >= 0
+		})
+		if p == numPages {
+			return numRows
+		}
+		return oi.FirstRowIndex(p)
+	}
+
+	return cutAbove, cutBelow
+}
+
+// refineSegment plans the refinement of one overlapping segment, returning the
+// refined sub-segments: an alternation of merged regions (built with
+// makeMerged from two or more participants) and single-source row groups or
+// range views. It returns nil when no refinement applies, in which case the
+// caller merges the whole segment as usual.
+func refineSegment(targets []refineTarget, compare func(Row, Row) int, makeMerged func([]RowGroup) RowGroup) []RowGroup {
+	if len(targets) < 2 {
+		return nil
+	}
+
+	type event struct {
+		key   Row
+		start bool
+		index int
+	}
+
+	events := make([]event, 0, 2*len(targets))
+	for i := range targets {
+		events = append(events,
+			event{key: targets[i].minRow, start: true, index: i},
+			event{key: targets[i].maxRow, start: false, index: i},
+		)
+	}
+	slices.SortStableFunc(events, func(a, b event) int {
+		if c := compare(a.key, b.key); c != 0 {
+			return c
+		}
+		// Starts sort before ends so that touching ranges (a max equal to
+		// another's min) produce a merged region for the shared key instead
+		// of being falsely torn apart.
+		switch {
+		case a.start && !b.start:
+			return -1
+		case !a.start && b.start:
+			return +1
+		default:
+			return 0
+		}
+	})
+
+	// regionPart tracks the target index of each participant so merged
+	// regions can list participants deterministically in minRow order.
+	type regionPart struct {
+		index int
+		part  RowGroup
+	}
+
+	var (
+		plan    []RowGroup
+		region  []regionPart     // participants of the merged region being built
+		cursors map[int]int64    // rows of each target consumed by earlier regions
+		active  map[int]struct{} // targets whose key interval covers the sweep position
+		sliced  bool             // whether any lone slice was emitted
+
+		// pendingLone is set while the sweep is inside a stretch of key space
+		// covered by a single target; leftK is the exclusive lower bound of
+		// the stretch (nil at the start of the segment).
+		pendingLone  = -1
+		pendingLeftK Row
+	)
+	cursors = make(map[int]int64, len(targets))
+	active = make(map[int]struct{}, len(targets))
+
+	remainder := func(i int) (RowGroup, bool) {
+		t := &targets[i]
+		off := cursors[i]
+		if off >= t.numRows {
+			return nil, false
+		}
+		cursors[i] = t.numRows
+		if off == 0 {
+			return t.rowGroup, true
+		}
+		return newRowRangeRowGroup(t.rowGroup, off, t.numRows-off), true
+	}
+
+	closeRegion := func() {
+		switch len(region) {
+		case 0:
+		case 1:
+			plan = append(plan, region[0].part)
+		default:
+			slices.SortStableFunc(region, func(a, b regionPart) int { return a.index - b.index })
+			parts := make([]RowGroup, len(region))
+			for i, p := range region {
+				parts[i] = p.part
+			}
+			plan = append(plan, makeMerged(parts))
+		}
+		region = nil
+	}
+
+	// resolveLone ends the pending lone stretch, bounded above by rightK (nil
+	// at the end of the segment). When the stretch is sliceable and large
+	// enough, the region below it is closed and the slice emitted; otherwise
+	// the stretch simply remains part of the current region.
+	resolveLone := func(rightK Row) {
+		i := pendingLone
+		pendingLone = -1
+		t := &targets[i]
+		if t.cutAbove == nil || t.cutBelow == nil {
+			return
+		}
+		off := int64(0)
+		if pendingLeftK != nil {
+			off = t.cutAbove(pendingLeftK)
+		}
+		end := t.numRows
+		if rightK != nil {
+			end = t.cutBelow(rightK)
+		}
+		off = max(off, cursors[i])
+		end = min(end, t.numRows)
+		if end-off < minStreamedRegionRows {
+			return
+		}
+
+		// Close the region below the slice: every participant contributes its
+		// remaining rows (their key intervals ended inside the region), and
+		// the lone target contributes its rows before the slice.
+		if off > cursors[i] {
+			region = append(region, regionPart{index: i, part: newRowRangeRowGroup(t.rowGroup, cursors[i], off-cursors[i])})
+		}
+		closeRegion()
+
+		if off == 0 && end == t.numRows {
+			plan = append(plan, t.rowGroup)
+		} else {
+			plan = append(plan, newRowRangeRowGroup(t.rowGroup, off, end-off))
+		}
+		cursors[i] = end
+		sliced = true
+	}
+
+	for _, ev := range events {
+		if ev.start {
+			if pendingLone >= 0 {
+				resolveLone(ev.key)
+			}
+			active[ev.index] = struct{}{}
+			if len(active) == 1 {
+				// First target of the segment: it is alone until the next
+				// start event.
+				pendingLone = ev.index
+				pendingLeftK = nil
+			}
+		} else {
+			// If the ending target is the pending lone one, its stretch runs
+			// to the end of its rows: resolve before consuming the remainder.
+			if ev.index == pendingLone {
+				resolveLone(nil)
+			}
+			delete(active, ev.index)
+			if r, ok := remainder(ev.index); ok {
+				region = append(region, regionPart{index: ev.index, part: r})
+			}
+			if len(active) == 1 && pendingLone < 0 {
+				for lone := range active {
+					pendingLone = lone
+				}
+				pendingLeftK = ev.key
+			}
+		}
+	}
+	closeRegion()
+
+	if !sliced {
+		return nil
+	}
+	return plan
+}

--- a/merge_refine_internal_test.go
+++ b/merge_refine_internal_test.go
@@ -620,3 +620,88 @@ func TestMergeRefinementWrite(t *testing.T) {
 		}
 	})
 }
+
+func benchmarkMergeRefinement(b *testing.B, mode string, refine bool, write bool) {
+	const numFiles, rowsPerFile = 8, 20_000
+	files := make([]*File, numFiles)
+	for i := range files {
+		var start int64
+		switch mode {
+		case "chain": // ~2% boundary overlap with the next file
+			start = int64(i) * (rowsPerFile - rowsPerFile/50)
+		case "full_overlap":
+			start = int64(i) // all files cover ~the same range
+		case "slivers": // ~50% overlap: lone stretches straddle the floor
+			start = int64(i) * rowsPerFile / 2
+		}
+		rows := make([]benchRow, rowsPerFile)
+		for j := range rows {
+			id := start + int64(j)
+			rows[j] = benchRow{ID: id, Name: fmt.Sprintf("c%d", id%32), Email: fmt.Sprintf("u%d@x.com", id), Score: float64(id), Flag: id%2 == 0, Count: int32(id % 1000)}
+		}
+		var buf bytes.Buffer
+		w := NewGenericWriter[benchRow](&buf, SortingWriterConfig(SortingColumns(Ascending("id"))), PageBufferSize(4096))
+		if _, err := w.Write(rows); err != nil {
+			b.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			b.Fatal(err)
+		}
+		f, err := OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		if err != nil {
+			b.Fatal(err)
+		}
+		files[i] = f
+	}
+
+	defer func(prev bool) { disableMergeRefinement = prev }(disableMergeRefinement)
+	disableMergeRefinement = !refine
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		rgs := make([]RowGroup, numFiles)
+		for i, f := range files {
+			rgs[i] = f.RowGroups()[0]
+		}
+		m, err := MergeRowGroups(rgs,
+			&RowGroupConfig{Schema: rgs[0].Schema()},
+			SortingRowGroupConfig(SortingColumns(Ascending("id"))),
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if write {
+			w := NewGenericWriter[benchRow](io.Discard, SortingWriterConfig(SortingColumns(Ascending("id"))))
+			if _, err := w.WriteRowGroup(m); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			rows := m.Rows()
+			buf := make([]Row, 256)
+			for {
+				_, err := rows.ReadRows(buf)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			rows.Close()
+		}
+	}
+}
+
+func BenchmarkMergeRefinement(b *testing.B) {
+	for _, mode := range []string{"chain", "full_overlap", "slivers"} {
+		for _, op := range []string{"read", "write"} {
+			write := op == "write"
+			b.Run(fmt.Sprintf("%s/%s/refined", mode, op), func(b *testing.B) { benchmarkMergeRefinement(b, mode, true, write) })
+			b.Run(fmt.Sprintf("%s/%s/baseline", mode, op), func(b *testing.B) { benchmarkMergeRefinement(b, mode, false, write) })
+		}
+	}
+}

--- a/merge_refine_internal_test.go
+++ b/merge_refine_internal_test.go
@@ -490,3 +490,133 @@ func TestMergeRefinementSkippedWithDedup(t *testing.T) {
 		}
 	}
 }
+
+// refineWriteRow includes a repeated column so bloom sizing must handle
+// inexact range-view value counts.
+type refineWriteRow struct {
+	Key  int64   `parquet:"key"`
+	Src  string  `parquet:"src"`
+	List []int32 `parquet:"list,list"`
+}
+
+// TestMergeRefinementWrite writes refined merges through WriteRowGroup and
+// verifies that the streamed regions take the column-oriented fast paths, that
+// the output matches the row-path reference, and that a bloom filter on a
+// repeated column is built exactly despite range views only knowing an upper
+// bound of their value count.
+func TestMergeRefinementWrite(t *testing.T) {
+	newFile := func(src string, start, n int64) *File {
+		rows := make([]refineWriteRow, n)
+		for i := range rows {
+			rows[i] = refineWriteRow{Key: start + int64(i), Src: fmt.Sprintf("%s-%d", src, i)}
+			for j := range int(start+int64(i)) % 3 {
+				rows[i].List = append(rows[i].List, int32(j))
+			}
+		}
+		var buf bytes.Buffer
+		w := NewGenericWriter[refineWriteRow](&buf,
+			SortingWriterConfig(SortingColumns(Ascending("key"))), PageBufferSize(512))
+		if _, err := w.Write(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		f, err := OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return f
+	}
+
+	// Chain with ~4% boundary overlaps.
+	files := []*File{
+		newFile("a", 0, 5000),
+		newFile("b", 4800, 5000),
+		newFile("c", 9600, 5000),
+	}
+
+	write := func(refine bool, opts ...WriterOption) ([]byte, int64) {
+		defer func(prev bool) { disableMergeRefinement = prev }(disableMergeRefinement)
+		disableMergeRefinement = !refine
+		rgs := make([]RowGroup, len(files))
+		for i, f := range files {
+			rgs[i] = f.RowGroups()[0]
+		}
+		m, err := MergeRowGroups(rgs,
+			&RowGroupConfig{Schema: rgs[0].Schema()},
+			SortingRowGroupConfig(SortingColumns(Ascending("key"))),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var dst bytes.Buffer
+		opts = append(opts, SortingWriterConfig(SortingColumns(Ascending("key"))))
+		w := NewGenericWriter[refineWriteRow](&dst, opts...)
+		before := reencodePathCounter.Load()
+		if _, err := w.WriteRowGroup(m); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return dst.Bytes(), reencodePathCounter.Load() - before
+	}
+
+	refined, l3 := write(true)
+	reference, _ := write(false)
+
+	if l3 == 0 {
+		t.Fatal("expected refined merge to take the column-oriented fast path for streamed regions")
+	}
+
+	readAll := func(b []byte) []refineWriteRow {
+		r := NewGenericReader[refineWriteRow](bytes.NewReader(b))
+		defer r.Close()
+		out := make([]refineWriteRow, 16000)
+		n, _ := r.Read(out)
+		return out[:n]
+	}
+	gotR := readAll(refined)
+	gotRef := readAll(reference)
+	if len(gotR) != len(gotRef) {
+		t.Fatalf("refined write has %d rows, reference %d", len(gotR), len(gotRef))
+	}
+	for i := 1; i < len(gotR); i++ {
+		if gotR[i].Key < gotR[i-1].Key {
+			t.Fatalf("refined write output not sorted at %d", i)
+		}
+	}
+
+	t.Run("bloom_on_repeated_column", func(t *testing.T) {
+		out, _ := write(true, BloomFilters(SplitBlockFilter(10, "list", "list", "element")))
+		f, err := OpenFile(bytes.NewReader(out), int64(len(out)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		checked := 0
+		for _, rg := range f.RowGroups() {
+			var listChunk ColumnChunk
+			for _, c := range rg.ColumnChunks() {
+				if c.Type().Kind() == Int32 {
+					listChunk = c
+				}
+			}
+			bf := listChunk.BloomFilter()
+			if bf == nil {
+				continue // row groups whose column had no filter written
+			}
+			ok, err := bf.Check(ValueOf(int32(0)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("bloom filter misses value 0, present in every non-empty list")
+			}
+			checked++
+		}
+		if checked == 0 {
+			t.Fatal("no bloom filters found in refined output")
+		}
+	})
+}

--- a/merge_refine_internal_test.go
+++ b/merge_refine_internal_test.go
@@ -1,0 +1,492 @@
+package parquet
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// planTarget builds a refineTarget over a synthetic sorted key space
+// [minKey, maxKey] with numRows rows spread uniformly, and cut functions
+// rounded to pageRows-page boundaries (pageRows == 1 gives exact cuts).
+func planTarget(name string, minKey, maxKey, numRows, pageRows int64) refineTarget {
+	rg := &namedTestRowGroup{name: name, numRows: numRows}
+	keyOf := func(row int64) int64 {
+		if numRows == 1 {
+			return minKey
+		}
+		return minKey + row*(maxKey-minKey)/(numRows-1)
+	}
+	// exactCutAbove: smallest row such that all rows >= it have key > k.
+	exactCutAbove := func(k int64) int64 {
+		row := int64(0)
+		for row < numRows && keyOf(row) <= k {
+			row++
+		}
+		return row
+	}
+	// exactCutBelow: largest row such that all rows < it have key < k.
+	exactCutBelow := func(k int64) int64 {
+		row := int64(0)
+		for row < numRows && keyOf(row) < k {
+			row++
+		}
+		return row
+	}
+	return refineTarget{
+		rowGroup: rg,
+		minRow:   Row{ValueOf(minKey).Level(0, 0, 0)},
+		maxRow:   Row{ValueOf(maxKey).Level(0, 0, 0)},
+		numRows:  numRows,
+		cutAbove: func(key Row) int64 {
+			// Page rounding pushes the boundary page's rows below the cut...
+			// no: cutAbove keeps the page containing the key BELOW the cut,
+			// i.e. rounds UP to the page end.
+			row := exactCutAbove(key[0].Int64())
+			return min(((row+pageRows-1)/pageRows)*pageRows, numRows)
+		},
+		cutBelow: func(key Row) int64 {
+			// cutBelow keeps the page containing the key AT OR ABOVE the cut,
+			// i.e. rounds DOWN to the page start.
+			row := exactCutBelow(key[0].Int64())
+			return (row / pageRows) * pageRows
+		},
+	}
+}
+
+// namedTestRowGroup is a placeholder RowGroup carrying an identity; the
+// planner only reads NumRows and stores the reference.
+type namedTestRowGroup struct {
+	name    string
+	numRows int64
+}
+
+func (g *namedTestRowGroup) NumRows() int64                  { return g.numRows }
+func (g *namedTestRowGroup) ColumnChunks() []ColumnChunk     { return nil }
+func (g *namedTestRowGroup) Schema() *Schema                 { return nil }
+func (g *namedTestRowGroup) SortingColumns() []SortingColumn { return nil }
+func (g *namedTestRowGroup) Rows() Rows                      { return nil }
+
+// describePlan renders a plan compactly for assertions, e.g.
+// "A[0:5000) M(A[5000:10000) B) C".
+func describePlan(plan []RowGroup) string {
+	var describe func(rg RowGroup) string
+	describe = func(rg RowGroup) string {
+		switch g := rg.(type) {
+		case *namedTestRowGroup:
+			return g.name
+		case *rowRangeRowGroup:
+			base := describe(g.base)
+			return fmt.Sprintf("%s[%d:%d)", base, g.off, g.off+g.length)
+		case *testMergedGroup:
+			s := "M("
+			for i, p := range g.parts {
+				if i > 0 {
+					s += " "
+				}
+				s += describe(p)
+			}
+			return s + ")"
+		default:
+			return fmt.Sprintf("%T", rg)
+		}
+	}
+	out := ""
+	for i, rg := range plan {
+		if i > 0 {
+			out += " "
+		}
+		out += describe(rg)
+	}
+	return out
+}
+
+type testMergedGroup struct {
+	namedTestRowGroup
+	parts []RowGroup
+}
+
+func testMakeMerged(parts []RowGroup) RowGroup {
+	return &testMergedGroup{parts: parts}
+}
+
+func testCompareRows(a, b Row) int {
+	switch {
+	case a[0].Int64() < b[0].Int64():
+		return -1
+	case a[0].Int64() > b[0].Int64():
+		return +1
+	default:
+		return 0
+	}
+}
+
+func TestRefineSegmentPlan(t *testing.T) {
+	// Row groups: 10_000 rows each, uniform keys, exact cuts (pageRows=1)
+	// unless stated. Keys chosen so overlaps are a small fraction.
+	tests := []struct {
+		name    string
+		targets []refineTarget
+		want    string
+	}{
+		{
+			// A: keys [0, 9999], B: keys [9000, 18999] — boundary overlap.
+			// A alone below 9000 (rows [0:9000)), overlap [9000,9999],
+			// B alone above 9999.
+			name: "two_boundary_overlap",
+			targets: []refineTarget{
+				planTarget("A", 0, 9999, 10000, 1),
+				planTarget("B", 9000, 18999, 10000, 1),
+			},
+			want: "A[0:9000) M(A[9000:10000) B[0:1000)) B[1000:10000)",
+		},
+		{
+			// Chain: A [0,9999], B [9000,18999], C [18000,27999].
+			name: "chain_of_three",
+			targets: []refineTarget{
+				planTarget("A", 0, 9999, 10000, 1),
+				planTarget("B", 9000, 18999, 10000, 1),
+				planTarget("C", 18000, 27999, 10000, 1),
+			},
+			want: "A[0:9000) M(A[9000:10000) B[0:1000)) B[1000:9000) M(B[9000:10000) C[0:1000)) C[1000:10000)",
+		},
+		{
+			// Full containment: B inside A. A is lone on both sides.
+			name: "containment",
+			targets: []refineTarget{
+				planTarget("A", 0, 99990, 10000, 1),
+				planTarget("B", 40000, 60000, 5000, 1),
+			},
+			want: "A[0:4000) M(A[4000:6001) B) A[6001:10000)",
+		},
+		{
+			// Identical ranges: fully overlapping, nothing to refine.
+			name: "identical",
+			targets: []refineTarget{
+				planTarget("A", 0, 9999, 10000, 1),
+				planTarget("B", 0, 9999, 10000, 1),
+			},
+			want: "", // nil plan
+		},
+		{
+			// Overlap leaves lone stretches below the floor: no refinement.
+			name: "tiny_lone_stretches",
+			targets: []refineTarget{
+				planTarget("A", 0, 9999, 1500, 1),    // ~6.7 keys/row
+				planTarget("B", 500, 10499, 1500, 1), // A alone in [0,500): ~75 rows < floor
+			},
+			want: "",
+		},
+		{
+			// Cut functions unavailable on B: only A's stretches slice.
+			name: "unavailable_cuts",
+			targets: []refineTarget{
+				planTarget("A", 0, 9999, 10000, 1),
+				func() refineTarget {
+					t := planTarget("B", 9000, 18999, 10000, 1)
+					t.cutAbove = nil
+					t.cutBelow = nil
+					return t
+				}(),
+			},
+			want: "A[0:9000) M(A[9000:10000) B)",
+		},
+		{
+			// Page-rounded cuts (1000-row pages): boundaries snap so that the
+			// boundary pages stay in the merged region.
+			name: "page_rounded",
+			targets: []refineTarget{
+				planTarget("A", 0, 9999, 10000, 1000),
+				planTarget("B", 9000, 18999, 10000, 1000),
+			},
+			want: "A[0:9000) M(A[9000:10000) B[0:1000)) B[1000:10000)",
+		},
+		{
+			// Touching ranges (A.max == B.min): treated as overlapping; both
+			// boundary regions merge around the shared key.
+			name: "touching",
+			targets: []refineTarget{
+				planTarget("A", 0, 10000, 10001, 1),
+				planTarget("B", 10000, 20000, 10001, 1),
+			},
+			want: "A[0:10000) M(A[10000:10001) B[0:1)) B[1:10001)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := refineSegment(tt.targets, testCompareRows, testMakeMerged)
+			got := describePlan(plan)
+			if got != tt.want {
+				t.Fatalf("plan mismatch:\ngot  %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// refineOracleRow carries a sort key and provenance (source file, position).
+type refineOracleRow struct {
+	Key int64  `parquet:"key"`
+	Src string `parquet:"src"`
+}
+
+// TestMergeRefinementOracle verifies that refined merge plans produce the same
+// rows as the unrefined merge: identical multiset (checked via provenance),
+// globally sorted by key, and stable within each source (each file's rows
+// appear in their original relative order). The interleaving of equal keys
+// across files is implementation-defined and not compared.
+func TestMergeRefinementOracle(t *testing.T) {
+	newFile := func(t *testing.T, src string, keys []int64) *File {
+		rows := make([]refineOracleRow, len(keys))
+		for i, k := range keys {
+			rows[i] = refineOracleRow{Key: k, Src: fmt.Sprintf("%s-%d", src, i)}
+		}
+		var buf bytes.Buffer
+		w := NewGenericWriter[refineOracleRow](&buf,
+			SortingWriterConfig(SortingColumns(Ascending("key"))),
+			PageBufferSize(512), // small pages: fine-grained cuts
+		)
+		if _, err := w.Write(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		f, err := OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return f
+	}
+
+	seqKeys := func(start, n, dupEvery int64) []int64 {
+		keys := make([]int64, n)
+		for i := range keys {
+			keys[i] = start + int64(i)
+			if dupEvery > 0 && int64(i)%dupEvery == 0 && i > 0 {
+				keys[i] = keys[i-1] // duplicate across adjacent rows
+			}
+		}
+		return keys
+	}
+
+	scenarios := []struct {
+		name       string
+		files      map[string][]int64
+		wantRefine bool
+	}{
+		{
+			name: "chain_boundary_overlap",
+			files: map[string][]int64{
+				"a": seqKeys(0, 5000, 0),
+				"b": seqKeys(4800, 5000, 0),
+				"c": seqKeys(9600, 5000, 0),
+			},
+			wantRefine: true,
+		},
+		{
+			name: "containment",
+			files: map[string][]int64{
+				"outer": seqKeys(0, 8000, 0),
+				"inner": seqKeys(3000, 2000, 0),
+			},
+			wantRefine: true,
+		},
+		{
+			name: "duplicates_at_boundaries",
+			files: map[string][]int64{
+				"a": append(seqKeys(0, 4000, 7), 4000, 4000, 4000),
+				"b": append([]int64{4000, 4000}, seqKeys(4001, 4000, 5)...),
+			},
+			wantRefine: true,
+		},
+		{
+			name: "full_overlap_no_refinement",
+			files: map[string][]int64{
+				"a": seqKeys(0, 3000, 0),
+				"b": seqKeys(1, 3000, 0),
+			},
+			wantRefine: false,
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			var rowGroups []RowGroup
+			for _, name := range sortedKeys(sc.files) {
+				rowGroups = append(rowGroups, newFile(t, name, sc.files[name]).RowGroups()[0])
+			}
+
+			merge := func(refine bool) (RowGroup, []refineOracleRow) {
+				defer func(prev bool) { disableMergeRefinement = prev }(disableMergeRefinement)
+				disableMergeRefinement = !refine
+				m, err := MergeRowGroups(rowGroups, SortingRowGroupConfig(SortingColumns(Ascending("key"))))
+				if err != nil {
+					t.Fatal(err)
+				}
+				rows := m.Rows()
+				defer rows.Close()
+				var out []refineOracleRow
+				buf := make([]Row, 97)
+				for {
+					n, err := rows.ReadRows(buf)
+					for _, row := range buf[:n] {
+						out = append(out, refineOracleRow{Key: row[0].Int64(), Src: row[1].String()})
+					}
+					if err == io.EOF {
+						break
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if n == 0 {
+						t.Fatal("no progress")
+					}
+				}
+				return m, out
+			}
+
+			refinedGroup, refined := merge(true)
+			_, reference := merge(false)
+
+			// Structure: refinement fired (or not) as expected.
+			hasRange := false
+			if seg, ok := refinedGroup.(*sortedSegmentRowGroup); ok {
+				for _, s := range seg.segments {
+					if _, ok := s.(*rowRangeRowGroup); ok {
+						hasRange = true
+					}
+				}
+			}
+			if hasRange != sc.wantRefine {
+				t.Fatalf("refinement fired = %v, want %v (merged type %T)", hasRange, sc.wantRefine, refinedGroup)
+			}
+
+			// Same number of rows, globally sorted.
+			if len(refined) != len(reference) {
+				t.Fatalf("refined %d rows, reference %d", len(refined), len(reference))
+			}
+			for i := 1; i < len(refined); i++ {
+				if refined[i].Key < refined[i-1].Key {
+					t.Fatalf("refined output not sorted at %d: %d < %d", i, refined[i].Key, refined[i-1].Key)
+				}
+			}
+
+			// Multiset equality via provenance.
+			seen := make(map[refineOracleRow]int, len(reference))
+			for _, r := range reference {
+				seen[r]++
+			}
+			for _, r := range refined {
+				seen[r]--
+				if seen[r] < 0 {
+					t.Fatalf("row %+v appears more times in refined than reference", r)
+				}
+			}
+
+			// Per-source stability: each file's rows appear in original order.
+			lastPos := make(map[string]int)
+			for _, r := range refined {
+				sep := strings.LastIndexByte(r.Src, '-')
+				src := r.Src[:sep]
+				pos, err := strconv.Atoi(r.Src[sep+1:])
+				if err != nil {
+					t.Fatalf("bad provenance %q: %v", r.Src, err)
+				}
+				if last, ok := lastPos[src]; ok && pos < last {
+					t.Fatalf("source %q rows out of order: position %d after %d", src, pos, last)
+				}
+				lastPos[src] = pos
+			}
+		})
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestMergeRefinementSkippedWithDedup verifies that DropDuplicatedRows disables
+// refinement (which duplicate of an equal-key run survives depends on tie
+// interleaving, which refinement does not preserve) while deduplication remains
+// correct.
+func TestMergeRefinementSkippedWithDedup(t *testing.T) {
+	newFile := func(keys []int64) *File {
+		rows := make([]refineOracleRow, len(keys))
+		for i, k := range keys {
+			rows[i] = refineOracleRow{Key: k, Src: fmt.Sprintf("s-%d", i)}
+		}
+		var buf bytes.Buffer
+		w := NewGenericWriter[refineOracleRow](&buf,
+			SortingWriterConfig(SortingColumns(Ascending("key"))), PageBufferSize(512))
+		if _, err := w.Write(rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		f, err := OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return f
+	}
+
+	keysA := make([]int64, 5000)
+	keysB := make([]int64, 5000)
+	for i := range keysA {
+		keysA[i] = int64(i)
+		keysB[i] = int64(i + 4500) // overlap [4500, 4999] with duplicates
+	}
+	fa, fb := newFile(keysA), newFile(keysB)
+
+	m, err := MergeRowGroups(
+		[]RowGroup{fa.RowGroups()[0], fb.RowGroups()[0]},
+		SortingRowGroupConfig(SortingColumns(Ascending("key")), DropDuplicatedRows(true)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seg, ok := m.(*sortedSegmentRowGroup); ok {
+		for _, s := range seg.segments {
+			if _, isRange := s.(*rowRangeRowGroup); isRange {
+				t.Fatal("refinement must not fire when dropping duplicated rows")
+			}
+		}
+	}
+
+	rows := m.Rows()
+	defer rows.Close()
+	var keys []int64
+	buf := make([]Row, 64)
+	for {
+		n, err := rows.ReadRows(buf)
+		for _, row := range buf[:n] {
+			keys = append(keys, row[0].Int64())
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Deduplicated union of [0,4999] and [4500,9499] is [0,9499].
+	if len(keys) != 9500 {
+		t.Fatalf("deduplicated to %d rows, want 9500", len(keys))
+	}
+	for i, k := range keys {
+		if k != int64(i) {
+			t.Fatalf("key %d at position %d", k, i)
+		}
+	}
+}

--- a/merge_refine_internal_test.go
+++ b/merge_refine_internal_test.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -317,7 +318,7 @@ func TestMergeRefinementOracle(t *testing.T) {
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
 			var rowGroups []RowGroup
-			for _, name := range sortedKeys(sc.files) {
+			for _, name := range slices.Sorted(maps.Keys(sc.files)) {
 				rowGroups = append(rowGroups, newFile(t, name, sc.files[name]).RowGroups()[0])
 			}
 
@@ -404,15 +405,6 @@ func TestMergeRefinementOracle(t *testing.T) {
 			}
 		})
 	}
-}
-
-func sortedKeys[V any](m map[string]V) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 // TestMergeRefinementSkippedWithDedup verifies that DropDuplicatedRows disables

--- a/row_range.go
+++ b/row_range.go
@@ -38,11 +38,13 @@ func newRowRangeRowGroup(base RowGroup, off, length int64) *rowRangeRowGroup {
 	// The value count of a row range is only knowable from metadata when each
 	// row holds exactly one value, i.e. for non-repeated columns.
 	repeated := make([]bool, len(baseChunks))
-	forEachLeafColumnOf(base.Schema(), func(leaf leafColumn) {
-		if int(leaf.columnIndex) < len(repeated) {
-			repeated[leaf.columnIndex] = leaf.maxRepetitionLevel > 0
-		}
-	})
+	if schema := base.Schema(); schema != nil {
+		forEachLeafColumnOf(schema, func(leaf leafColumn) {
+			if int(leaf.columnIndex) < len(repeated) {
+				repeated[leaf.columnIndex] = leaf.maxRepetitionLevel > 0
+			}
+		})
+	}
 
 	for i, chunk := range baseChunks {
 		rg.chunks[i] = &rangeColumnChunk{

--- a/row_range.go
+++ b/row_range.go
@@ -1,0 +1,174 @@
+package parquet
+
+import (
+	"fmt"
+	"io"
+)
+
+// This file implements row-range views of row groups: a rowRangeRowGroup
+// presents rows [off, off+length) of a base row group, with column chunks that
+// seek to the range start and stop after the range's row count. Range views are
+// produced by the merge planner (see merge_refine.go) to slice partially
+// overlapping row groups into disjoint stretches — which stream through the
+// writer's column-oriented fast paths — and truly overlapping stretches, which
+// go through the loser-tree merge.
+
+// rowRangeRowGroup is a view of rows [off, off+length) of a base row group.
+type rowRangeRowGroup struct {
+	base   RowGroup
+	off    int64
+	length int64
+	chunks []ColumnChunk
+}
+
+// newRowRangeRowGroup returns a view of rows [off, off+length) of base. The
+// caller is responsible for bounds: 0 <= off, off+length <= base.NumRows(),
+// length > 0, and for not constructing views that span the whole base row
+// group (use the base row group directly instead, which preserves its
+// eligibility for the verbatim copy fast path).
+func newRowRangeRowGroup(base RowGroup, off, length int64) *rowRangeRowGroup {
+	baseChunks := base.ColumnChunks()
+	rg := &rowRangeRowGroup{
+		base:   base,
+		off:    off,
+		length: length,
+		chunks: make([]ColumnChunk, len(baseChunks)),
+	}
+
+	// The value count of a row range is only knowable from metadata when each
+	// row holds exactly one value, i.e. for non-repeated columns.
+	repeated := make([]bool, len(baseChunks))
+	forEachLeafColumnOf(base.Schema(), func(leaf leafColumn) {
+		if int(leaf.columnIndex) < len(repeated) {
+			repeated[leaf.columnIndex] = leaf.maxRepetitionLevel > 0
+		}
+	})
+
+	for i, chunk := range baseChunks {
+		rg.chunks[i] = &rangeColumnChunk{
+			base:   chunk,
+			off:    off,
+			length: length,
+			exact:  !repeated[i],
+		}
+	}
+	return rg
+}
+
+func (rg *rowRangeRowGroup) NumRows() int64                  { return rg.length }
+func (rg *rowRangeRowGroup) ColumnChunks() []ColumnChunk     { return rg.chunks }
+func (rg *rowRangeRowGroup) Schema() *Schema                 { return rg.base.Schema() }
+func (rg *rowRangeRowGroup) SortingColumns() []SortingColumn { return rg.base.SortingColumns() }
+func (rg *rowRangeRowGroup) Rows() Rows                      { return NewRowGroupRowReader(rg) }
+
+// chunkTransparentRowGroup marks range views as safe for the chunk-level write
+// fast paths: Rows() is NewRowGroupRowReader over the range chunks, so reading
+// the chunks in order is the definition of its row semantics.
+func (rg *rowRangeRowGroup) chunkTransparentRowGroup() {}
+
+// rangeColumnChunk presents rows [off, off+length) of a base column chunk.
+type rangeColumnChunk struct {
+	base   ColumnChunk
+	off    int64
+	length int64
+	exact  bool // NumValues is exact (non-repeated column)
+}
+
+func (c *rangeColumnChunk) Type() Type  { return c.base.Type() }
+func (c *rangeColumnChunk) Column() int { return c.base.Column() }
+
+func (c *rangeColumnChunk) Pages() Pages {
+	pages := c.base.Pages()
+	if err := pages.SeekToRow(c.off); err != nil {
+		pages.Close()
+		return &errorPages{err: fmt.Errorf("seeking to start of row range at %d: %w", c.off, err)}
+	}
+	return &rangePages{base: pages, off: c.off, length: c.length, remaining: c.length}
+}
+
+// The page index and bloom filter of the base chunk describe all of its rows;
+// exposing them for a sub-range would let consumers draw wrong conclusions
+// (e.g. bounds that rows in the range never reach), so range views report them
+// as absent.
+func (c *rangeColumnChunk) ColumnIndex() (ColumnIndex, error) { return nil, ErrMissingColumnIndex }
+func (c *rangeColumnChunk) OffsetIndex() (OffsetIndex, error) { return nil, ErrMissingOffsetIndex }
+func (c *rangeColumnChunk) BloomFilter() BloomFilter          { return nil }
+
+// NumValues returns the number of values in the row range. For non-repeated
+// columns this is exactly the row count; for repeated columns the count is not
+// knowable from metadata and the base chunk's total is returned as an upper
+// bound (see exactNumValues).
+func (c *rangeColumnChunk) NumValues() int64 {
+	if c.exact {
+		return c.length
+	}
+	return c.base.NumValues()
+}
+
+// exactNumValues reports whether NumValues is exact rather than an upper
+// bound. Consumers that size resources from NumValues (bloom filters) must
+// check this and fall back when the count is inexact.
+func (c *rangeColumnChunk) exactNumValues() bool { return c.exact }
+
+// rangePages limits a Pages stream positioned inside its base column chunk to
+// the rows [off, off+length) of the base, slicing the final page when the
+// range ends mid-page.
+type rangePages struct {
+	base      Pages
+	off       int64 // start of the range, in base row indexes
+	length    int64
+	remaining int64
+}
+
+func (p *rangePages) ReadPage() (Page, error) {
+	if p.remaining <= 0 {
+		return nil, io.EOF
+	}
+	page, err := p.base.ReadPage()
+	if err != nil {
+		return nil, err
+	}
+	numRows := page.NumRows()
+	if numRows <= p.remaining {
+		p.remaining -= numRows
+		return page, nil
+	}
+	// The range ends inside this page. The slice shares the page's underlying
+	// buffers without incrementing their reference counts, so ownership of the
+	// page transfers to the caller through the slice: the caller's Release of
+	// the slice releases the shared buffers.
+	tail := page.Slice(0, p.remaining)
+	p.remaining = 0
+	return tail, nil
+}
+
+// SeekToRow positions the stream on the row at index rowIndex within the
+// range (i.e. relative to the start of the range, not of the base chunk).
+func (p *rangePages) SeekToRow(rowIndex int64) error {
+	if rowIndex < 0 || rowIndex > p.length {
+		return fmt.Errorf("SeekToRow: row index %d out of range of row range view of %d rows", rowIndex, p.length)
+	}
+	if err := p.base.SeekToRow(p.off + rowIndex); err != nil {
+		return err
+	}
+	p.remaining = p.length - rowIndex
+	return nil
+}
+
+func (p *rangePages) Close() error {
+	p.remaining = 0
+	return p.base.Close()
+}
+
+// errorPages is a Pages implementation which returns an error on every read.
+type errorPages struct{ err error }
+
+func (p *errorPages) ReadPage() (Page, error) { return nil, p.err }
+func (p *errorPages) SeekToRow(int64) error   { return p.err }
+func (p *errorPages) Close() error            { return nil }
+
+var (
+	_ RowGroup    = (*rowRangeRowGroup)(nil)
+	_ ColumnChunk = (*rangeColumnChunk)(nil)
+	_ Pages       = (*rangePages)(nil)
+)

--- a/row_range_internal_test.go
+++ b/row_range_internal_test.go
@@ -1,0 +1,207 @@
+package parquet
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+type rangeTestRow struct {
+	ID   int64    `parquet:"id"`
+	Name string   `parquet:"name,dict"`
+	Opt  *float64 `parquet:"opt,optional"`
+	List []int32  `parquet:"list,list"`
+}
+
+func makeRangeTestRows(n int) []rangeTestRow {
+	rows := make([]rangeTestRow, n)
+	for i := range rows {
+		rows[i] = rangeTestRow{ID: int64(i), Name: fmt.Sprintf("n%d", i%7)}
+		if i%3 != 0 {
+			v := float64(i) * 0.5
+			rows[i].Opt = &v
+		}
+		// Variable-length lists (including empty) exercise repeated columns
+		// where row count != value count.
+		for j := range i % 4 {
+			rows[i].List = append(rows[i].List, int32(i+j))
+		}
+	}
+	return rows
+}
+
+func writeRangeTestFile(t testing.TB, rows []rangeTestRow, opts ...WriterOption) *File {
+	t.Helper()
+	var buf bytes.Buffer
+	w := NewGenericWriter[rangeTestRow](&buf, opts...)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func readRowGroupRows(t *testing.T, rg RowGroup) []Row {
+	t.Helper()
+	rows := rg.Rows()
+	defer rows.Close()
+	var out []Row
+	buf := make([]Row, 33) // odd batch size to exercise batch boundaries
+	for {
+		n, err := rows.ReadRows(buf)
+		for _, row := range buf[:n] {
+			out = append(out, row.Clone())
+		}
+		if err == io.EOF {
+			return out
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n == 0 {
+			t.Fatal("no progress")
+		}
+	}
+}
+
+// TestRowRangeRowGroup verifies that a range view of a file row group returns
+// exactly the base rows [off, off+length), across offsets that start and end
+// mid-page, with optional and repeated columns, for both data page versions.
+func TestRowRangeRowGroup(t *testing.T) {
+	rows := makeRangeTestRows(1000)
+
+	for _, version := range []int{1, 2} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			// Small pages so ranges span several pages and cut mid-page.
+			f := writeRangeTestFile(t, rows, DataPageVersion(version), PageBufferSize(1024))
+			base := f.RowGroups()[0]
+			all := readRowGroupRows(t, base)
+			if len(all) != len(rows) {
+				t.Fatalf("base read %d rows, want %d", len(all), len(rows))
+			}
+
+			for _, r := range []struct{ off, length int64 }{
+				{0, 10},    // prefix
+				{990, 10},  // suffix
+				{1, 998},   // all but first and last
+				{500, 1},   // single mid-file row
+				{123, 456}, // arbitrary mid-page to mid-page
+			} {
+				t.Run(fmt.Sprintf("off=%d,len=%d", r.off, r.length), func(t *testing.T) {
+					view := newRowRangeRowGroup(base, r.off, r.length)
+					if got := view.NumRows(); got != r.length {
+						t.Fatalf("NumRows = %d, want %d", got, r.length)
+					}
+					got := readRowGroupRows(t, view)
+					if int64(len(got)) != r.length {
+						t.Fatalf("read %d rows, want %d", len(got), r.length)
+					}
+					for i, row := range got {
+						want := all[r.off+int64(i)]
+						if !row.Equal(want) {
+							t.Fatalf("row %d differs:\ngot  %v\nwant %v", i, row, want)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestRowRangeRowGroupWriteRoundTrip writes range views through a writer (which
+// exercises the column-oriented read paths end to end) and verifies the output.
+func TestRowRangeRowGroupWriteRoundTrip(t *testing.T) {
+	rows := makeRangeTestRows(600)
+	f := writeRangeTestFile(t, rows, PageBufferSize(2048))
+	base := f.RowGroups()[0]
+
+	var dst bytes.Buffer
+	w := NewGenericWriter[rangeTestRow](&dst)
+	// Two disjoint ranges written in order: rows [50, 250) and [250, 600).
+	for _, r := range []struct{ off, length int64 }{{50, 200}, {250, 350}} {
+		if _, err := w.WriteRowGroup(newRowRangeRowGroup(base, r.off, r.length)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewGenericReader[rangeTestRow](bytes.NewReader(dst.Bytes()))
+	defer r.Close()
+	got := make([]rangeTestRow, 600)
+	n, _ := r.Read(got)
+	if n != 550 {
+		t.Fatalf("read %d rows, want 550", n)
+	}
+	// Normalize nil vs empty list representations before comparing.
+	normalize := func(rows []rangeTestRow) {
+		for i := range rows {
+			if len(rows[i].List) == 0 {
+				rows[i].List = nil
+			}
+		}
+	}
+	want := slices.Clone(rows[50:600])
+	normalize(got[:n])
+	normalize(want)
+	if !reflect.DeepEqual(got[:n], want) {
+		t.Fatal("round-tripped range rows differ from source")
+	}
+}
+
+// TestRangeColumnChunkMetadata verifies metadata suppression and NumValues
+// exactness reporting.
+func TestRangeColumnChunkMetadata(t *testing.T) {
+	rows := makeRangeTestRows(100)
+	f := writeRangeTestFile(t, rows)
+	view := newRowRangeRowGroup(f.RowGroups()[0], 10, 50)
+
+	schema := f.RowGroups()[0].Schema()
+	repeated := make([]bool, len(view.chunks))
+	forEachLeafColumnOf(schema, func(leaf leafColumn) {
+		repeated[leaf.columnIndex] = leaf.maxRepetitionLevel > 0
+	})
+
+	sawRepeated := false
+	for i, chunk := range view.chunks {
+		rc := chunk.(*rangeColumnChunk)
+		if _, err := rc.ColumnIndex(); err != ErrMissingColumnIndex {
+			t.Fatalf("column %d: ColumnIndex error = %v, want ErrMissingColumnIndex", i, err)
+		}
+		if _, err := rc.OffsetIndex(); err != ErrMissingOffsetIndex {
+			t.Fatalf("column %d: OffsetIndex error = %v, want ErrMissingOffsetIndex", i, err)
+		}
+		if rc.BloomFilter() != nil {
+			t.Fatalf("column %d: BloomFilter should be nil", i)
+		}
+		if repeated[i] {
+			sawRepeated = true
+			if rc.exactNumValues() {
+				t.Fatalf("column %d: repeated column must not report exact NumValues", i)
+			}
+			if rc.NumValues() < 50 {
+				t.Fatalf("column %d: NumValues upper bound %d below row count", i, rc.NumValues())
+			}
+		} else {
+			if !rc.exactNumValues() {
+				t.Fatalf("column %d: non-repeated column must report exact NumValues", i)
+			}
+			if rc.NumValues() != 50 {
+				t.Fatalf("column %d: NumValues = %d, want 50", i, rc.NumValues())
+			}
+		}
+	}
+	if !sawRepeated {
+		t.Fatal("test schema must include a repeated column")
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -888,8 +888,34 @@ func (rg *ConcurrentRowGroupWriter) reset() {
 func (rg *ConcurrentRowGroupWriter) configureBloomFilters(columnChunks []ColumnChunk) {
 	for i, c := range rg.columns {
 		if c.columnFilter != nil {
+			// When the source only knows an upper bound of its value count
+			// (row-range views of repeated columns), leave the filter
+			// unallocated: flushFilterPages then builds it from the actual
+			// number of values written, keeping the filter exactly the size
+			// the configuration prescribes.
+			if !chunkNumValuesIsExact(columnChunks[i]) {
+				continue
+			}
 			c.resizeBloomFilter(columnChunks[i].NumValues())
 		}
+	}
+}
+
+// chunkNumValuesIsExact reports whether chunk.NumValues() is the exact number
+// of values, as opposed to an upper bound (see rangeColumnChunk).
+func chunkNumValuesIsExact(chunk ColumnChunk) bool {
+	switch c := chunk.(type) {
+	case *rangeColumnChunk:
+		return c.exactNumValues()
+	case *multiColumnChunk:
+		for _, part := range c.chunks {
+			if !chunkNumValuesIsExact(part) {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
 	}
 }
 

--- a/writer.go
+++ b/writer.go
@@ -890,6 +890,14 @@ func (rg *ConcurrentRowGroupWriter) configureBloomFilters(columnChunks []ColumnC
 		if c.columnFilter == nil {
 			continue
 		}
+		// When the source only knows an upper bound of its value count
+		// (row-range views of repeated columns), leave the filter
+		// unallocated: flushFilterPages then builds it from the actual
+		// number of values written, keeping the filter exactly the size
+		// the configuration prescribes.
+		if !chunkNumValuesIsExact(columnChunks[i]) {
+			continue
+		}
 		values := columnChunks[i].NumValues()
 		if numRows > rg.maxRows {
 			// The input will be split across multiple output row groups, so the
@@ -906,6 +914,24 @@ func (rg *ConcurrentRowGroupWriter) configureBloomFilters(columnChunks []ColumnC
 			values = min(values, rg.maxRows)
 		}
 		c.resizeBloomFilter(values)
+	}
+}
+
+// chunkNumValuesIsExact reports whether chunk.NumValues() is the exact number
+// of values, as opposed to an upper bound (see rangeColumnChunk).
+func chunkNumValuesIsExact(chunk ColumnChunk) bool {
+	switch c := chunk.(type) {
+	case *rangeColumnChunk:
+		return c.exactNumValues()
+	case *multiColumnChunk:
+		for _, part := range c.chunks {
+			if !chunkNumValuesIsExact(part) {
+				return false
+			}
+		}
+		return true
+	default:
+		return true
 	}
 }
 

--- a/writer_reencode.go
+++ b/writer_reencode.go
@@ -52,10 +52,7 @@ func (w *Writer) columnOrientedRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool)
 		return nil, false
 	}
 	for _, col := range columns {
-		switch col.(type) {
-		case *FileColumnChunk:
-		case ColumnBuffer:
-		default:
+		if !columnOrientedChunk(col) {
 			return nil, false
 		}
 	}
@@ -63,6 +60,22 @@ func (w *Writer) columnOrientedRowGroup(rowGroup RowGroup) ([]ColumnChunk, bool)
 		return nil, false
 	}
 	return columns, true
+}
+
+// columnOrientedChunk reports whether a column chunk can be read column-wise
+// while preserving row order: file-backed chunks, in-memory column buffers,
+// and row-range views over either.
+func columnOrientedChunk(col ColumnChunk) bool {
+	switch c := col.(type) {
+	case *FileColumnChunk:
+		return true
+	case ColumnBuffer:
+		return true
+	case *rangeColumnChunk:
+		return columnOrientedChunk(c.base)
+	default:
+		return false
+	}
 }
 
 // reencodableRowGroup reports whether rowGroup can be written via the L3
@@ -157,17 +170,25 @@ func (w *Writer) packSegmentsByColumn(segments []RowGroup, schema *Schema, sorti
 }
 
 // configureBloomFiltersForSegments sizes each column's bloom filter for the
-// total number of values across all segments being packed together.
+// total number of values across all segments being packed together. Columns
+// whose value count is only an upper bound (row-range views of repeated
+// columns) are left unallocated so flushFilterPages sizes the filter from the
+// number of values actually written.
 func (w *Writer) configureBloomFiltersForSegments(segments []RowGroup) {
 	for i, c := range w.writer.currentRowGroup.columns {
 		if c.columnFilter == nil {
 			continue
 		}
-		var total int64
+		total := int64(0)
+		exact := true
 		for _, seg := range segments {
-			total += seg.ColumnChunks()[i].NumValues()
+			chunk := seg.ColumnChunks()[i]
+			exact = exact && chunkNumValuesIsExact(chunk)
+			total += chunk.NumValues()
 		}
-		c.resizeBloomFilter(total)
+		if exact {
+			c.resizeBloomFilter(total)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #535/#562/#567/#568/#572/#573. Overlap in `MergeRowGroups` was classified at **whole-row-group granularity**: one row of overlap condemned both row groups to the row-by-row merge in full. Time-ordered files overlapping only around their boundaries — the common compaction input — merged 100% of their rows to resolve a ~1–2% overlap.

Overlapping segments are now **refined**: a key-space sweep over the exact row-group bounds finds the stretches covered by a single row group and slices them off as **row-range views**, which stream through the column-oriented write fast paths; only the truly overlapping stretches go to the loser-tree merge.

## Design

- **`rowRangeRowGroup` / `rangeColumnChunk`** (`row_range.go`): a view of rows `[off, off+len)` of a base row group; `Pages()` seeks to the range start and row-limits reads, slicing the tail page. `Rows()` is `NewRowGroupRowReader(self)`, so reading the chunks in order *is* the view's row semantics — it opts into the chunk-transparency marker on that basis. Base-chunk page index/bloom filter are reported absent (they describe all rows, not the range).
- **Lone-only cuts** (`merge_refine.go`): cuts are only applied to the row group that is *alone* in a stretch, validated against the exact bounds of the others. This sidesteps a subtle hazard found during design: page-granular cuts of *different* row groups at one nominal boundary key land at different actual keys and can reorder rows across regions. With lone-only cuts, region concatenation provably preserves sorted order, and cross-group ties always land in merged regions.
- **Page-granular planning**: cut rows come from binary searches over the first sorting column's column/offset indexes (descending-aware); planning decodes no pages. Missing indexes or null pages disable slicing for that row group only; sub-1024-row stretches stay merged; a plan with no surviving slices falls back to exactly today's behavior.
- **Contract**: sorted output, per-source row order, same multiset — verified by an oracle. Cross-group tie interleaving is implementation-defined (it already differs between merge arities), so refinement is **skipped under `DropDuplicatedRows`**, where tie order decides which duplicate survives.
- **Exact bloom filters without demotion**: range views of repeated columns only know an upper bound of their value count. Instead of demoting, the writer skips filter preallocation for inexact counts and lets `flushFilterPages` build the filter post hoc from the values actually written (its pre-existing fallback), keeping filters exactly the configured size on every path.

## Benchmarks (8 files × 20k rows, ~2% boundary-overlap chain, 4KB source pages, M4 Max)

| workload | baseline | refined | delta |
|---|---|---|---|
| chain / write | 22.9ms | 11.6ms | **~1.9×, 2.5× less memory** |
| chain / read | 11.4ms | 9.5ms | ~1.2× |
| full overlap (read/write) | — | — | unchanged |
| slivers (~50% overlap) | — | — | slightly positive |

The write side gains more because streamed regions skip row assembly entirely (L3/packing); the read side is already served by the loser-tree run detection (#572/#573). Note: refinement needs multiple pages per source chunk to find cut points — single-page chunks correctly no-op.

## Testing

- **Pure-function planner** unit tests: chains, containment, touching bounds, page rounding, unavailable indexes, sub-floor stretches — exact plan shapes asserted.
- **Oracle** (`disableMergeRefinement` flag): refined vs unrefined on real files — sorted, per-source stable, multiset-equal via per-row provenance — including duplicates straddling region boundaries.
- **Range-view mechanics**: mid-page offsets, tail-page slicing, optional + repeated columns, DataPage V1 and V2, write round-trips.
- **Dedup skip** pinned; **write integration** verifies fast paths fire and bloom filters on repeated columns remain functional through range views.
- Full `./...` + `-race` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)