### PR TITLE
perf(reconstruct): reduce allocations for wide map reconstruction

### DIFF
--- a/row.go
+++ b/row.go
@@ -666,7 +666,8 @@ func reconstructFuncOfRepeated(columnIndex uint16, node Node) (uint16, reconstru
 			return nil
 		}
 
-		values := make([][]Value, len(columns))
+		b := acquireValuesSliceBuffer()
+		values := b.reserve(len(columns))
 		column := columns[0]
 		n := 0
 
@@ -701,6 +702,7 @@ func reconstructFuncOfRepeated(columnIndex uint16, node Node) (uint16, reconstru
 			}
 
 			if err := reconstruct(value.Index(i), levels, values); err != nil {
+				b.release()
 				return err
 			}
 
@@ -711,6 +713,7 @@ func reconstructFuncOfRepeated(columnIndex uint16, node Node) (uint16, reconstru
 			levels.repetitionLevel = levels.repetitionDepth
 		}
 
+		b.release()
 		return nil
 	}
 }
@@ -761,7 +764,8 @@ func reconstructFuncOfMap(columnIndex uint16, node Node) (uint16, reconstructFun
 			return nil
 		}
 
-		values := make([][]Value, len(columns))
+		b := acquireValuesSliceBuffer()
+		values := b.reserve(len(columns))
 		column := columns[0]
 		t := value.Type()
 		if t.Kind() == reflect.Interface {
@@ -808,6 +812,7 @@ func reconstructFuncOfMap(columnIndex uint16, node Node) (uint16, reconstructFun
 			}
 
 			if err := reconstruct(elem, levels, values); err != nil {
+				b.release()
 				return err
 			}
 
@@ -832,6 +837,7 @@ func reconstructFuncOfMap(columnIndex uint16, node Node) (uint16, reconstructFun
 			levels.repetitionLevel = levels.repetitionDepth
 		}
 
+		b.release()
 		return nil
 	}
 }

--- a/schema.go
+++ b/schema.go
@@ -385,14 +385,7 @@ func (s *Schema) Reconstruct(value any, row Row) error {
 		v = v.Elem()
 	}
 
-	b := valuesSliceBufferPool.Get(
-		func() *valuesSliceBuffer {
-			return &valuesSliceBuffer{
-				values: make([][]Value, 0, 64),
-			}
-		},
-		func(v *valuesSliceBuffer) { v.values = v.values[:0] },
-	)
+	b := acquireValuesSliceBuffer()
 
 	state := s.lazyLoadState()
 	funcs := s.lazyLoadFuncs()
@@ -431,6 +424,17 @@ func (v *valuesSliceBuffer) release() {
 }
 
 var valuesSliceBufferPool memory.Pool[valuesSliceBuffer]
+
+func acquireValuesSliceBuffer() *valuesSliceBuffer {
+	return valuesSliceBufferPool.Get(
+		func() *valuesSliceBuffer {
+			return &valuesSliceBuffer{
+				values: make([][]Value, 0, 64),
+			}
+		},
+		func(v *valuesSliceBuffer) { v.values = v.values[:0] },
+	)
+}
 
 // Lookup returns the leaf column at the given path.
 //


### PR DESCRIPTION
## Summary

For a 32-entry map with two repeated descendants, allocations decreased from 347 to 282 allocs/op (18.7%).

## Changes

Update buffer handling in the map and repeated reconstruction paths in `schema.go` and `row.go`. The recorded measurement reports aggregate behavior rather than attributing the allocation delta to individual operations.

## Benchmarks

On Linux/x86_64, the selected 32-entry map/list workload measured 347 to 282 allocs/op. Supporting footprint was 20,409 to 18,655 B/op. Timing was 52,814 versus 52,480 ns/op, with no statistically measurable timing change for this workload.

The result is limited to this map/list shape and recorded test environment; it does not establish an end-to-end reader or CPU-time improvement across other schema shapes or platforms. Full proof: https://app.perfloop.ai/t/oss/case_q8p970nh3n

## Testing

`go test -trimpath ./...` passed.