### PR TITLE
Fix index out of range panic in multiColumnChunk.OffsetIndex on merged row groups

### DIFF
--- a/multi_row_group.go
+++ b/multi_row_group.go
@@ -218,10 +218,20 @@ func (c *multiColumnChunk) OffsetIndex() (OffsetIndex, error) {
 		offsets[i+1] = offsets[i] + index.NumPages()
 	}
 
-	// Build cumulative row offsets for each chunk
+	// Build cumulative row offsets for each chunk. Use rowCounts when
+	// available (flattened chunks), otherwise fall back to rowGroups; the
+	// chunk count can exceed len(rowGroups) when merging already-merged
+	// row groups.
+	rowCounts := c.rowCounts
 	rowOffsets := make([]int64, len(c.chunks)+1)
 	for i := range c.chunks {
-		rowOffsets[i+1] = rowOffsets[i] + c.rowGroup.rowGroups[i].NumRows()
+		var numRows int64
+		if i < len(rowCounts) {
+			numRows = rowCounts[i]
+		} else {
+			numRows = c.rowGroup.rowGroups[i].NumRows()
+		}
+		rowOffsets[i+1] = rowOffsets[i] + numRows
 	}
 
 	return &multiOffsetIndex{

--- a/multi_row_group_test.go
+++ b/multi_row_group_test.go
@@ -525,3 +525,30 @@ func TestMultiOffsetIndexErrors(t *testing.T) {
 		t.Errorf("OffsetIndex() NumPages() = %d, expected > 0", index.NumPages())
 	}
 }
+
+func TestMultiOffsetIndexMergedRowGroups(t *testing.T) {
+	// Merging already-merged row groups flattens the nested chunks, so a
+	// column chunk ends up with more chunks than the outer merge has row
+	// groups. OffsetIndex used to index rowGroups by the chunk position,
+	// which ran past the end of the slice and panicked.
+	inner := makeMultiRowGroupWithBloomFilters(t, []rowGroupConfig{
+		{numRows: 10, startID: 0, valuePrefix: "a"},
+		{numRows: 20, startID: 100, valuePrefix: "b"},
+	})
+
+	merged := parquet.MultiRowGroup(inner, inner)
+
+	index, err := merged.ColumnChunks()[0].OffsetIndex()
+	if err != nil {
+		t.Fatalf("OffsetIndex() error: %v", err)
+	}
+
+	prevRowIndex := int64(-1)
+	for i := range index.NumPages() {
+		rowIndex := index.FirstRowIndex(i)
+		if rowIndex < prevRowIndex {
+			t.Errorf("Page %d FirstRowIndex() = %d, expected >= %d", i, rowIndex, prevRowIndex)
+		}
+		prevRowIndex = rowIndex
+	}
+}


### PR DESCRIPTION
Merging already-merged row groups flattens the nested chunks, so a `multiColumnChunk` can end up with more chunks than the outer merge has row groups. `OffsetIndex` indexed `rowGroup.rowGroups` by the chunk position, which runs past the end of that slice and panics with `index out of range`. This uses the per-chunk `rowCounts` (already populated during flattening) when available, matching what `SeekToRow` already does, and falls back to `rowGroups` otherwise.

Fixes #575.