### PR TITLE
fix(writer): later rowgroups can overwrite earlier page counts

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1759,7 +1759,7 @@ func (w *writer) writeRowGroup(rg *ConcurrentRowGroupWriter, rowGroupSchema *Sch
 	}
 	for i := range columns {
 		c := &columns[i]
-		c.MetaData.EncodingStats = append(c.MetaData.EncodingStats[:0], rg.columnChunk[i].MetaData.EncodingStats...)
+		c.MetaData.EncodingStats = slices.Clone(rg.columnChunk[i].MetaData.EncodingStats)
 	}
 
 	for i := range offsetIndex {

--- a/writer_test.go
+++ b/writer_test.go
@@ -1960,6 +1960,63 @@ func TestWriterMaxRowsPerRowGroup(t *testing.T) {
 	}
 }
 
+func TestWriterEncodingStatsDoNotAliasRowGroups(t *testing.T) {
+	type Row struct {
+		Value string `parquet:"value,plain"`
+	}
+
+	output := new(bytes.Buffer)
+	writer := parquet.NewGenericWriter[Row](output, parquet.PageBufferSize(64))
+
+	writeRow := func(value string) {
+		t.Helper()
+		if _, err := writer.Write([]Row{{Value: value}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := range 3 {
+		writeRow(strings.Repeat(string(rune('a'+i)), 128))
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	writeRow(strings.Repeat("z", 128))
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := parquet.OpenFile(bytes.NewReader(output.Bytes()), int64(output.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.RowGroups()) != 2 {
+		t.Fatalf("wrong number of row groups: got %d, want 2", len(f.RowGroups()))
+	}
+
+	wantPages := []int{3, 1}
+	for i, rowGroup := range f.RowGroups() {
+		offsetIndex, err := rowGroup.ColumnChunks()[0].OffsetIndex()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if numPages := offsetIndex.NumPages(); numPages != wantPages[i] {
+			t.Fatalf("row group %d has %d pages, want %d", i, numPages, wantPages[i])
+		}
+
+		var dataPageCount int32
+		for _, stats := range f.Metadata().RowGroups[i].Columns[0].MetaData.EncodingStats {
+			if stats.PageType == format.DataPage || stats.PageType == format.DataPageV2 {
+				dataPageCount += stats.Count
+			}
+		}
+		if dataPageCount != int32(wantPages[i]) {
+			t.Errorf("row group %d encoding stats report %d data pages, want %d", i, dataPageCount, wantPages[i])
+		}
+	}
+}
+
 func TestSetKeyValueMetadata(t *testing.T) {
 	testKey := "test-key"
 	testValue := "test-value"


### PR DESCRIPTION
Clone encoding statistics when storing row group metadata so later row groups cannot overwrite earlier page counts.