### PR TITLE
fix(writer): correctly size bloom filters on row group limit

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -580,13 +580,13 @@ func (w *Writer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 	// copied verbatim (config differs) is re-encoded column-by-column, skipping
 	// the row assembly/deconstruction round-trip of the path below.
 	if cols, ok := w.reencodableRowGroup(rowGroup); ok {
-		w.writer.currentRowGroup.configureBloomFilters(rowGroup.ColumnChunks())
+		w.writer.currentRowGroup.configureBloomFilters(rowGroup.ColumnChunks(), rowGroup.NumRows())
 		if err := w.writeRowGroupByColumn(cols); err != nil {
 			return 0, err
 		}
 		return w.writer.writeRowGroup(w.writer.currentRowGroup, rowGroup.Schema(), rowGroup.SortingColumns())
 	}
-	w.writer.currentRowGroup.configureBloomFilters(rowGroup.ColumnChunks())
+	w.writer.currentRowGroup.configureBloomFilters(rowGroup.ColumnChunks(), rowGroup.NumRows())
 	rows := rowGroup.Rows()
 	defer rows.Close()
 	n, err := CopyRows(w.writer, rows)
@@ -885,11 +885,27 @@ func (rg *ConcurrentRowGroupWriter) reset() {
 	}
 }
 
-func (rg *ConcurrentRowGroupWriter) configureBloomFilters(columnChunks []ColumnChunk) {
+func (rg *ConcurrentRowGroupWriter) configureBloomFilters(columnChunks []ColumnChunk, numRows int64) {
 	for i, c := range rg.columns {
-		if c.columnFilter != nil {
-			c.resizeBloomFilter(columnChunks[i].NumValues())
+		if c.columnFilter == nil {
+			continue
 		}
+		values := columnChunks[i].NumValues()
+		if numRows > rg.maxRows {
+			// The input will be split across multiple output row groups, so the
+			// whole-input value count over-sizes each group's filter.
+			if c.maxRepetitionLevel > 0 {
+				// Repeated columns can hold more values than rows, so we can't
+				// apportion the value count per group ahead of time. Leave the
+				// filter unallocated and let each group size itself exactly at
+				// flush time (see flushFilterPages).
+				continue
+			}
+			// Non-repeated columns hold at most one value per row, so a full
+			// output group holds at most maxRows values.
+			values = min(values, rg.maxRows)
+		}
+		c.resizeBloomFilter(values)
 	}
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hexops/gotextdiff/span"
 	"github.com/parquet-go/bitpack/unsafecast"
 	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/bloom"
 	"github.com/parquet-go/parquet-go/compress"
 	"github.com/parquet-go/parquet-go/compress/zstd"
 	"github.com/parquet-go/parquet-go/encoding"
@@ -4504,5 +4505,64 @@ func TestWriterPlainDictionaryEncoding(t *testing.T) {
 	encodings := pf.Metadata().RowGroups[0].Columns[0].MetaData.Encoding
 	if slices.Contains(encodings, format.PlainDictionary) || !slices.Contains(encodings, format.RLEDictionary) {
 		t.Errorf("column chunk encodings = %v, want RLE_DICTIONARY and no PLAIN_DICTIONARY", encodings)
+	}
+}
+
+// TestWriterCorrectlySizesBloomFilterOnRowLimit verifies that when a single
+// input row group is split into multiple output row groups (because it exceeds
+// MaxRowsPerRowGroup), each output group's bloom filter is sized to the values
+// that actually land in that group rather than to the whole input. Without the
+// fix, filters were sized from the full-input value count and over-allocated on
+// every split group.
+func TestWriterCorrectlySizesBloomFilterOnRowLimit(t *testing.T) {
+	type Row struct {
+		ID int64 `parquet:"id"`
+	}
+
+	// Make sure the row group size is greater than max rows. This avoids the fast
+	// paths on purpose, and the splitting of groups would trigger the resize bug
+	// without the fix.
+	const (
+		writtenRows        = 60
+		maxRowsPerRowGroup = 50
+	)
+
+	inputGroup := parquet.NewGenericBuffer[Row]()
+	_, err := inputGroup.Write(make([]Row, writtenRows))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	w := parquet.NewGenericWriter[Row](&buf,
+		parquet.BloomFilters(parquet.SplitBlockFilter(10, "id")),
+		parquet.MaxRowsPerRowGroup(maxRowsPerRowGroup),
+	)
+	if _, err := w.WriteRowGroup(inputGroup); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	pf, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rg := range pf.Metadata().RowGroups {
+		meta := rg.Columns[0].MetaData
+		section := io.NewSectionReader(pf, meta.BloomFilterOffset, int64(meta.BloomFilterLength))
+		compact := thrift.CompactProtocol{}
+
+		var header format.BloomFilterHeader
+		if err := thrift.NewDecoder(compact.NewReader(section)).Decode(&header); err != nil {
+			t.Fatal(err)
+		}
+
+		expectBloomSize := bloom.BlockSize * bloom.NumSplitBlocksOf(rg.NumRows, 10)
+		gotBloomSize := int(header.NumBytes)
+		if gotBloomSize != expectBloomSize {
+			t.Errorf("got %v, want %v", gotBloomSize, expectBloomSize)
+		}
 	}
 }


### PR DESCRIPTION
### Problem

When a single input row group is larger than `MaxRowsPerRowGroup`, the writer splits it into multiple output row groups.
`configureBloomFilters` sized each column's bloom filter from the **whole input's** value count, so every split output
group got a filter allocated for the entire input rather than for the values it actually held — over-sizing the filters
and inflating the reported `BloomFilterLength` in the metadata.

Note that while this is a minor bug which just inflates the bloom size, it blocks the L0 merge due to the bloom size checks in `bloomFilterIsCopyable`.

### Fix

`configureBloomFilters` now takes the input row count and only pre-sizes when the input fits in a single output group:

- **No split** (`numRows <= maxRows`): pre-size from the full value count, exact as before.
- **Split, non-repeated column**: at most one value per row, so a full group holds at most `maxRows` values — cap with
  `min(values, maxRows)`.
- **Split, repeated column** (`maxRepetitionLevel > 0`): value count can exceed the row count and can't be apportioned
  per group ahead of time, so skip pre-allocation and let each group size itself exactly at flush time
  (`flushFilterPages`), the same path all groups after the first already use.

This keeps the pre-allocation fast path (no page read-back) for the common non-repeated case while guaranteeing correct sizing for splits.

### Tests

Adds `TestWriterCorrectlySizesBloomFilterOnRowLimit`, which writes an input larger than `MaxRowsPerRowGroup` and asserts each output group's bloom filter `NumBytes` matches the blocks needed for that group's row count.

### Notes

- No behavior change for inputs that fit in a single row group.
- Sizing changes only affect bloom filter allocation; a mis-sized filter would only affect false-positive rate, never
  correctness.