### PR TITLE
perf: fast path for fixed-length lists (page-level detection + bulk list reads in GenericReader)

### DIFF
--- a/column.go
+++ b/column.go
@@ -748,31 +748,50 @@ func (c *Column) decodeDataPageV1(header DataPageHeaderV1, page *buffer[byte], d
 		numValues        = int(header.NumValues())
 		repetitionLevels *buffer[byte]
 		definitionLevels *buffer[byte]
+		fixedListLength  = 0
 	)
 
-	if c.maxRepetitionLevel > 0 {
-		encoding := lookupLevelEncoding(header.RepetitionLevelEncoding(), c.maxRepetitionLevel)
-		repetitionLevels, pageData, err = decodeLevelsV1(encoding, numValues, pageData)
-		if err != nil {
-			return nil, fmt.Errorf("decoding repetition levels of data page v1: %w", err)
+	// Fast path: if the encoded level streams show that the page contains
+	// only complete lists of the same length with no nulls, skip decoding
+	// the levels entirely and compute row boundaries arithmetically.
+	if fixedListFastPathEnabled && c.maxRepetitionLevel == 1 &&
+		header.RepetitionLevelEncoding() == format.RLE &&
+		header.DefinitionLevelEncoding() == format.RLE {
+		if repData, rest, err := splitLevelsV1(pageData); err == nil {
+			if defData, rest, err := splitLevelsV1(rest); err == nil {
+				if n, ok := detectFixedList(repData, defData, numValues, c.maxDefinitionLevel); ok {
+					fixedListLength = n
+					pageData = rest
+				}
+			}
 		}
-		defer repetitionLevels.unref()
 	}
 
-	if c.maxDefinitionLevel > 0 {
-		encoding := lookupLevelEncoding(header.DefinitionLevelEncoding(), c.maxDefinitionLevel)
-		definitionLevels, pageData, err = decodeLevelsV1(encoding, numValues, pageData)
-		if err != nil {
-			return nil, fmt.Errorf("decoding definition levels of data page v1: %w", err)
+	if fixedListLength == 0 {
+		if c.maxRepetitionLevel > 0 {
+			encoding := lookupLevelEncoding(header.RepetitionLevelEncoding(), c.maxRepetitionLevel)
+			repetitionLevels, pageData, err = decodeLevelsV1(encoding, numValues, pageData)
+			if err != nil {
+				return nil, fmt.Errorf("decoding repetition levels of data page v1: %w", err)
+			}
+			defer repetitionLevels.unref()
 		}
-		defer definitionLevels.unref()
 
-		// Data pages v1 did not embed the number of null values,
-		// so we have to compute it from the definition levels.
-		numValues -= countLevelsNotEqual(definitionLevels.data.Slice(), c.maxDefinitionLevel)
+		if c.maxDefinitionLevel > 0 {
+			encoding := lookupLevelEncoding(header.DefinitionLevelEncoding(), c.maxDefinitionLevel)
+			definitionLevels, pageData, err = decodeLevelsV1(encoding, numValues, pageData)
+			if err != nil {
+				return nil, fmt.Errorf("decoding definition levels of data page v1: %w", err)
+			}
+			defer definitionLevels.unref()
+
+			// Data pages v1 did not embed the number of null values,
+			// so we have to compute it from the definition levels.
+			numValues -= countLevelsNotEqual(definitionLevels.data.Slice(), c.maxDefinitionLevel)
+		}
 	}
 
-	return c.decodeDataPage(header, numValues, repetitionLevels, definitionLevels, page, pageData, dict)
+	return c.decodeDataPage(header, numValues, fixedListLength, repetitionLevels, definitionLevels, page, pageData, dict)
 }
 
 // DecodeDataPageV2 decodes a data page from the header, compressed data, and
@@ -788,8 +807,30 @@ func (c *Column) decodeDataPageV2(header DataPageHeaderV2, page *buffer[byte], d
 
 	var repetitionLevels *buffer[byte]
 	var definitionLevels *buffer[byte]
+	fixedListLength := 0
 
-	if length := header.RepetitionLevelsByteLength(); length > 0 {
+	// Fast path: if the encoded level streams show that the page contains
+	// only complete lists of the same length with no nulls, skip decoding
+	// the levels entirely and compute row boundaries arithmetically.
+	if repLength, defLength := header.RepetitionLevelsByteLength(), header.DefinitionLevelsByteLength(); fixedListFastPathEnabled &&
+		c.maxRepetitionLevel == 1 && c.maxDefinitionLevel > 0 &&
+		header.NumNulls() == 0 && repLength > 0 && defLength > 0 &&
+		(repLength+defLength) <= int64(len(pageData)) {
+		repData := pageData[:repLength]
+		defData := pageData[repLength : repLength+defLength]
+		if n, ok := detectFixedList(repData, defData, numValues, c.maxDefinitionLevel); ok {
+			// Data pages v2 embed the number of rows, use it to cross check
+			// the detected list length.
+			if int64(numValues/n) == header.NumRows() {
+				fixedListLength = n
+				pageData = pageData[repLength+defLength:]
+			}
+		}
+	}
+
+	if fixedListLength > 0 {
+		// Levels were validated without being decoded.
+	} else if length := header.RepetitionLevelsByteLength(); length > 0 {
 		if c.maxRepetitionLevel == 0 {
 			// In some cases we've observed files which have a non-zero
 			// repetition level despite the column not being repeated
@@ -815,7 +856,7 @@ func (c *Column) decodeDataPageV2(header DataPageHeaderV2, page *buffer[byte], d
 		}
 	}
 
-	if length := header.DefinitionLevelsByteLength(); length > 0 {
+	if length := header.DefinitionLevelsByteLength(); fixedListLength == 0 && length > 0 {
 		if c.maxDefinitionLevel == 0 {
 			pageData, err = skipLevelsV2(pageData, length)
 		} else {
@@ -839,10 +880,10 @@ func (c *Column) decodeDataPageV2(header DataPageHeaderV2, page *buffer[byte], d
 	}
 
 	numValues -= int(header.NumNulls())
-	return c.decodeDataPage(header, numValues, repetitionLevels, definitionLevels, page, pageData, dict)
+	return c.decodeDataPage(header, numValues, fixedListLength, repetitionLevels, definitionLevels, page, pageData, dict)
 }
 
-func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetitionLevels, definitionLevels, page *buffer[byte], data []byte, dict Dictionary) (Page, error) {
+func (c *Column) decodeDataPage(header DataPageHeader, numValues, fixedListLength int, repetitionLevels, definitionLevels, page *buffer[byte], data []byte, dict Dictionary) (Page, error) {
 	pageEncoding := LookupEncoding(header.Encoding())
 	pageType := c.Type()
 	pageKind := pageType.Kind()
@@ -891,6 +932,12 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 
 	newPage := pageType.NewPage(c.Index(), numValues, values)
 	switch {
+	case fixedListLength > 0:
+		newPage = newFixedRepeatedPage(
+			newPage,
+			fixedListLength,
+			c.maxDefinitionLevel,
+		)
 	case c.maxRepetitionLevel > 0:
 		newPage = newRepeatedPage(
 			newPage,
@@ -921,6 +968,20 @@ func decodeLevelsV1(enc encoding.Encoding, numValues int, data []byte) (*buffer[
 	}
 	levels, err := decodeLevels(enc, numValues, data[i:j])
 	return levels, data[j:], err
+}
+
+// splitLevelsV1 slices the length-prefixed level section at the beginning of
+// a data page v1 without decoding it, returning the encoded level stream and
+// the remainder of the page.
+func splitLevelsV1(data []byte) (levels, rest []byte, err error) {
+	if len(data) < 4 {
+		return nil, data, io.ErrUnexpectedEOF
+	}
+	j := 4 + int(binary.LittleEndian.Uint32(data))
+	if j < 4 || j > len(data) {
+		return nil, data, io.ErrUnexpectedEOF
+	}
+	return data[4:j], data[j:], nil
 }
 
 func decodeLevelsV2(enc encoding.Encoding, numValues int, data []byte, length int64) (*buffer[byte], []byte, error) {

--- a/level_fixed.go
+++ b/level_fixed.go
@@ -1,0 +1,335 @@
+package parquet
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+// fixedListFastPathEnabled controls whether data page decoding attempts to
+// detect pages containing only lists of the same length with no null values
+// by inspecting the encoded repetition and definition level streams. When a
+// page passes detection, the level streams are never decoded and the page is
+// represented by a fixedRepeatedPage, which computes row boundaries
+// arithmetically.
+//
+// The detection verifies the entire encoded streams, so enabling the fast
+// path never changes the values, repetition levels, or definition levels
+// observed by readers. The variable exists so tests and benchmarks can
+// compare both code paths.
+var fixedListFastPathEnabled = true
+
+// maxDetectableRunLength bounds the run lengths accepted by the detector.
+// The bound guards the arithmetic on run lengths (e.g. count*8 for
+// bit-packed runs) against overflow, including on 32-bit platforms, and is
+// still far beyond the length of any valid run in a real page.
+const maxDetectableRunLength = 1 << 24
+
+// detectFixedList inspects the encoded (RLE/bit-packed hybrid) repetition and
+// definition level streams of a data page holding numValues values, and
+// reports whether the page contains only complete lists of the same length
+// with no null values.
+//
+// It returns the common list length and true when:
+//
+//   - every definition level equals maxDefinitionLevel (no null or empty
+//     lists, no null elements), and
+//   - the repetition levels encode the periodic pattern 0,1,1,...,1 with a
+//     constant distance n between record boundaries, and
+//   - numValues is a multiple of n (the last list is complete).
+//
+// The caller must only use this for columns with maxRepetitionLevel == 1
+// (the repetition level stream is then encoded with a bit width of 1).
+func detectFixedList(repData, defData []byte, numValues int, maxDefinitionLevel byte) (listLength int, ok bool) {
+	if numValues <= 0 || maxDefinitionLevel == 0 {
+		return 0, false
+	}
+	if !encodedLevelsAllEqual(defData, numValues, maxDefinitionLevel) {
+		return 0, false
+	}
+	n, ok := firstRepetitionPeriod(repData, numValues)
+	if !ok || n <= 0 || numValues%n != 0 {
+		return 0, false
+	}
+	if !verifyRepetitionPeriod(repData, numValues, n) {
+		return 0, false
+	}
+	return n, true
+}
+
+// encodedLevelsAllEqual reports whether the encoded level stream src decodes
+// to (at least) numValues values which are all equal to value. Values encoded
+// beyond numValues are ignored, mirroring the behavior of decodeLevels which
+// truncates the decoded levels to numValues.
+//
+// The stream is assumed to be encoded with a bit width of bits.Len8(value),
+// which is how lookupLevelEncoding selects the level encoding.
+func encodedLevelsAllEqual(src []byte, numValues int, value byte) bool {
+	bitWidth := uint(bits.Len8(value))
+	// Byte pattern of a bit-packed group where every value equals `value`.
+	// Only computable when values do not straddle byte boundaries.
+	var packed byte
+	packedOK := 8%bitWidth == 0
+	if packedOK {
+		for i := uint(0); i < 8; i += bitWidth {
+			packed |= value << i
+		}
+	}
+
+	pos := 0
+	i := 0
+	for pos < numValues {
+		if i >= len(src) {
+			return false
+		}
+		u, k := binary.Uvarint(src[i:])
+		if k <= 0 || (u>>1) > maxDetectableRunLength {
+			return false
+		}
+		i += k
+		count := int(u >> 1)
+		if count == 0 {
+			continue
+		}
+		if (u & 1) != 0 {
+			// Bit-packed run of count groups of 8 values.
+			if !packedOK {
+				return false
+			}
+			runBytes := count * int(bitWidth)
+			if i+runBytes > len(src) {
+				return false
+			}
+			checkValues := min(count*8, numValues-pos)
+			checkBits := checkValues * int(bitWidth)
+			for j := range checkBits / 8 {
+				if src[i+j] != packed {
+					return false
+				}
+			}
+			if rem := checkBits % 8; rem != 0 {
+				mask := byte(1<<rem) - 1
+				if (src[i+checkBits/8]^packed)&mask != 0 {
+					return false
+				}
+			}
+			pos += checkValues
+			i += runBytes
+		} else {
+			// RLE run of count values equal to the next byte.
+			if i >= len(src) {
+				return false
+			}
+			if src[i] != value {
+				return false
+			}
+			i++
+			pos += count
+		}
+	}
+	return true
+}
+
+// firstRepetitionPeriod scans the encoded repetition level stream (bit width
+// 1) for the positions of the first two zero levels and returns the distance
+// between them, which is the length of the first list in the page.
+//
+// It returns false if the first repetition level is not zero (the page starts
+// in the middle of a row) or if the stream is malformed. If the page contains
+// a single record, the returned period is numValues.
+func firstRepetitionPeriod(src []byte, numValues int) (int, bool) {
+	pos := 0
+	sawFirstZero := false
+	i := 0
+	for pos < numValues {
+		if i >= len(src) {
+			return 0, false
+		}
+		u, k := binary.Uvarint(src[i:])
+		if k <= 0 || (u>>1) > maxDetectableRunLength {
+			return 0, false
+		}
+		i += k
+		count := int(u >> 1)
+		if count == 0 {
+			continue
+		}
+		if (u & 1) != 0 {
+			// Bit-packed run of count bytes holding count*8 levels,
+			// least significant bit first.
+			if i+count > len(src) {
+				return 0, false
+			}
+			for j := range count {
+				if pos+8*j >= numValues {
+					break
+				}
+				b := src[i+j]
+				for b != 0xFF {
+					z := bits.TrailingZeros8(^b)
+					q := pos + 8*j + z
+					if q >= numValues {
+						break
+					}
+					if !sawFirstZero {
+						if q != 0 {
+							return 0, false
+						}
+						sawFirstZero = true
+					} else {
+						return q, true
+					}
+					b |= 1 << z
+				}
+			}
+			pos += count * 8
+			i += count
+		} else {
+			if i >= len(src) {
+				return 0, false
+			}
+			w := src[i]
+			i++
+			switch w {
+			case 0:
+				if !sawFirstZero {
+					if pos != 0 {
+						return 0, false
+					}
+					sawFirstZero = true
+					if count > 1 && numValues > 1 {
+						return 1, true
+					}
+				} else {
+					return pos, true
+				}
+			case 1:
+				if !sawFirstZero {
+					// The first repetition level is not zero.
+					return 0, false
+				}
+			default:
+				return 0, false
+			}
+			pos += count
+		}
+	}
+	if sawFirstZero {
+		// Only one record boundary: the page holds a single list.
+		return numValues, true
+	}
+	return 0, false
+}
+
+// verifyRepetitionPeriod reports whether the encoded repetition level stream
+// (bit width 1) decodes, for the first numValues values, to the exact
+// periodic pattern where level i is 0 when i%n == 0 and 1 otherwise.
+//
+// RLE runs are verified in O(1); bit-packed runs are compared byte-wise
+// against the expected periodic byte pattern.
+func verifyRepetitionPeriod(src []byte, numValues, n int) bool {
+	// For short periods the whole stream is bit-packed; precompute the
+	// expected byte for each starting phase to avoid recomputing it.
+	var stampTable [8]byte
+	useStamp := n <= 8
+	if useStamp {
+		for r := range n {
+			stampTable[r] = expectedRepByte(r, n)
+		}
+	}
+
+	pos := 0
+	i := 0
+	for pos < numValues {
+		if i >= len(src) {
+			return false
+		}
+		u, k := binary.Uvarint(src[i:])
+		if k <= 0 || (u>>1) > maxDetectableRunLength {
+			return false
+		}
+		i += k
+		count := int(u >> 1)
+		if count == 0 {
+			continue
+		}
+		if (u & 1) != 0 {
+			// Bit-packed run of count bytes holding count*8 levels.
+			if i+count > len(src) {
+				return false
+			}
+			numBytes := count
+			if maxBytes := (numValues - pos + 7) / 8; numBytes > maxBytes {
+				numBytes = maxBytes
+			}
+			r, step := pos%n, 8%n
+			for j := range numBytes {
+				var want byte
+				if useStamp {
+					want = stampTable[r]
+					if r += step; r >= n {
+						r -= n
+					}
+				} else {
+					want = expectedRepByte(pos+8*j, n)
+				}
+				if got := src[i+j]; got != want {
+					// The last byte may contain padding bits beyond
+					// numValues whose content is unspecified.
+					if rem := numValues - (pos + 8*j); rem < 8 {
+						mask := byte(1<<rem) - 1
+						if (got^want)&mask == 0 {
+							continue
+						}
+					}
+					return false
+				}
+			}
+			pos += count * 8
+			i += count
+		} else {
+			if i >= len(src) {
+				return false
+			}
+			w := src[i]
+			i++
+			end := min(pos+count, numValues)
+			switch w {
+			case 0:
+				// Every level in [pos,end) is a record boundary: only
+				// allowed for single-element lists, or a single boundary
+				// landing on a multiple of n.
+				if n != 1 && (pos%n != 0 || end-pos > 1) {
+					return false
+				}
+			case 1:
+				// No record boundary may fall within [pos,end).
+				next := pos
+				if r := pos % n; r != 0 {
+					next = pos + (n - r)
+				}
+				if next < end {
+					return false
+				}
+			default:
+				return false
+			}
+			pos += count
+		}
+	}
+	return true
+}
+
+// expectedRepByte returns the byte holding the bit-packed (bit width 1)
+// repetition levels for positions pos..pos+7 of the periodic pattern with
+// record boundaries at every multiple of n: bit j is 0 when (pos+j)%n == 0.
+func expectedRepByte(pos, n int) byte {
+	b := byte(0xFF)
+	j := 0
+	if r := pos % n; r != 0 {
+		j = n - r
+	}
+	for ; j < 8; j += n {
+		b &^= 1 << j
+	}
+	return b
+}

--- a/level_fixed_test.go
+++ b/level_fixed_test.go
@@ -1,0 +1,210 @@
+package parquet
+
+import (
+	"math/bits"
+	"math/rand"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/encoding/rle"
+)
+
+// encodeTestLevels encodes levels using the RLE/bit-packed hybrid encoding
+// with the bit width derived from maxLevel, like the parquet-go writer does.
+func encodeTestLevels(t testing.TB, levels []byte, maxLevel byte) []byte {
+	t.Helper()
+	enc := rle.Encoding{BitWidth: bits.Len8(maxLevel)}
+	data, err := enc.EncodeLevels(nil, levels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// makeFixedLevels returns the repetition and definition levels of numRows
+// lists of length n with no nulls.
+func makeFixedLevels(numRows, n int, maxDef byte) (rep, def []byte) {
+	rep = make([]byte, numRows*n)
+	def = make([]byte, numRows*n)
+	for i := range rep {
+		if i%n != 0 {
+			rep[i] = 1
+		}
+		def[i] = maxDef
+	}
+	return rep, def
+}
+
+func TestDetectFixedList(t *testing.T) {
+	for _, maxDef := range []byte{1, 2, 3} {
+		for _, n := range []int{1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 24, 64, 100, 768} {
+			for _, numRows := range []int{1, 2, 3, 7, 8, 100} {
+				rep, def := makeFixedLevels(numRows, n, maxDef)
+				repData := encodeTestLevels(t, rep, 1)
+				defData := encodeTestLevels(t, def, maxDef)
+				numValues := numRows * n
+
+				got, ok := detectFixedList(repData, defData, numValues, maxDef)
+				if !ok || got != n {
+					t.Errorf("maxDef=%d n=%d numRows=%d: got (%d,%t), want (%d,true)", maxDef, n, numRows, got, ok, n)
+				}
+			}
+		}
+	}
+}
+
+func TestDetectFixedListRejects(t *testing.T) {
+	const maxDef = 1
+
+	encode := func(rep, def []byte) (repData, defData []byte) {
+		return encodeTestLevels(t, rep, 1), encodeTestLevels(t, def, maxDef)
+	}
+
+	t.Run("variable lengths", func(t *testing.T) {
+		rep := []byte{0, 1, 1, 0, 1, 0, 1, 1, 1}
+		def := []byte{1, 1, 1, 1, 1, 1, 1, 1, 1}
+		repData, defData := encode(rep, def)
+		if _, ok := detectFixedList(repData, defData, len(rep), maxDef); ok {
+			t.Error("detected fixed list in variable-length stream")
+		}
+	})
+
+	t.Run("last list differs", func(t *testing.T) {
+		numRows, n := 100, 3
+		rep, def := makeFixedLevels(numRows, n, maxDef)
+		rep = append(rep, 1) // extend the last list by one element
+		def = append(def, maxDef)
+		repData, defData := encode(rep, def)
+		if _, ok := detectFixedList(repData, defData, len(rep), maxDef); ok {
+			t.Error("detected fixed list when last list is longer")
+		}
+	})
+
+	t.Run("last list shorter", func(t *testing.T) {
+		numRows, n := 100, 3
+		rep, def := makeFixedLevels(numRows, n, maxDef)
+		rep = rep[:len(rep)-1] // truncate the last list
+		def = def[:len(def)-1]
+		repData, defData := encode(rep, def)
+		if _, ok := detectFixedList(repData, defData, len(rep), maxDef); ok {
+			t.Error("detected fixed list when last list is truncated")
+		}
+	})
+
+	t.Run("null element", func(t *testing.T) {
+		const maxDef = 2
+		numRows, n := 100, 4
+		rep, def := makeFixedLevels(numRows, n, maxDef)
+		def[57] = 1 // null element in the middle
+		repData := encodeTestLevels(t, rep, 1)
+		defData := encodeTestLevels(t, def, maxDef)
+		if _, ok := detectFixedList(repData, defData, len(rep), maxDef); ok {
+			t.Error("detected fixed list with a null element")
+		}
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		// Lists of length 4 with an empty list in the middle: the empty
+		// list contributes one value slot with def level 0.
+		rep := []byte{0, 1, 1, 1, 0, 0, 1, 1, 1}
+		def := []byte{1, 1, 1, 1, 0, 1, 1, 1, 1}
+		repData, defData := encode(rep, def)
+		if _, ok := detectFixedList(repData, defData, len(rep), maxDef); ok {
+			t.Error("detected fixed list with an empty list")
+		}
+	})
+
+	t.Run("page starts mid-row", func(t *testing.T) {
+		rep := []byte{1, 1, 0, 1, 1, 0, 1, 1}
+		def := []byte{1, 1, 1, 1, 1, 1, 1, 1}
+		repData, defData := encode(rep, def)
+		if _, ok := detectFixedList(repData, defData, len(rep), maxDef); ok {
+			t.Error("detected fixed list in page starting mid-row")
+		}
+	})
+
+	t.Run("empty page", func(t *testing.T) {
+		if _, ok := detectFixedList(nil, nil, 0, maxDef); ok {
+			t.Error("detected fixed list in empty page")
+		}
+	})
+
+	t.Run("def stream too short", func(t *testing.T) {
+		numRows, n := 10, 3
+		rep, def := makeFixedLevels(numRows, n, maxDef)
+		repData := encodeTestLevels(t, rep, 1)
+		defData := encodeTestLevels(t, def[:len(def)-5], maxDef)
+		if _, ok := detectFixedList(repData, defData, len(rep), maxDef); ok {
+			t.Error("detected fixed list with truncated definition levels")
+		}
+	})
+}
+
+// TestDetectFixedListRandomized cross-checks the detector against ground
+// truth computed from the decoded levels, on randomly generated pages.
+func TestDetectFixedListRandomized(t *testing.T) {
+	prng := rand.New(rand.NewSource(0))
+
+	for range 2000 {
+		maxDef := byte(1 + prng.Intn(3))
+		numRows := 1 + prng.Intn(50)
+		fixed := prng.Intn(2) == 0
+		n := 1 + prng.Intn(20)
+		withNulls := !fixed && prng.Intn(2) == 0
+
+		var rep, def []byte
+		for range numRows {
+			length := n
+			if !fixed {
+				length = 1 + prng.Intn(20)
+			}
+			for j := range length {
+				if j == 0 {
+					rep = append(rep, 0)
+				} else {
+					rep = append(rep, 1)
+				}
+				d := maxDef
+				if withNulls && prng.Intn(10) == 0 {
+					d = byte(prng.Intn(int(maxDef)))
+				}
+				def = append(def, d)
+			}
+		}
+
+		// Ground truth: fixed length iff all rows have the same length and
+		// every definition level is maxDef.
+		truthN := -1
+		truthOK := true
+		rowLen := 0
+		for i := range rep {
+			if rep[i] == 0 && i > 0 {
+				if truthN == -1 {
+					truthN = rowLen
+				} else if rowLen != truthN {
+					truthOK = false
+				}
+				rowLen = 0
+			}
+			rowLen++
+		}
+		if truthN == -1 {
+			truthN = rowLen
+		} else if rowLen != truthN {
+			truthOK = false
+		}
+		for _, d := range def {
+			if d != maxDef {
+				truthOK = false
+			}
+		}
+
+		repData := encodeTestLevels(t, rep, 1)
+		defData := encodeTestLevels(t, def, maxDef)
+		gotN, gotOK := detectFixedList(repData, defData, len(rep), maxDef)
+
+		if gotOK != truthOK || (gotOK && gotN != truthN) {
+			t.Fatalf("numRows=%d rep=%v def=%v: got (%d,%t), want (%d,%t)",
+				numRows, rep, def, gotN, gotOK, truthN, truthOK)
+		}
+	}
+}

--- a/list_column_reader.go
+++ b/list_column_reader.go
@@ -1,0 +1,568 @@
+package parquet
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"unsafe"
+
+	"github.com/parquet-go/parquet-go/encoding"
+	"github.com/parquet-go/parquet-go/internal/unsafecast"
+)
+
+// This file implements the bulk decoding path used by GenericReader for
+// struct fields holding lists of fixed-size primitive values (e.g. a
+// []float32 field storing vector embeddings).
+//
+// Instead of materializing one parquet.Value per list element, copying it
+// into a Row, and assigning it to the Go slice through reflection, eligible
+// columns are "detached" from the row reading pipeline (see rowGroupRows)
+// and read by a listColumnReader which copies list elements page-wise,
+// straight from the decoded page data into a backing array shared by all
+// rows of a read batch.
+//
+// Pages detected to contain fixed-length lists (fixedRepeatedPage) have
+// their row boundaries computed arithmetically; other pages fall back to
+// deriving boundaries from the decoded repetition/definition levels, but
+// still bypass the Value pipeline. The results are bit-identical to the
+// regular path in both cases.
+
+// listFastPathReader drives the bulk list read path of a GenericReader.
+type listFastPathReader struct {
+	schema      *Schema
+	rowGroup    RowGroup
+	detached    []bool
+	columns     []listFastPathColumn
+	allDetached bool
+	rows        *rowGroupRows
+	rowIndex    int64
+	numRows     int64
+}
+
+type listFastPathColumn struct {
+	field    Field
+	setSlice func(fieldPtr, base unsafe.Pointer, n int)
+	reader   listColumnReader
+}
+
+// setSliceOf writes a []E slice header at fieldPtr without going through
+// reflection. A nil base produces a nil slice; a non-nil base with n == 0
+// produces an empty non-nil slice, matching what Schema.Reconstruct returns
+// for null and empty lists respectively.
+func setSliceOf[E any](fieldPtr, base unsafe.Pointer, n int) {
+	if base == nil {
+		*(*[]E)(fieldPtr) = nil
+	} else {
+		*(*[]E)(fieldPtr) = unsafe.Slice((*E)(base), n)
+	}
+}
+
+// newListFastPathReader analyzes the pairing of a row group schema with the
+// Go struct type rows are read into, and returns a listFastPathReader if at
+// least one column is eligible for the bulk list read path.
+//
+// The schema must be the exact schema of the row group (no conversion), and
+// rowType must be the struct type the schema was generated from.
+func newListFastPathReader(schema *Schema, rowGroup RowGroup, rowType reflect.Type) *listFastPathReader {
+	if !fixedListFastPathEnabled {
+		return nil
+	}
+	if schema == nil || rowType == nil || rowType.Kind() != reflect.Struct {
+		return nil
+	}
+	columnChunks := rowGroup.ColumnChunks()
+	numColumns := len(schema.Columns())
+	if numColumns != len(columnChunks) {
+		return nil
+	}
+
+	detached := make([]bool, numColumns)
+	columns := []listFastPathColumn(nil)
+	columnIndex := 0
+
+	for _, field := range schema.Fields() {
+		numLeaves := numLeafColumns(field, 0)
+		leafIndex := columnIndex
+		columnIndex += numLeaves
+
+		if numLeaves != 1 || leafIndex >= numColumns {
+			continue
+		}
+		leaf, nullDef, ok := eligibleListField(field)
+		if !ok {
+			continue
+		}
+		setSlice, elemSize, ok := listSliceSetterOf(rowType, field, leaf)
+		if !ok {
+			continue
+		}
+
+		maxDef := byte(1)
+		if field.Optional() {
+			maxDef = 2
+		}
+		detached[leafIndex] = true
+		columns = append(columns, listFastPathColumn{
+			field:    field,
+			setSlice: setSlice,
+			reader: listColumnReader{
+				chunk:    columnChunks[leafIndex],
+				kind:     encodingKindOf(leaf.Type().Kind()),
+				elemSize: elemSize,
+				maxDef:   maxDef,
+				nullDef:  nullDef,
+			},
+		})
+	}
+
+	if len(columns) == 0 {
+		return nil
+	}
+	return &listFastPathReader{
+		schema:      schema,
+		rowGroup:    rowGroup,
+		detached:    detached,
+		columns:     columns,
+		allDetached: len(columns) == numColumns,
+		rowIndex:    -1,
+		numRows:     rowGroup.NumRows(),
+	}
+}
+
+// eligibleListField reports whether a top-level schema field is a list of
+// required fixed-size primitive elements with a repetition level of one.
+// It returns the leaf node holding the values and the definition level at or
+// below which the list itself is null (-1 when the list cannot be null).
+func eligibleListField(field Field) (leaf Node, nullDef int, ok bool) {
+	nullDef = -1
+	if field.Optional() {
+		// One definition level for the optional wrapper: level 0 is a null
+		// list, level 1 an empty one.
+		nullDef = 0
+	}
+	switch {
+	case field.Leaf():
+		if !field.Repeated() {
+			return nil, 0, false
+		}
+		leaf = field
+	case isList(field):
+		defer func() {
+			// listElementOf panics on malformed list nodes.
+			if recover() != nil {
+				leaf, ok = nil, false
+			}
+		}()
+		elem := listElementOf(field)
+		if !elem.Leaf() || elem.Optional() || elem.Repeated() {
+			return nil, 0, false
+		}
+		leaf = elem
+	default:
+		return nil, 0, false
+	}
+	switch leaf.Type().Kind() {
+	case Int32, Int64, Float, Double:
+		return leaf, nullDef, true
+	}
+	return nil, 0, false
+}
+
+// listSliceSetterOf checks that the Go struct field paired with the schema
+// field is a slice of the primitive type matching the parquet leaf column,
+// and returns the function used to write slice headers into row values.
+func listSliceSetterOf(rowType reflect.Type, field Field, leaf Node) (setSlice func(fieldPtr, base unsafe.Pointer, n int), elemSize int, ok bool) {
+	defer func() {
+		// Field.Value may panic if the schema was not generated from rowType.
+		if recover() != nil {
+			setSlice, elemSize, ok = nil, 0, false
+		}
+	}()
+
+	fieldValue := field.Value(reflect.New(rowType).Elem())
+	if !fieldValue.IsValid() || fieldValue.Kind() != reflect.Slice {
+		return nil, 0, false
+	}
+
+	switch elem, kind := fieldValue.Type().Elem(), leaf.Type().Kind(); {
+	case elem == reflect.TypeFor[float32]() && kind == Float:
+		return setSliceOf[float32], 4, true
+	case elem == reflect.TypeFor[float64]() && kind == Double:
+		return setSliceOf[float64], 8, true
+	case elem == reflect.TypeFor[int32]() && kind == Int32:
+		return setSliceOf[int32], 4, true
+	case elem == reflect.TypeFor[uint32]() && kind == Int32:
+		return setSliceOf[uint32], 4, true
+	case elem == reflect.TypeFor[int64]() && kind == Int64:
+		return setSliceOf[int64], 8, true
+	case elem == reflect.TypeFor[uint64]() && kind == Int64:
+		return setSliceOf[uint64], 8, true
+	}
+	return nil, 0, false
+}
+
+// baseRows returns the row reader used for the non-detached columns,
+// creating it on the first call.
+func (f *listFastPathReader) baseRows() *rowGroupRows {
+	if f.rows == nil {
+		f.rows = newRowGroupRowsDetached(f.schema, f.rowGroup.ColumnChunks(), defaultValueBufferSize, f.detached)
+	}
+	return f.rows
+}
+
+func (f *listFastPathReader) SeekToRow(rowIndex int64) error {
+	if !f.allDetached {
+		if err := f.baseRows().SeekToRow(rowIndex); err != nil {
+			return err
+		}
+	}
+	for i := range f.columns {
+		if err := f.columns[i].reader.seekToRow(rowIndex); err != nil {
+			return err
+		}
+	}
+	f.rowIndex = rowIndex
+	return nil
+}
+
+// invalidate forces the next read to re-seek all readers, realigning the
+// columns after an error interrupted a read batch mid-way.
+func (f *listFastPathReader) invalidate() {
+	f.rowIndex = -1
+}
+
+func (f *listFastPathReader) Close() error {
+	var err error
+	if f.rows != nil {
+		err = f.rows.Close()
+	}
+	for i := range f.columns {
+		if closeErr := f.columns[i].reader.close(); err == nil {
+			err = closeErr
+		}
+	}
+	return err
+}
+
+// listSpan describes the list of one row within the backing array produced
+// by a call to listColumnReader.readLists.
+type listSpan struct {
+	start int // offset of the first element (in elements)
+	n     int // number of elements
+	null  bool
+}
+
+// emptyListBase is the base pointer used for empty (but non-null) list
+// slices when a read batch produced no elements at all. It points to an
+// 8-byte aligned allocation so that it can be converted to a pointer of any
+// of the supported element types.
+var emptyListBase = new(uint64)
+
+// encodingKindOf translates a parquet physical type to the corresponding
+// encoding.Values kind.
+func encodingKindOf(kind Kind) encoding.Kind {
+	switch kind {
+	case Boolean:
+		return encoding.Boolean
+	case Int32:
+		return encoding.Int32
+	case Int64:
+		return encoding.Int64
+	case Int96:
+		return encoding.Int96
+	case Float:
+		return encoding.Float
+	case Double:
+		return encoding.Double
+	case ByteArray:
+		return encoding.ByteArray
+	case FixedLenByteArray:
+		return encoding.FixedLenByteArray
+	default:
+		return encoding.Undefined
+	}
+}
+
+// listColumnReader reads the pages of one repeated leaf column and assembles
+// the raw list elements of consecutive rows.
+type listColumnReader struct {
+	chunk    ColumnChunk
+	kind     encoding.Kind
+	elemSize int
+	maxDef   byte
+	nullDef  int
+
+	// Current page state. elems views the page's decoded values when the
+	// page is plain-encoded; dictionary-encoded pages expose indices and
+	// dictData instead.
+	pages    Pages
+	page     Page
+	fixedN   int    // > 0 when the current page holds fixed-length lists
+	reps     []byte // repetition levels (nil in fixed mode)
+	defs     []byte // definition levels (nil in fixed mode)
+	elems    []byte
+	indices  []int32
+	dictData []byte
+	numElems int // total elements in the current page
+	slot     int // next level slot (general mode)
+	elemOff  int // next element index
+
+	// Per-batch outputs of readLists. The backing array is allocated fresh
+	// for every batch because its ownership is transferred to the assembled
+	// row values; spans are reused across batches.
+	backing []byte
+	spans   []listSpan
+}
+
+// appendBacking appends src to the batch backing array, keeping the array in
+// 8-byte aligned allocations so that the assembled slices are always aligned
+// for their element type.
+func (c *listColumnReader) appendBacking(src []byte) {
+	if size := len(c.backing) + len(src); size > cap(c.backing) {
+		grown := unsafecast.Slice[byte](make([]uint64, (max(size, 2*cap(c.backing), 512)+7)/8))
+		c.backing = grown[:copy(grown[:len(c.backing)], c.backing)]
+	}
+	c.backing = append(c.backing, src...)
+}
+
+func (c *listColumnReader) close() (err error) {
+	c.releasePage()
+	if c.pages != nil {
+		err = c.pages.Close()
+		c.pages = nil
+	}
+	return err
+}
+
+func (c *listColumnReader) seekToRow(rowIndex int64) error {
+	if c.pages == nil {
+		c.pages = c.chunk.Pages()
+	}
+	c.releasePage()
+	return c.pages.SeekToRow(rowIndex)
+}
+
+func (c *listColumnReader) releasePage() {
+	if c.page != nil {
+		Release(c.page)
+		c.page = nil
+		c.reps, c.defs = nil, nil
+		c.elems, c.indices, c.dictData = nil, nil, nil
+		c.fixedN, c.numElems, c.slot, c.elemOff = 0, 0, 0, 0
+	}
+}
+
+func (c *listColumnReader) nextPage() error {
+	c.releasePage()
+	if c.pages == nil {
+		c.pages = c.chunk.Pages()
+	}
+	for {
+		page, err := c.pages.ReadPage()
+		if err != nil {
+			return err
+		}
+		if page.NumValues() == 0 {
+			Release(page)
+			continue
+		}
+		if err := c.setPage(page); err != nil {
+			Release(page)
+			return err
+		}
+		return nil
+	}
+}
+
+func (c *listColumnReader) setPage(page Page) error {
+	inner := Page(page)
+	if buffered, ok := inner.(*bufferedPage); ok {
+		inner = buffered.Page
+	}
+
+	valuesPage := inner
+	if fixed, ok := inner.(*fixedRepeatedPage); ok {
+		c.fixedN = fixed.listLength
+		valuesPage = fixed.base
+	} else {
+		c.reps = inner.RepetitionLevels()
+		c.defs = inner.DefinitionLevels()
+		if len(c.defs) == 0 || len(c.reps) != len(c.defs) {
+			return fmt.Errorf("parquet: list column %d page has malformed levels (%d repetition, %d definition)",
+				page.Column(), len(c.reps), len(c.defs))
+		}
+	}
+
+	data := valuesPage.Data()
+	if dict := page.Dictionary(); dict != nil {
+		if data.Kind() != encoding.Int32 {
+			return fmt.Errorf("parquet: list column %d dictionary page indexes have kind %d", page.Column(), data.Kind())
+		}
+		c.indices = data.Int32()
+		dictValues := dict.Page().Data()
+		if dictValues.Kind() != c.kind {
+			return fmt.Errorf("parquet: list column %d dictionary holds unexpected data of kind %d", page.Column(), dictValues.Kind())
+		}
+		c.dictData, _ = dictValues.Data()
+		c.numElems = len(c.indices)
+		// Validate the indexes ahead of time so that gathering values from
+		// the dictionary cannot access memory out of bounds on corrupted
+		// inputs.
+		numDictValues := int32(len(c.dictData) / c.elemSize)
+		for _, index := range c.indices {
+			if index < 0 || index >= numDictValues {
+				return fmt.Errorf("parquet: list column %d contains dictionary index out of bounds: %d/%d",
+					page.Column(), index, numDictValues)
+			}
+		}
+	} else {
+		elems, _ := data.Data()
+		if data.Kind() != c.kind || len(elems)%c.elemSize != 0 {
+			return fmt.Errorf("parquet: list column %d page holds unexpected data of kind %d", page.Column(), data.Kind())
+		}
+		c.elems = elems
+		c.numElems = len(elems) / c.elemSize
+	}
+	c.page = page
+	return nil
+}
+
+// appendElems appends elements [elemOff, elemOff+n) of the current page to
+// the backing array.
+func (c *listColumnReader) appendElems(n int) {
+	if c.indices == nil {
+		c.appendBacking(c.elems[c.elemOff*c.elemSize : (c.elemOff+n)*c.elemSize])
+	} else {
+		size := c.elemSize
+		for _, index := range c.indices[c.elemOff : c.elemOff+n] {
+			c.appendBacking(c.dictData[int(index)*size : (int(index)+1)*size])
+		}
+	}
+	c.elemOff += n
+}
+
+func (c *listColumnReader) pageDone() bool {
+	if c.fixedN > 0 {
+		return c.elemOff == c.numElems
+	}
+	return c.slot == len(c.defs)
+}
+
+// readLists assembles the lists of the next count rows into c.backing and
+// c.spans. It returns an error if the column runs out of values before count
+// rows were assembled, which would indicate that the column is out of sync
+// with the rest of the row group.
+func (c *listColumnReader) readLists(count int) error {
+	c.backing = nil
+	c.spans = c.spans[:0]
+
+	for len(c.spans) < count {
+		if c.page == nil || c.pageDone() {
+			if err := c.nextPage(); err != nil {
+				if err == io.EOF {
+					err = io.ErrUnexpectedEOF
+				}
+				return err
+			}
+		}
+		if c.fixedN > 0 {
+			c.readFixedRows(count - len(c.spans))
+		} else if err := c.readGeneralRow(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readFixedRows consumes up to count rows from the current fixed-length list
+// page with a single bulk copy.
+func (c *listColumnReader) readFixedRows(count int) {
+	n := c.fixedN
+	if rowsLeft := (c.numElems - c.elemOff) / n; count > rowsLeft {
+		count = rowsLeft
+	}
+	start := len(c.backing) / c.elemSize
+	c.appendElems(count * n)
+	for i := range count {
+		c.spans = append(c.spans, listSpan{start: start + i*n, n: n})
+	}
+}
+
+// readGeneralRow consumes one row from the current general (variable-length)
+// page, following the row across page boundaries when it does not end on the
+// current page (which may happen in data pages v1).
+func (c *listColumnReader) readGeneralRow() error {
+	if c.reps[c.slot] != 0 {
+		return fmt.Errorf("parquet: list column %d row starts with repetition level %d", c.page.Column(), c.reps[c.slot])
+	}
+	if def := c.defs[c.slot]; def < c.maxDef {
+		// Null or empty list, occupying a single value slot.
+		c.spans = append(c.spans, listSpan{null: int(def) <= c.nullDef})
+		c.slot++
+		return nil
+	}
+
+	start := len(c.backing) / c.elemSize
+	n := 0
+	for {
+		// All slots of a present list hold present elements: the element is
+		// required, so definition levels below the maximum can only appear
+		// on the empty and null list slots handled above.
+		k := 1 + bytes.IndexByte(c.reps[c.slot+1:], 0)
+		last := k == 0
+		if last {
+			k = len(c.reps) - c.slot
+		}
+		if countLevelsEqual(c.defs[c.slot:c.slot+k], c.maxDef) != k {
+			return fmt.Errorf("parquet: list column %d contains null elements", c.page.Column())
+		}
+		c.appendElems(k)
+		c.slot += k
+		n += k
+		if !last {
+			break
+		}
+		// The row may continue on the next page. A page starting with a
+		// non-zero repetition level continues the current row; any other
+		// page (including fixed-length list pages, which always start on a
+		// row boundary) belongs to the next row.
+		if err := c.nextPage(); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		if c.fixedN > 0 || c.reps[0] == 0 {
+			break
+		}
+	}
+	c.spans = append(c.spans, listSpan{start: start, n: n})
+	return nil
+}
+
+// setRowSlices writes the assembled lists of the last readLists call into
+// the rows' struct fields. rowOf must return the addressable reflect.Value
+// of the i-th row.
+func (col *listFastPathColumn) setRowSlices(rowOf func(int) reflect.Value, numRows int) {
+	c := &col.reader
+	var base unsafe.Pointer
+	if len(c.backing) > 0 {
+		base = unsafe.Pointer(&c.backing[0])
+	} else {
+		// Empty lists still need a non-nil base pointer to produce empty
+		// non-nil slices.
+		base = unsafe.Pointer(emptyListBase)
+	}
+
+	elemSize := uintptr(c.elemSize)
+	for i := range numRows {
+		span := c.spans[i]
+		fieldPtr := unsafe.Pointer(col.field.Value(rowOf(i)).UnsafeAddr())
+		if span.null {
+			col.setSlice(fieldPtr, nil, 0)
+		} else {
+			col.setSlice(fieldPtr, unsafe.Add(base, uintptr(span.start)*elemSize), span.n)
+		}
+	}
+}

--- a/list_column_reader_test.go
+++ b/list_column_reader_test.go
@@ -1,0 +1,399 @@
+package parquet
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// TestListFastPathEngaged guards against silent regressions where the
+// GenericReader bulk list path stops being selected for eligible schemas.
+func TestListFastPathEngaged(t *testing.T) {
+	rows := makeFixedListTestRows(10, 4)
+	data := writeFixedListTestFile(t, rows)
+
+	r := NewGenericReader[fixedListTestRow](bytes.NewReader(data))
+	defer r.Close()
+	if r.fast == nil {
+		t.Fatal("bulk list read path not engaged for eligible schema")
+	}
+	if len(r.fast.columns) != 1 {
+		t.Fatalf("expected 1 fast column, got %d", len(r.fast.columns))
+	}
+	if r.fast.allDetached {
+		t.Fatal("allDetached should be false: the id column uses the regular path")
+	}
+
+	type allLists struct {
+		A []float32 `parquet:"a"`
+		B []int64   `parquet:"b,list"`
+	}
+	prng := rand.New(rand.NewSource(3))
+	listRows := make([]allLists, 100)
+	for i := range listRows {
+		a := make([]float32, 3)
+		b := make([]int64, 1+prng.Intn(4))
+		for j := range a {
+			a[j] = prng.Float32()
+		}
+		for j := range b {
+			b[j] = prng.Int63()
+		}
+		listRows[i] = allLists{A: a, B: b}
+	}
+	listData := writeFixedListTestFile(t, listRows)
+	r2 := NewGenericReader[allLists](bytes.NewReader(listData))
+	defer r2.Close()
+	if r2.fast == nil || !r2.fast.allDetached || len(r2.fast.columns) != 2 {
+		t.Fatal("bulk list read path not fully engaged for all-list schema")
+	}
+
+	got := readAllRows[allLists](t, listData)
+	if !reflect.DeepEqual(got, listRows) {
+		t.Fatal("all-list rows read back differ from rows written")
+	}
+}
+
+// TestListFastPathIneligible verifies schemas that must not use the bulk
+// path: optional elements, nested lists, string lists, non-slice fields.
+func TestListFastPathIneligible(t *testing.T) {
+	type ineligible struct {
+		A []string   `parquet:"a,list"` // byte-array elements
+		B []int16    `parquet:"b,list"` // Go element narrower than the int32 column
+		C []*float32 `parquet:"c,list"` // optional (pointer) elements
+		D int64      `parquet:"d"`      // not a list
+		E []bool     `parquet:"e,list"` // boolean elements (bit-packed)
+	}
+	rows := []ineligible{{
+		A: []string{"x", "y"},
+		B: []int16{1, 2, 3},
+		C: []*float32{new(float32)},
+		D: 42,
+		E: []bool{true, false},
+	}}
+	data := writeFixedListTestFile(t, rows)
+
+	r := NewGenericReader[ineligible](bytes.NewReader(data))
+	defer r.Close()
+	if r.fast != nil {
+		t.Fatal("bulk list read path engaged for ineligible schema")
+	}
+	got := readAllRows[ineligible](t, data)
+	if !reflect.DeepEqual(got, rows) {
+		t.Fatal("ineligible rows read back differ from rows written")
+	}
+}
+
+type listVariantsRow struct {
+	ID       int64     `parquet:"id"`
+	Plain    []float32 `parquet:"plain"`
+	List     []float64 `parquet:"lst,list"`
+	Optional []int32   `parquet:"opt,optional,list"`
+	Uints    []uint64  `parquet:"uints,list"`
+	Name     string    `parquet:"name"`
+}
+
+func makeListVariantsRows(prng *rand.Rand, numRows int, fixedN int) []listVariantsRow {
+	rows := make([]listVariantsRow, numRows)
+	for i := range rows {
+		lengthOf := func() int {
+			if fixedN > 0 {
+				return fixedN
+			}
+			return prng.Intn(6)
+		}
+		plain := make([]float32, lengthOf())
+		for j := range plain {
+			plain[j] = prng.Float32()
+		}
+		lst := make([]float64, lengthOf())
+		for j := range lst {
+			lst[j] = prng.Float64()
+		}
+		var opt []int32
+		if fixedN > 0 || prng.Intn(4) != 0 { // sometimes nil (null list)
+			opt = make([]int32, lengthOf())
+			for j := range opt {
+				opt[j] = prng.Int31()
+			}
+		}
+		uints := make([]uint64, lengthOf())
+		for j := range uints {
+			uints[j] = prng.Uint64()
+		}
+		rows[i] = listVariantsRow{
+			ID:       int64(i),
+			Plain:    plain,
+			List:     lst,
+			Optional: opt,
+			Uints:    uints,
+			Name:     fmt.Sprintf("row-%d", i),
+		}
+	}
+	return rows
+}
+
+// TestListFastPathEquivalence compares rows read with the bulk list path
+// against rows read with it disabled, across fixed and variable lists, page
+// versions, and seeks.
+func TestListFastPathEquivalence(t *testing.T) {
+	prng := rand.New(rand.NewSource(4))
+	for _, fixedN := range []int{0, 1, 3, 16} { // 0 = variable lengths
+		for _, pageVersion := range []int{1, 2} {
+			t.Run(fmt.Sprintf("fixedN=%d/v%d", fixedN, pageVersion), func(t *testing.T) {
+				rows := makeListVariantsRows(prng, 3000, fixedN)
+				data := writeFixedListTestFile(t, rows, DataPageVersion(pageVersion))
+
+				enabled, disabled := withFixedListFastPath(t, func(t testing.TB) []listVariantsRow {
+					return readAllRows[listVariantsRow](t, data)
+				})
+				if len(enabled) != len(rows) {
+					t.Fatalf("read %d rows, want %d", len(enabled), len(rows))
+				}
+				for i := range disabled {
+					if !reflect.DeepEqual(enabled[i], disabled[i]) {
+						t.Fatalf("row %d differs:\nfast: %+v\nslow: %+v", i, enabled[i], disabled[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestListFastPathSeek verifies seeking behaves identically on the bulk
+// list path.
+func TestListFastPathSeek(t *testing.T) {
+	prng := rand.New(rand.NewSource(5))
+	rows := makeListVariantsRows(prng, 5000, 0)
+	data := writeFixedListTestFile(t, rows)
+
+	for _, seekTo := range []int64{0, 1, 1234, 2500, 4999} {
+		readFrom := func(t testing.TB) []listVariantsRow {
+			r := NewGenericReader[listVariantsRow](bytes.NewReader(data))
+			defer r.Close()
+			if err := r.SeekToRow(seekTo); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]listVariantsRow, 50)
+			n, err := r.Read(buf)
+			if n == 0 && err != nil {
+				t.Fatal(err)
+			}
+			return buf[:n]
+		}
+		enabled, disabled := withFixedListFastPath(t, readFrom)
+		if !reflect.DeepEqual(enabled, disabled) {
+			t.Fatalf("seek to %d: fast path rows differ", seekTo)
+		}
+		if len(enabled) == 0 || enabled[0].ID != seekTo {
+			t.Fatalf("seek to %d: first row has ID %d", seekTo, enabled[0].ID)
+		}
+	}
+
+	// Interleave reads and seeks on a single reader.
+	interleaved := func(t testing.TB) []listVariantsRow {
+		r := NewGenericReader[listVariantsRow](bytes.NewReader(data))
+		defer r.Close()
+		var out []listVariantsRow
+		buf := make([]listVariantsRow, 10)
+		for _, seekTo := range []int64{100, 4000, 100, 0, 4995} {
+			if err := r.SeekToRow(seekTo); err != nil {
+				t.Fatal(err)
+			}
+			n, err := r.Read(buf)
+			if n == 0 && err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, buf[:n]...)
+		}
+		return out
+	}
+	enabled, disabled := withFixedListFastPath(t, interleaved)
+	if !reflect.DeepEqual(enabled, disabled) {
+		t.Fatal("interleaved seek/read: fast path rows differ")
+	}
+}
+
+// TestListFastPathSmallBatches reads with a tiny buffer to exercise batch
+// boundaries falling inside pages.
+func TestListFastPathSmallBatches(t *testing.T) {
+	prng := rand.New(rand.NewSource(6))
+	rows := makeListVariantsRows(prng, 1111, 0)
+	data := writeFixedListTestFile(t, rows)
+
+	readSmall := func(t testing.TB) []listVariantsRow {
+		r := NewGenericReader[listVariantsRow](bytes.NewReader(data))
+		defer r.Close()
+		var out []listVariantsRow
+		buf := make([]listVariantsRow, 7)
+		for {
+			n, err := r.Read(buf)
+			for i := range buf[:n] {
+				// Rows must remain valid after subsequent reads: deep-copy
+				// nothing, later batches must not overwrite earlier slices.
+				out = append(out, buf[i])
+			}
+			if err != nil {
+				break
+			}
+		}
+		return out
+	}
+	enabled, disabled := withFixedListFastPath(t, readSmall)
+	if !reflect.DeepEqual(enabled, disabled) {
+		t.Fatal("small batches: fast path rows differ")
+	}
+	if len(enabled) != len(rows) {
+		t.Fatalf("read %d rows, want %d", len(enabled), len(rows))
+	}
+}
+
+// TestListFastPathDictionary exercises the dictionary gather path with a
+// dict-encoded list column holding few distinct values.
+func TestListFastPathDictionary(t *testing.T) {
+	type dictRow struct {
+		ID  int64     `parquet:"id"`
+		Emb []float32 `parquet:"emb,list,dict"`
+	}
+	prng := rand.New(rand.NewSource(8))
+	distinct := []float32{1.5, -2.5, 3.25, 0}
+	rows := make([]dictRow, 2000)
+	for i := range rows {
+		emb := make([]float32, 4)
+		for j := range emb {
+			emb[j] = distinct[prng.Intn(len(distinct))]
+		}
+		rows[i] = dictRow{ID: int64(i), Emb: emb}
+	}
+	data := writeFixedListTestFile(t, rows)
+
+	enabled, disabled := withFixedListFastPath(t, func(t testing.TB) []dictRow {
+		return readAllRows[dictRow](t, data)
+	})
+	if !reflect.DeepEqual(enabled, disabled) {
+		t.Fatal("dictionary-encoded rows differ between fast and regular paths")
+	}
+	if !reflect.DeepEqual(enabled, rows) {
+		t.Fatal("dictionary-encoded rows read back differ from rows written")
+	}
+}
+
+// TestListFastPathMultiRowGroup verifies reads spanning multiple row groups.
+func TestListFastPathMultiRowGroup(t *testing.T) {
+	prng := rand.New(rand.NewSource(9))
+	rows := makeListVariantsRows(prng, 3000, 0)
+
+	buf := new(bytes.Buffer)
+	w := NewGenericWriter[listVariantsRow](buf)
+	for chunk := 0; chunk < 3; chunk++ {
+		if _, err := w.Write(rows[chunk*1000 : (chunk+1)*1000]); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Flush(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+
+	f, err := OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.RowGroups()) != 3 {
+		t.Fatalf("expected 3 row groups, got %d", len(f.RowGroups()))
+	}
+
+	enabled, disabled := withFixedListFastPath(t, func(t testing.TB) []listVariantsRow {
+		return readAllRows[listVariantsRow](t, data)
+	})
+	if !reflect.DeepEqual(enabled, disabled) {
+		t.Fatal("multi row group rows differ between fast and regular paths")
+	}
+	if !reflect.DeepEqual(enabled, rows) {
+		t.Fatal("multi row group rows read back differ from rows written")
+	}
+
+	// Seek across row group boundaries.
+	for _, seekTo := range []int64{999, 1000, 1500, 2999} {
+		seekRead := func(t testing.TB) []listVariantsRow {
+			r := NewGenericReader[listVariantsRow](bytes.NewReader(data))
+			defer r.Close()
+			if err := r.SeekToRow(seekTo); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]listVariantsRow, 10)
+			n, err := r.Read(buf)
+			if n == 0 && err != nil {
+				t.Fatal(err)
+			}
+			return buf[:n]
+		}
+		enabled, disabled := withFixedListFastPath(t, seekRead)
+		if !reflect.DeepEqual(enabled, disabled) {
+			t.Fatalf("seek to %d: fast path rows differ", seekTo)
+		}
+	}
+}
+
+// TestListFastPathSmallPages uses a tiny page buffer size so that column
+// chunks are split into many small pages.
+func TestListFastPathSmallPages(t *testing.T) {
+	prng := rand.New(rand.NewSource(10))
+	for _, fixedN := range []int{0, 8} {
+		rows := makeListVariantsRows(prng, 2000, fixedN)
+		for _, pageVersion := range []int{1, 2} {
+			data := writeFixedListTestFile(t, rows,
+				DataPageVersion(pageVersion),
+				PageBufferSize(1024),
+			)
+			enabled, disabled := withFixedListFastPath(t, func(t testing.TB) []listVariantsRow {
+				return readAllRows[listVariantsRow](t, data)
+			})
+			if !reflect.DeepEqual(enabled, disabled) {
+				t.Fatalf("fixedN=%d v%d: small page rows differ between fast and regular paths", fixedN, pageVersion)
+			}
+			if !reflect.DeepEqual(enabled, rows) {
+				t.Fatalf("fixedN=%d v%d: small page rows read back differ from rows written", fixedN, pageVersion)
+			}
+		}
+	}
+}
+
+// TestListFastPathRowGroupReader exercises NewGenericRowGroupReader over an
+// in-memory buffer row group.
+func TestListFastPathRowGroupReader(t *testing.T) {
+	prng := rand.New(rand.NewSource(7))
+	rows := makeListVariantsRows(prng, 500, 0)
+
+	buffer := NewGenericBuffer[listVariantsRow]()
+	if _, err := buffer.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+
+	readBuffered := func(t testing.TB) []listVariantsRow {
+		r := NewGenericRowGroupReader[listVariantsRow](buffer)
+		defer r.Close()
+		var out []listVariantsRow
+		buf := make([]listVariantsRow, 64)
+		for {
+			n, err := r.Read(buf)
+			out = append(out, buf[:n]...)
+			if err != nil {
+				break
+			}
+		}
+		return out
+	}
+	enabled, disabled := withFixedListFastPath(t, readBuffered)
+	if !reflect.DeepEqual(enabled, disabled) {
+		t.Fatal("row group reader: fast path rows differ")
+	}
+	if len(enabled) != len(rows) {
+		t.Fatalf("read %d rows, want %d", len(enabled), len(rows))
+	}
+}

--- a/list_fast_path_bench_test.go
+++ b/list_fast_path_bench_test.go
@@ -1,0 +1,161 @@
+package parquet_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+type benchFixedListRow struct {
+	Emb []float32 `parquet:"emb"`
+}
+
+// makeFixedListFile writes a parquet file where every row contains a list of
+// exactly n float32 values, and returns the serialized file.
+func makeFixedListFile(b testing.TB, n, numRows int) []byte {
+	buf := new(bytes.Buffer)
+	w := parquet.NewGenericWriter[benchFixedListRow](buf)
+	batch := make([]benchFixedListRow, 1000)
+	v := float32(0)
+	for i := range batch {
+		emb := make([]float32, n)
+		for j := range emb {
+			emb[j] = v
+			v++
+		}
+		batch[i].Emb = emb
+	}
+	for written := 0; written < numRows; written += len(batch) {
+		m := min(len(batch), numRows-written)
+		if _, err := w.Write(batch[:m]); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		b.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func benchmarkFixedListSizes(n int) (numRows int) {
+	// Target ~32 MiB of float32 payload for each list width.
+	const targetValues = 8 << 20
+	numRows = targetValues / n
+	if numRows == 0 {
+		numRows = 1
+	}
+	return numRows
+}
+
+// BenchmarkFixedListGenericReader measures the end-to-end GenericReader path:
+// pages -> Value pipeline -> rows -> reflect reconstruct.
+func BenchmarkFixedListGenericReader(b *testing.B) {
+	for _, n := range []int{3, 16, 768} {
+		numRows := benchmarkFixedListSizes(n)
+		data := makeFixedListFile(b, n, numRows)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.SetBytes(int64(numRows * n * 4))
+			out := make([]benchFixedListRow, 1000)
+			for b.Loop() {
+				r := parquet.NewGenericReader[benchFixedListRow](bytes.NewReader(data))
+				total := 0
+				for {
+					m, err := r.Read(out)
+					total += m
+					if err != nil {
+						break
+					}
+				}
+				r.Close()
+				if total != numRows {
+					b.Fatalf("read %d rows, want %d", total, numRows)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFixedListPageValues measures the Value pipeline without row
+// assembly or reflection: pages -> Values().ReadValues.
+func BenchmarkFixedListPageValues(b *testing.B) {
+	for _, n := range []int{3, 16, 768} {
+		numRows := benchmarkFixedListSizes(n)
+		data := makeFixedListFile(b, n, numRows)
+		f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.SetBytes(int64(numRows * n * 4))
+			values := make([]parquet.Value, 4096)
+			for b.Loop() {
+				total := 0
+				for _, rg := range f.RowGroups() {
+					pages := rg.ColumnChunks()[0].Pages()
+					for {
+						p, err := pages.ReadPage()
+						if err != nil {
+							break
+						}
+						vr := p.Values()
+						for {
+							m, err := vr.ReadValues(values)
+							total += m
+							if err != nil {
+								break
+							}
+						}
+						parquet.Release(p)
+					}
+					pages.Close()
+				}
+				if total != numRows*n {
+					b.Fatalf("read %d values, want %d", total, numRows*n)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFixedListPageData measures the columnar floor: pages decoded and
+// accessed through Data() without materializing values.
+func BenchmarkFixedListPageData(b *testing.B) {
+	for _, n := range []int{3, 16, 768} {
+		numRows := benchmarkFixedListSizes(n)
+		data := makeFixedListFile(b, n, numRows)
+		f, err := parquet.OpenFile(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.SetBytes(int64(numRows * n * 4))
+			var sink float32
+			for b.Loop() {
+				total := 0
+				for _, rg := range f.RowGroups() {
+					pages := rg.ColumnChunks()[0].Pages()
+					for {
+						p, err := pages.ReadPage()
+						if err != nil {
+							break
+						}
+						pdata := p.Data()
+						vals := pdata.Float()
+						total += len(vals)
+						if len(vals) > 0 {
+							sink += vals[len(vals)-1]
+						}
+						parquet.Release(p)
+					}
+					pages.Close()
+				}
+				if total != numRows*n {
+					b.Fatalf("read %d values, want %d", total, numRows*n)
+				}
+			}
+			_ = sink
+		})
+	}
+}

--- a/page.go
+++ b/page.go
@@ -397,6 +397,7 @@ func errPageBoundsOutOfRange(i, j, n int64) error {
 var (
 	_ Page       = (*optionalPage)(nil)
 	_ Page       = (*repeatedPage)(nil)
+	_ Page       = (*fixedRepeatedPage)(nil)
 	_ Page       = (*booleanPage)(nil)
 	_ Page       = (*int32Page)(nil)
 	_ Page       = (*int64Page)(nil)

--- a/page_repeated_fixed.go
+++ b/page_repeated_fixed.go
@@ -1,0 +1,148 @@
+package parquet
+
+import (
+	"io"
+	"sync"
+
+	"github.com/parquet-go/parquet-go/encoding"
+	"github.com/parquet-go/parquet-go/internal/bytealg"
+)
+
+// fixedRepeatedPage is a Page implementation for pages of repeated columns
+// which were detected (from their encoded level streams) to contain only
+// complete lists of the same length with no null values.
+//
+// Compared to repeatedPage, it does not hold materialized repetition and
+// definition level arrays: row boundaries are computed arithmetically from
+// the list length, making NumRows, NumNulls and Slice O(1). The level slices
+// are only generated if a consumer explicitly requests them through the
+// RepetitionLevels or DefinitionLevels methods.
+//
+// fixedRepeatedPage is only used for columns with maxRepetitionLevel == 1.
+type fixedRepeatedPage struct {
+	base               Page
+	listLength         int
+	maxDefinitionLevel byte
+
+	levelsOnce       sync.Once
+	repetitionLevels []byte
+	definitionLevels []byte
+}
+
+func newFixedRepeatedPage(base Page, listLength int, maxDefinitionLevel byte) *fixedRepeatedPage {
+	return &fixedRepeatedPage{
+		base:               base,
+		listLength:         listLength,
+		maxDefinitionLevel: maxDefinitionLevel,
+	}
+}
+
+// FixedListLength returns the common length of the lists in the page.
+func (page *fixedRepeatedPage) FixedListLength() int { return page.listLength }
+
+func (page *fixedRepeatedPage) Type() Type { return page.base.Type() }
+
+func (page *fixedRepeatedPage) Column() int { return page.base.Column() }
+
+func (page *fixedRepeatedPage) Dictionary() Dictionary { return page.base.Dictionary() }
+
+func (page *fixedRepeatedPage) NumRows() int64 {
+	return page.base.NumValues() / int64(page.listLength)
+}
+
+func (page *fixedRepeatedPage) NumValues() int64 { return page.base.NumValues() }
+
+func (page *fixedRepeatedPage) NumNulls() int64 { return 0 }
+
+func (page *fixedRepeatedPage) Bounds() (min, max Value, ok bool) { return page.base.Bounds() }
+
+func (page *fixedRepeatedPage) Size() int64 { return page.base.Size() }
+
+func (page *fixedRepeatedPage) RepetitionLevels() []byte {
+	page.materializeLevels()
+	return page.repetitionLevels
+}
+
+func (page *fixedRepeatedPage) DefinitionLevels() []byte {
+	page.materializeLevels()
+	return page.definitionLevels
+}
+
+func (page *fixedRepeatedPage) materializeLevels() {
+	page.levelsOnce.Do(func() {
+		numValues := int(page.base.NumValues())
+		levels := make([]byte, 2*numValues)
+
+		repetitionLevels := levels[:numValues:numValues]
+		bytealg.Broadcast(repetitionLevels, 1)
+		for i := 0; i < numValues; i += page.listLength {
+			repetitionLevels[i] = 0
+		}
+		page.repetitionLevels = repetitionLevels
+
+		definitionLevels := levels[numValues:]
+		bytealg.Broadcast(definitionLevels, page.maxDefinitionLevel)
+		page.definitionLevels = definitionLevels
+	})
+}
+
+func (page *fixedRepeatedPage) Data() encoding.Values { return page.base.Data() }
+
+func (page *fixedRepeatedPage) Values() ValueReader {
+	return &fixedRepeatedPageValues{
+		page:   page,
+		values: page.base.Values(),
+	}
+}
+
+func (page *fixedRepeatedPage) Slice(i, j int64) Page {
+	numRows := page.NumRows()
+	if i < 0 || i > numRows || j < 0 || j > numRows || i > j {
+		panic(errPageBoundsOutOfRange(i, j, numRows))
+	}
+	n := int64(page.listLength)
+	return newFixedRepeatedPage(
+		page.base.Slice(i*n, j*n),
+		page.listLength,
+		page.maxDefinitionLevel,
+	)
+}
+
+type fixedRepeatedPageValues struct {
+	page   *fixedRepeatedPage
+	values ValueReader
+	offset int
+}
+
+func (r *fixedRepeatedPageValues) ReadValues(values []Value) (n int, err error) {
+	numValues := int(r.page.base.NumValues())
+	if r.offset >= numValues {
+		return 0, io.EOF
+	}
+	if remain := numValues - r.offset; len(values) > remain {
+		values = values[:remain]
+	}
+
+	n, err = r.values.ReadValues(values)
+
+	listLength := r.page.listLength
+	maxDefinitionLevel := r.page.maxDefinitionLevel
+	for i := range values[:n] {
+		values[i].repetitionLevel = 1
+		values[i].definitionLevel = maxDefinitionLevel
+	}
+	// Zero the repetition level at each record boundary.
+	i := 0
+	if k := r.offset % listLength; k != 0 {
+		i = listLength - k
+	}
+	for ; i < n; i += listLength {
+		values[i].repetitionLevel = 0
+	}
+
+	r.offset += n
+	if err == nil && r.offset == numValues {
+		err = io.EOF
+	}
+	return n, err
+}

--- a/page_repeated_fixed_test.go
+++ b/page_repeated_fixed_test.go
@@ -1,0 +1,314 @@
+package parquet
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/parquet-go/parquet-go/compress"
+	"github.com/parquet-go/parquet-go/compress/uncompressed"
+	"github.com/parquet-go/parquet-go/compress/zstd"
+)
+
+type fixedListTestRow struct {
+	ID  int64     `parquet:"id"`
+	Emb []float32 `parquet:"emb,list"`
+}
+
+func makeFixedListTestRows(numRows, n int) []fixedListTestRow {
+	prng := rand.New(rand.NewSource(1))
+	rows := make([]fixedListTestRow, numRows)
+	for i := range rows {
+		emb := make([]float32, n)
+		for j := range emb {
+			emb[j] = prng.Float32()
+		}
+		rows[i] = fixedListTestRow{ID: int64(i), Emb: emb}
+	}
+	return rows
+}
+
+func writeFixedListTestFile[T any](t testing.TB, rows []T, options ...WriterOption) []byte {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := NewGenericWriter[T](buf, options...)
+	if _, err := w.Write(rows); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// withFixedListFastPath runs f twice, once with the fast path enabled and
+// once disabled, and returns both results for comparison.
+func withFixedListFastPath[T any](t testing.TB, f func(t testing.TB) T) (enabled, disabled T) {
+	t.Helper()
+	defer func(saved bool) { fixedListFastPathEnabled = saved }(fixedListFastPathEnabled)
+	fixedListFastPathEnabled = true
+	enabled = f(t)
+	fixedListFastPathEnabled = false
+	disabled = f(t)
+	return enabled, disabled
+}
+
+// readAllValues reads every value of every column of the file, capturing the
+// exact Value stream (data, repetition levels, definition levels).
+func readAllValues(t testing.TB, data []byte) [][]Value {
+	t.Helper()
+	f, err := OpenFile(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	numColumns := len(f.Schema().Columns())
+	columns := make([][]Value, numColumns)
+	for _, rg := range f.RowGroups() {
+		for c, chunk := range rg.ColumnChunks() {
+			pages := chunk.Pages()
+			buf := make([]Value, 333) // odd size to exercise partial reads
+			for {
+				p, err := pages.ReadPage()
+				if err != nil {
+					break
+				}
+				vr := p.Values()
+				for {
+					n, err := vr.ReadValues(buf)
+					for _, v := range buf[:n] {
+						columns[c] = append(columns[c], v.Clone())
+					}
+					if err != nil {
+						break
+					}
+				}
+				Release(p)
+			}
+			pages.Close()
+		}
+	}
+	return columns
+}
+
+func readAllRows[T any](t testing.TB, data []byte) []T {
+	t.Helper()
+	r := NewGenericReader[T](bytes.NewReader(data))
+	defer r.Close()
+	var rows []T
+	buf := make([]T, 100)
+	for {
+		n, err := r.Read(buf)
+		rows = append(rows, buf[:n]...)
+		if err != nil {
+			break
+		}
+	}
+	return rows
+}
+
+func assertValuesEqual(t *testing.T, enabled, disabled [][]Value) {
+	t.Helper()
+	if len(enabled) != len(disabled) {
+		t.Fatalf("column count mismatch: %d != %d", len(enabled), len(disabled))
+	}
+	for c := range enabled {
+		if len(enabled[c]) != len(disabled[c]) {
+			t.Fatalf("column %d: value count mismatch: %d != %d", c, len(enabled[c]), len(disabled[c]))
+		}
+		for i := range enabled[c] {
+			a, b := enabled[c][i], disabled[c][i]
+			if !Equal(a, b) || a.RepetitionLevel() != b.RepetitionLevel() || a.DefinitionLevel() != b.DefinitionLevel() {
+				t.Fatalf("column %d value %d mismatch: fast=%v(r%d,d%d) slow=%v(r%d,d%d)",
+					c, i, a, a.RepetitionLevel(), a.DefinitionLevel(), b, b.RepetitionLevel(), b.DefinitionLevel())
+			}
+		}
+	}
+}
+
+func TestFixedListFastPathEquivalence(t *testing.T) {
+	codecs := map[string]compress.Codec{
+		"uncompressed": &uncompressed.Codec{},
+		"zstd":         &zstd.Codec{},
+	}
+	for _, n := range []int{1, 3, 8, 15, 16, 768} {
+		for _, pageVersion := range []int{1, 2} {
+			for codecName, codec := range codecs {
+				name := fmt.Sprintf("n=%d/v%d/%s", n, pageVersion, codecName)
+				t.Run(name, func(t *testing.T) {
+					rows := makeFixedListTestRows(1000, n)
+					data := writeFixedListTestFile(t, rows,
+						DataPageVersion(pageVersion),
+						Compression(codec),
+					)
+
+					valuesEnabled, valuesDisabled := withFixedListFastPath(t, func(t testing.TB) [][]Value {
+						return readAllValues(t, data)
+					})
+					assertValuesEqual(t, valuesEnabled, valuesDisabled)
+
+					rowsEnabled, rowsDisabled := withFixedListFastPath(t, func(t testing.TB) []fixedListTestRow {
+						return readAllRows[fixedListTestRow](t, data)
+					})
+					if !reflect.DeepEqual(rowsEnabled, rowsDisabled) {
+						t.Fatal("rows read with fast path differ from rows read without")
+					}
+					if !reflect.DeepEqual(rowsEnabled, rows) {
+						t.Fatal("rows read with fast path differ from rows written")
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestFixedListFastPathDetected verifies that pages of fixed-length list
+// files actually take the fast path (guarding against silent regressions
+// where detection stops triggering).
+func TestFixedListFastPathDetected(t *testing.T) {
+	for _, pageVersion := range []int{1, 2} {
+		t.Run(fmt.Sprintf("v%d", pageVersion), func(t *testing.T) {
+			rows := makeFixedListTestRows(1000, 16)
+			data := writeFixedListTestFile(t, rows, DataPageVersion(pageVersion))
+
+			f, err := OpenFile(bytes.NewReader(data), int64(len(data)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, rg := range f.RowGroups() {
+				for _, chunk := range rg.ColumnChunks() {
+					if chunk.Type().Kind() != Float {
+						continue
+					}
+					pages := chunk.Pages()
+					for {
+						p, err := pages.ReadPage()
+						if err != nil {
+							break
+						}
+						bp, ok := p.(*bufferedPage)
+						if !ok {
+							t.Fatalf("expected *bufferedPage, got %T", p)
+						}
+						fp, ok := bp.Page.(*fixedRepeatedPage)
+						if !ok {
+							t.Fatalf("expected fast-path page, got %T", bp.Page)
+						}
+						if fp.FixedListLength() != 16 {
+							t.Fatalf("fixed list length = %d, want 16", fp.FixedListLength())
+						}
+						if fp.NumRows()*16 != fp.NumValues() {
+							t.Fatalf("NumRows %d * 16 != NumValues %d", fp.NumRows(), fp.NumValues())
+						}
+						found = true
+						Release(p)
+					}
+					pages.Close()
+				}
+			}
+			if !found {
+				t.Fatal("no data pages read for the list column")
+			}
+		})
+	}
+}
+
+// TestFixedListFastPathVariableLists verifies that files containing
+// variable-length lists (which must not take the fast path) read
+// identically with the flag on and off, and that mixed files work.
+func TestFixedListFastPathVariableLists(t *testing.T) {
+	prng := rand.New(rand.NewSource(2))
+	rows := make([]fixedListTestRow, 1000)
+	for i := range rows {
+		emb := make([]float32, prng.Intn(8))
+		for j := range emb {
+			emb[j] = prng.Float32()
+		}
+		rows[i] = fixedListTestRow{ID: int64(i), Emb: emb}
+	}
+	data := writeFixedListTestFile(t, rows)
+
+	valuesEnabled, valuesDisabled := withFixedListFastPath(t, func(t testing.TB) [][]Value {
+		return readAllValues(t, data)
+	})
+	assertValuesEqual(t, valuesEnabled, valuesDisabled)
+
+	rowsEnabled, rowsDisabled := withFixedListFastPath(t, func(t testing.TB) []fixedListTestRow {
+		return readAllRows[fixedListTestRow](t, data)
+	})
+	if !reflect.DeepEqual(rowsEnabled, rowsDisabled) {
+		t.Fatal("rows read with fast path differ from rows read without")
+	}
+}
+
+// TestFixedListFastPathSeek verifies SeekToRow and page slicing behave the
+// same on fast-path pages.
+func TestFixedListFastPathSeek(t *testing.T) {
+	rows := makeFixedListTestRows(5000, 7)
+	data := writeFixedListTestFile(t, rows)
+
+	for _, seekTo := range []int64{0, 1, 999, 2500, 4999} {
+		readFrom := func(t testing.TB) []fixedListTestRow {
+			r := NewGenericReader[fixedListTestRow](bytes.NewReader(data))
+			defer r.Close()
+			if err := r.SeekToRow(seekTo); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]fixedListTestRow, 100)
+			n, err := r.Read(buf)
+			if n == 0 && err != nil {
+				t.Fatal(err)
+			}
+			return buf[:n]
+		}
+		enabled, disabled := withFixedListFastPath(t, readFrom)
+		if !reflect.DeepEqual(enabled, disabled) {
+			t.Fatalf("seek to %d: fast path rows differ", seekTo)
+		}
+		if len(enabled) == 0 || enabled[0].ID != seekTo {
+			t.Fatalf("seek to %d: first row has ID %d", seekTo, enabled[0].ID)
+		}
+	}
+}
+
+// TestFixedListFastPathLevels verifies lazily materialized levels match the
+// levels produced by the regular decode path.
+func TestFixedListFastPathLevels(t *testing.T) {
+	rows := makeFixedListTestRows(1000, 5)
+	data := writeFixedListTestFile(t, rows)
+
+	type levels struct{ rep, def [][]byte }
+	readLevels := func(t testing.TB) levels {
+		f, err := OpenFile(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var l levels
+		for _, rg := range f.RowGroups() {
+			for _, chunk := range rg.ColumnChunks() {
+				if chunk.Type().Kind() != Float {
+					continue
+				}
+				pages := chunk.Pages()
+				for {
+					p, err := pages.ReadPage()
+					if err != nil {
+						break
+					}
+					l.rep = append(l.rep, bytes.Clone(p.RepetitionLevels()))
+					l.def = append(l.def, bytes.Clone(p.DefinitionLevels()))
+					Release(p)
+				}
+				pages.Close()
+			}
+		}
+		return l
+	}
+
+	enabled, disabled := withFixedListFastPath(t, readLevels)
+	if !reflect.DeepEqual(enabled, disabled) {
+		t.Fatal("materialized levels differ between fast and regular paths")
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -16,6 +16,9 @@ import (
 type GenericReader[T any] struct {
 	base Reader
 	read readFunc[T]
+	// fast, when non-nil, holds the bulk read state for struct fields
+	// storing lists of primitive values (see list_column_reader.go).
+	fast *listFastPathReader
 }
 
 // NewGenericReader is like NewReader but returns GenericReader[T] suited to write
@@ -62,6 +65,8 @@ func NewGenericReader[T any](input io.ReaderAt, options ...ReaderOption) *Generi
 
 	if !EqualNodes(c.Schema, f.schema) {
 		r.base.file.rowGroup = convertRowGroupTo(r.base.file.rowGroup, c.Schema)
+	} else {
+		r.fast = newListFastPathReader(c.Schema, r.base.file.rowGroup, t)
 	}
 
 	r.base.read.init(r.base.file.schema, r.base.file.rowGroup)
@@ -95,6 +100,8 @@ func NewGenericRowGroupReader[T any](rowGroup RowGroup, options ...ReaderOption)
 
 	if !EqualNodes(c.Schema, rowGroup.Schema()) {
 		r.base.file.rowGroup = convertRowGroupTo(r.base.file.rowGroup, c.Schema)
+	} else {
+		r.fast = newListFastPathReader(c.Schema, r.base.file.rowGroup, t)
 	}
 
 	r.base.read.init(r.base.file.schema, r.base.file.rowGroup)
@@ -134,7 +141,14 @@ func (r *GenericReader[T]) SeekToRow(rowIndex int64) error {
 }
 
 func (r *GenericReader[T]) Close() error {
-	return r.base.Close()
+	var fastErr error
+	if r.fast != nil {
+		fastErr = r.fast.Close()
+	}
+	if err := r.base.Close(); err != nil {
+		return err
+	}
+	return fastErr
 }
 
 // File returns a FileView of the underlying parquet file.
@@ -150,6 +164,9 @@ func (r *GenericReader[T]) File() FileView {
 // The method returns the number of rows read and io.EOF when no more rows
 // can be read from the reader.
 func (r *GenericReader[T]) readRows(rows []T) (int, error) {
+	if r.fast != nil {
+		return r.readRowsFast(rows)
+	}
 	nRequest := len(rows)
 	if cap(r.base.rowbuf) < nRequest {
 		r.base.rowbuf = make([]Row, nRequest)
@@ -176,6 +193,83 @@ func (r *GenericReader[T]) readRows(rows []T) (int, error) {
 			}
 		}
 		nTotal += n
+		if n == 0 || nTotal == nRequest || err != nil {
+			break
+		}
+	}
+
+	return nTotal, err
+}
+
+// readRowsFast is the bulk variant of readRows used when the schema has
+// struct fields storing lists of primitive values (see list_column_reader.go):
+// those columns are read straight from page data into the rows' slice fields,
+// while the remaining columns go through the regular row reconstruction.
+func (r *GenericReader[T]) readRowsFast(rows []T) (int, error) {
+	f := r.fast
+	nRequest := len(rows)
+	if cap(r.base.rowbuf) < nRequest {
+		r.base.rowbuf = make([]Row, nRequest)
+	} else {
+		r.base.rowbuf = r.base.rowbuf[:nRequest]
+	}
+
+	// The reader's logical position is r.base.rowIndex (updated by both this
+	// function and SeekToRow); realign the fast path readers whenever it does
+	// not match their current position.
+	if target := r.base.rowIndex; f.rowIndex != target {
+		if err := f.SeekToRow(target); err != nil {
+			return 0, err
+		}
+	}
+
+	schema := r.base.Schema()
+	rowsValue := reflect.ValueOf(rows)
+	var nTotal int
+	var err error
+
+	for {
+		var n int
+		if f.allDetached {
+			// Every column is read by the fast path: there are no rows to
+			// read from the regular pipeline, the number of rows is derived
+			// from the row group.
+			n = nRequest - nTotal
+			if remain := f.numRows - f.rowIndex; int64(n) > remain {
+				n = int(remain)
+			}
+			if n == 0 {
+				err = io.EOF
+			}
+		} else {
+			n, err = f.baseRows().ReadRows(r.base.rowbuf[:nRequest-nTotal])
+			for i, row := range r.base.rowbuf[:n] {
+				if err2 := schema.Reconstruct(&rows[nTotal+i], row); err2 != nil {
+					// Rows of this batch are incomplete: their list fields
+					// have not been assembled yet, only report the rows of
+					// the batches completed before the error.
+					f.invalidate()
+					return nTotal, err2
+				}
+			}
+		}
+
+		if n > 0 {
+			batch := nTotal
+			rowOf := func(i int) reflect.Value { return rowsValue.Index(batch + i) }
+			for c := range f.columns {
+				col := &f.columns[c]
+				if err2 := col.reader.readLists(n); err2 != nil {
+					f.invalidate()
+					return nTotal, err2
+				}
+				col.setRowSlices(rowOf, n)
+			}
+		}
+
+		nTotal += n
+		f.rowIndex += int64(n)
+		r.base.rowIndex = f.rowIndex
 		if n == 0 || nTotal == nRequest || err != nil {
 			break
 		}

--- a/row.go
+++ b/row.go
@@ -94,11 +94,22 @@ func (row Row) Equal(other Row) bool {
 }
 
 // Range calls f for each column of row.
+//
+// Columns are numbered sequentially, but jump ahead to the column index
+// carried by the values themselves when it is greater: rows which do not
+// hold values for all columns (for example rows produced by readers which
+// read some columns outside of the row pipeline) only invoke f for the
+// columns present in the row. Values without a column index (e.g. rows
+// assembled by hand) keep being attributed to sequential column numbers.
 func (row Row) Range(f func(columnIndex int, columnValues []Value) bool) {
 	columnIndex := 0
 
 	for i := 0; i < len(row); {
 		j := i + 1
+
+		if k := int(^row[i].columnIndex); k > columnIndex && k < int(^uint16(0)) {
+			columnIndex = k
+		}
 
 		for j < len(row) && row[j].columnIndex == ^uint16(columnIndex) {
 			j++

--- a/row_group.go
+++ b/row_group.go
@@ -188,6 +188,10 @@ type rowGroupRows struct {
 	columns  []columnChunkRows
 	closed   bool
 	rowIndex int64
+	// detached flags columns which are read by an external columnar reader
+	// (see listColumnReader): those columns are skipped entirely when
+	// reading rows, and contribute no values to the returned Row slices.
+	detached []bool
 }
 
 type columnChunkRows struct {
@@ -208,14 +212,26 @@ func NewRowGroupRowReader(rowGroup RowGroup) Rows {
 }
 
 func newRowGroupRows(schema *Schema, columns []ColumnChunk, bufferSize int) *rowGroupRows {
+	return newRowGroupRowsDetached(schema, columns, bufferSize, nil)
+}
+
+// newRowGroupRowsDetached is like newRowGroupRows, but marks the columns
+// flagged in detached as being read by an external columnar reader: those
+// columns are not read (their pages are not even opened) and contribute no
+// values to the rows returned by ReadRows.
+func newRowGroupRowsDetached(schema *Schema, columns []ColumnChunk, bufferSize int, detached []bool) *rowGroupRows {
 	r := &rowGroupRows{
 		schema:   schema,
 		bufsize:  bufferSize,
 		buffers:  make([]Value, len(columns)*bufferSize),
 		columns:  make([]columnChunkRows, len(columns)),
 		rowIndex: -1,
+		detached: detached,
 	}
 	for i, column := range columns {
+		if detached != nil && detached[i] {
+			continue
+		}
 		switch column.Type().Kind() {
 		case ByteArray, FixedLenByteArray:
 			// (@mdisibio) - If the column can contain pointers, then we must not repool
@@ -242,6 +258,9 @@ func (r *rowGroupRows) clear() {
 
 func (r *rowGroupRows) Reset() {
 	for i := range r.columns {
+		if r.detached != nil && r.detached[i] {
+			continue
+		}
 		r.columns[i].reader.Reset()
 	}
 	r.clear()
@@ -268,6 +287,9 @@ func (r *rowGroupRows) SeekToRow(rowIndex int64) error {
 	}
 	if rowIndex != r.rowIndex {
 		for i := range r.columns {
+			if r.detached != nil && r.detached[i] {
+				continue
+			}
 			if err := r.columns[i].reader.SeekToRow(rowIndex); err != nil {
 				return err
 			}
@@ -297,18 +319,21 @@ func (r *rowGroupRows) ReadRows(rows []Row) (int, error) {
 	eofCount := 0
 	rowCount := 0
 
+	for rowIndex := range rows {
+		rows[rowIndex] = rows[rowIndex][:0]
+	}
+
 readColumnValues:
 	for columnIndex := range r.columns {
+		if r.detached != nil && r.detached[columnIndex] {
+			continue
+		}
 		c := &r.columns[columnIndex]
 		b := r.buffer(columnIndex)
 		eof := false
 
 		for rowIndex := range rows {
 			numValuesInRow := 1
-
-			if columnIndex == 0 {
-				rows[rowIndex] = rows[rowIndex][:0]
-			}
 
 			for {
 				if c.offset == c.length {

--- a/schema.go
+++ b/schema.go
@@ -397,6 +397,10 @@ func (s *Schema) Reconstruct(value any, row Row) error {
 	state := s.lazyLoadState()
 	funcs := s.lazyLoadFuncs()
 	columns := b.reserve(len(state.columns))
+	// The buffer is pooled: clear stale column values from previous calls so
+	// that columns without values in this row (e.g. columns read outside of
+	// the row pipeline by the list fast path) are seen as empty.
+	clear(columns)
 	row.Range(func(columnIndex int, columnValues []Value) bool {
 		if columnIndex < len(columns) {
 			columns[columnIndex] = columnValues


### PR DESCRIPTION
Ports the optimization described in Gunnar Morling's ["A Fast Path for Fixed-Length Lists in Parquet"](https://www.morling.dev/blog/fast-path-for-fixed-length-lists-in-parquet/) and builds on it with a bulk list read path in `GenericReader`. The target use case is columns of fixed-dimension vector embeddings (`[]float32`), but any list of fixed-size primitives benefits.

Reading 1M rows of a `struct { Emb []float32 }` embedding column (Apple M3, `BenchmarkFixedListGenericReader`):

| List length | main | this PR | speedup |
|---|---|---|---|
| n=3 | 98 MB/s | 1,103 MB/s | ~11x |
| n=16 | 192 MB/s | 2,764 MB/s | ~14x |
| n=768 | 240 MB/s | 4,918 MB/s | ~20x |

### Commit 1: detect fixed-length lists from encoded level streams

When decoding a data page of a repeated column with `maxRepetitionLevel == 1`, the encoded RLE/bit-packed level streams are inspected before decoding. If every definition level equals the maximum (no nulls anywhere) and the repetition levels encode the periodic pattern `0,1,...,1` with a constant period (every list has the same length), the page becomes a `fixedRepeatedPage`:

- level arrays are never allocated or decoded (`RepetitionLevels`/`DefinitionLevels` are generated lazily only if a consumer asks),
- `NumRows`, `NumNulls`, and `Slice` are O(1) arithmetic,
- `Values()` stamps levels arithmetically.

The detection verifies the entire encoded streams (RLE runs in O(1) per run, bit-packed runs byte-wise against the expected periodic pattern), so the fast path never changes the values or levels observed by any reader. Pages that fail detection fall back to the regular decode with no extra work beyond the failed scan.

### Commit 2: bulk list read path in `GenericReader`

Struct fields holding lists of fixed-size primitives (`[]float32`, `[]float64`, `[]int32`, `[]uint32`, `[]int64`, `[]uint64`) are read straight from decoded page data into the rows' slice fields, bypassing the `parquet.Value` pipeline and per-element reflection:

- Eligible columns are "detached" from `rowGroupRows` (their pages are not opened by the row pipeline) and read by a `listColumnReader` instead; remaining columns go through the regular row reconstruction.
- Fixed-length list pages copy whole batches of rows with a single copy; other pages derive list boundaries from decoded levels but still bulk-copy values. Dictionary-encoded pages gather by index (indexes bounds-checked upfront); v1 pages where a row spans page boundaries are handled.
- Null, empty, and optional lists reproduce `Schema.Reconstruct` semantics exactly (nil vs empty non-nil slices).
- Eligibility is conservative: top-level struct field, required fixed-size primitive element matching the Go slice element type, no schema conversion. Everything else uses the regular path unchanged.

One shared change: `Row.Range` now derives column indexes from the values themselves (jumping ahead of the sequential counter when the values' stored index is greater), so rows without values for some columns reconstruct correctly. Values without column indexes keep the previous sequential numbering.

Rows returned by a single `Read` call share one backing allocation per list column; ranges are disjoint and `cap == len`, so `append` on a returned slice copies.

### Testing

- Detector unit tests over hand-built RLE/bit-packed streams (including truncated/malformed inputs).
- Equivalence tests comparing the fast paths against the regular path (`fixedListFastPathEnabled = false`): full `Value` streams including levels, materialized level arrays, reconstructed rows, `SeekToRow`, page `Slice`, across data page v1/v2, uncompressed/zstd, fixed and variable list lengths, null/empty/optional lists, dictionary-encoded columns, multiple row groups, tiny page sizes, tiny read batches, and in-memory row groups (`NewGenericRowGroupReader`).
- `go test`, `go test -race` (with `checkptr`), and `go test -tags=purego` pass; cross-compiles for `s390x` and `386`.
