### PR TITLE
perf(bounds): add AVX-512VL INT64 kernel for default-page window

### DIFF
--- a/page_bounds_amd64.go
+++ b/page_bounds_amd64.go
@@ -38,7 +38,12 @@ package parquet
 // to running less instructions per loop. The performance starts to equalize
 // around 256KiB, and degrade beyond 1MiB, so we use this threshold to determine
 // which approach to prefer.
-const combinedBoundsThreshold = 1 * 1024 * 1024
+const (
+	combinedBoundsThreshold = 1 * 1024 * 1024
+	// ColumnWriter fills pages to 98% of DefaultPageBufferSize. This is the
+	// first whole INT64 value count that reaches that default page target.
+	combinedBoundsInt64Threshold = (DefaultPageBufferSize*98/100 + 7) / 8
+)
 
 //go:noescape
 func combinedBoundsBool(data []bool) (min, max bool)
@@ -48,6 +53,9 @@ func combinedBoundsInt32(data []int32) (min, max int32)
 
 //go:noescape
 func combinedBoundsInt64(data []int64) (min, max int64)
+
+//go:noescape
+func combinedBoundsInt64AVX512(data []int64) (min, max int64)
 
 //go:noescape
 func combinedBoundsUint32(data []uint32) (min, max uint32)
@@ -74,8 +82,13 @@ func boundsInt32(data []int32) (min, max int32) {
 }
 
 func boundsInt64(data []int64) (min, max int64) {
-	if 8*len(data) >= combinedBoundsThreshold {
-		return combinedBoundsInt64(data)
+	if len(data) >= combinedBoundsInt64Threshold {
+		if hasAVX512VL && 8*len(data) < combinedBoundsThreshold {
+			return combinedBoundsInt64AVX512(data)
+		}
+		if 8*len(data) >= combinedBoundsThreshold {
+			return combinedBoundsInt64(data)
+		}
 	}
 	min = minInt64(data)
 	max = maxInt64(data)

--- a/page_bounds_amd64.s
+++ b/page_bounds_amd64.s
@@ -212,6 +212,79 @@ done:
     MOVQ R9, max+32(FP)
     RET
 
+// func combinedBoundsInt64AVX512(data []int64) (min, max int64)
+TEXT ·combinedBoundsInt64AVX512(SB), NOSPLIT, $-40
+    MOVQ data_base+0(FP), AX
+    MOVQ data_len+8(FP), CX
+    XORQ SI, SI
+
+    MOVQ CX, DI
+    SHRQ $5, DI
+    SHLQ $5, DI
+    VPBROADCASTQ (AX), Z0
+    VPBROADCASTQ (AX), Z1
+    VPBROADCASTQ (AX), Z2
+    VPBROADCASTQ (AX), Z3
+loop32:
+    VMOVDQU64 (AX)(SI*8), Z4
+    VMOVDQU64 64(AX)(SI*8), Z5
+    VMOVDQU64 128(AX)(SI*8), Z6
+    VMOVDQU64 192(AX)(SI*8), Z7
+    VPMINSQ Z4, Z0, Z0
+    VPMAXSQ Z4, Z1, Z1
+    VPMINSQ Z5, Z2, Z2
+    VPMAXSQ Z5, Z3, Z3
+    VPMINSQ Z6, Z0, Z0
+    VPMAXSQ Z6, Z1, Z1
+    VPMINSQ Z7, Z2, Z2
+    VPMAXSQ Z7, Z3, Z3
+    ADDQ $32, SI
+    CMPQ SI, DI
+    JNE loop32
+
+    VPMINSQ Z2, Z0, Z0
+    VPMAXSQ Z3, Z1, Z1
+
+    VMOVDQU32 swap32+0(SB), Z2
+    VMOVDQU32 swap32+0(SB), Z3
+    VPERMI2D Z0, Z0, Z2
+    VPERMI2D Z1, Z1, Z3
+    VPMINSQ Y2, Y0, Y0
+    VPMAXSQ Y3, Y1, Y1
+
+    VMOVDQU32 swap32+32(SB), Y2
+    VMOVDQU32 swap32+32(SB), Y3
+    VPERMI2D Y0, Y0, Y2
+    VPERMI2D Y1, Y1, Y3
+    VPMINSQ X2, X0, X0
+    VPMAXSQ X3, X1, X1
+
+    VMOVDQU32 swap32+48(SB), X2
+    VMOVDQU32 swap32+48(SB), X3
+    VPERMI2D X0, X0, X2
+    VPERMI2D X1, X1, X3
+    VPMINSQ X2, X0, X0
+    VPMAXSQ X3, X1, X1
+    VZEROUPPER
+
+    MOVQ X0, R8
+    MOVQ X1, R9
+    CMPQ SI, CX
+    JE done
+loop:
+    MOVQ (AX)(SI*8), DX
+    CMPQ DX, R8
+    CMOVQLT DX, R8
+    CMPQ DX, R9
+    CMOVQGT DX, R9
+    INCQ SI
+    CMPQ SI, CX
+    JNE loop
+done:
+    MOVQ R8, min+24(FP)
+    MOVQ R9, max+32(FP)
+    RET
+
 // func combinedBoundsUint32(data []uint32) (min, max uint32)
 TEXT ·combinedBoundsUint32(SB), NOSPLIT, $-32
     MOVQ data_base+0(FP), AX

--- a/page_bounds_amd64_test.go
+++ b/page_bounds_amd64_test.go
@@ -1,0 +1,65 @@
+//go:build !purego && amd64
+
+package parquet
+
+import (
+	"math"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/encoding"
+)
+
+func TestInt64PageBoundsAVX512VectorSlots(t *testing.T) {
+	if !hasAVX512VL {
+		t.Skipf("requires AVX-512VL (hasAVX512VL=%t)", hasAVX512VL)
+	}
+
+	const (
+		vectorWidth = 32
+		vectorStart = 32 // Avoid the first iteration's broadcast seed.
+	)
+	// Round up past the dispatch start to leave a one-value scalar tail after
+	// the 32-wide vector prefix, regardless of the configured page threshold.
+	count := combinedBoundsInt64Threshold + (vectorWidth - combinedBoundsInt64Threshold%vectorWidth) + 1
+
+	t.Run("all-lanes", func(t *testing.T) {
+		for slot := 0; slot < vectorWidth; slot++ {
+			values := make([]int64, count)
+			state := uint64(count) + 0x9E3779B97F4A7C15
+			for i := range values {
+				state = state*6364136223846793005 + 1442695040888963407
+				values[i] = int64(state >> 1)
+			}
+
+			// Rotate both extrema through a non-initial vector iteration. This
+			// covers every lane of all four ZMM load/accumulator streams.
+			minIndex := vectorStart + slot
+			maxIndex := vectorStart + (slot+1)%vectorWidth
+			values[minIndex] = math.MinInt64
+			values[maxIndex] = math.MaxInt64
+
+			wantMin, wantMax := values[0], values[0]
+			for _, value := range values[1:] {
+				if value < wantMin {
+					wantMin = value
+				}
+				if value > wantMax {
+					wantMax = value
+				}
+			}
+
+			page := newInt64Page(Int64Type, 0, int32(len(values)), encoding.Int64Values(values))
+			min, max, ok := page.Bounds()
+			if !ok {
+				t.Errorf("slot %d: Bounds() returned ok=false", slot)
+				continue
+			}
+			if got := min.Int64(); got != wantMin {
+				t.Errorf("slot %d: min = %d, want %d", slot, got, wantMin)
+			}
+			if got := max.Int64(); got != wantMax {
+				t.Errorf("slot %d: max = %d, want %d", slot, got, wantMax)
+			}
+		}
+	})
+}

--- a/page_bounds_amd64_test.go
+++ b/page_bounds_amd64_test.go
@@ -23,7 +23,7 @@ func TestInt64PageBoundsAVX512VectorSlots(t *testing.T) {
 	count := combinedBoundsInt64Threshold + (vectorWidth - combinedBoundsInt64Threshold%vectorWidth) + 1
 
 	t.Run("all-lanes", func(t *testing.T) {
-		for slot := 0; slot < vectorWidth; slot++ {
+		for slot := range vectorWidth {
 			values := make([]int64, count)
 			state := uint64(count) + 0x9E3779B97F4A7C15
 			for i := range values {


### PR DESCRIPTION
## Summary

Add a specialized AVX-512VL INT64 bounds implementation for the default page-size dispatch window. At the 32,113-value `Page.Bounds` shape, the median changed from **3983.5 to 2915 ns/op** (**26.8% lower**, n=10 per arm, p=0.00001082508822446903), while both arms reported 0 B/op and 0 allocs/op.

Full proof: https://app.perfloop.ai/t/oss/case_x674012fms

## Why / How

Implementation detail: this diff adds `combinedBoundsInt64AVX512` in `page_bounds_amd64.s` and changes `boundsInt64` in `page_bounds_amd64.go` to select it for AVX-512VL INT64 slices from 32,113 through 131,071 values. The routine keeps minimum and maximum accumulators in the same vector loop. Slices below the lower boundary continue through the existing independent scans without reading the AVX-512 capability flag; the existing combined kernel remains selected at the 1 MiB handoff and above.

The benchmark results below measure end-to-end `Page.Bounds` timing for the selected shapes; they do not attribute the result to individual instructions or branches.

## Benchmarks

Results are medians from 10 samples per arm of the selected single-core `Page.Bounds` benchmarks.

| INT64 page shape | ns/op, baseline → patch | MB/s, baseline → patch | result |
| --- | --- | --- | --- |
| Default page (32,113 values) | 3983.5 → 2915 | 64494.44 → 88132.305 | 26.8% lower; p=0.00001082508822446903 |
| Upper dispatch window (131,071 values) | 18856 → 12349.5 | 55610.54 → 84909.165 | 34.5% lower; p=0.00001082508822446903 |
| Below dispatch window | 4130 → 4023.5 | 62207.905 → 63848.02 | 2.6% lower; p=0.435872, not significant |
| Existing handoff and above | 18144.5 → 18043 | 57791.39 → 58116.315 | 0.6% lower; p=0.853428, not significant |
| Small fallback | 84.495 → 84.99 | 48475.465 → 48194.215 | 0.6% higher; p=0.684211, not significant |

The MB/s values are reported alongside ns/op for the selected shapes. B/op and allocs/op were 0 for every selected shape.

## Testing

Passed focused Page.Bounds and page-statistics coverage, including scalar-tail extrema, AVX-512-disabled fallback behavior, pure-Go behavior, vector-lane coverage, and disabled-runtime capability handling:

```sh
go test -v -count=1 -run '^(TestInt64PageBoundsWindow|TestInt64PageBoundsStatistics)$' .
GODEBUG=cpu.avx512f=off go test -v -count=1 -run '^TestInt64PageBoundsAVX512Disabled$' .
go test -v -count=1 -tags=purego -run '^TestInt64PageBoundsWindow$' .
go test -v -count=1 -run '^(TestInt64PageBoundsStatistics|TestSkipPageStatistics)$' .
go test -v -count=1 -run '^(TestInt64PageBoundsWindow|TestInt64PageBoundsAVX512VectorSlots)$' .
GODEBUG=cpu.avx512f=off go test -v -count=1 -run '^(TestInt64PageBoundsAVX512Disabled|TestInt64PageBoundsAVX512VectorSlots)$' .
```

## Limits

The reported numbers were measured on one Linux/x86_64 host with AVX-512VL. They cover `Page.Bounds` on the listed INT64 page shapes and do not establish the same magnitude on other AVX-512VL CPUs, end-to-end writer throughput, or behavior outside the focused Page.Bounds and page-statistics tests.

---
This is an automated, human-reviewed Perfloop contribution opened by perfloop-agent. The body links to the full proof for the change. The change was benchmarked on perfloop/parquet-go, an automation fork of parquet-go/parquet-go; the commit on this PR's head branch carries the proof.