### PR TITLE
fix(value): format doubles with 64-bit precision in Value.String()

### DIFF
--- a/value.go
+++ b/value.go
@@ -788,7 +788,7 @@ func (v Value) String() string {
 	case Float:
 		return strconv.FormatFloat(float64(v.float()), 'g', -1, 32)
 	case Double:
-		return strconv.FormatFloat(v.double(), 'g', -1, 32)
+		return strconv.FormatFloat(v.double(), 'g', -1, 64)
 	case ByteArray, FixedLenByteArray:
 		return string(v.byteArray())
 	default:

--- a/value_test.go
+++ b/value_test.go
@@ -30,6 +30,30 @@ func BenchmarkValueAppend(b *testing.B) {
 	b.SetBytes(N * int64(unsafe.Sizeof(parquet.Value{})))
 }
 
+func TestValueString(t *testing.T) {
+	tests := []struct {
+		value  parquet.Value
+		expect string
+	}{
+		{parquet.Value{}, "<null>"},
+		{parquet.BooleanValue(true), "true"},
+		{parquet.Int32Value(-123), "-123"},
+		{parquet.Int64Value(math.MaxInt64), "9223372036854775807"},
+		{parquet.FloatValue(0.5), "0.5"},
+		{parquet.DoubleValue(0.1), "0.1"},
+		// Regression test for https://github.com/parquet-go/parquet-go/issues/582:
+		// doubles must be formatted with 64-bit precision.
+		{parquet.DoubleValue(1.0000000596046448), "1.0000000596046448"},
+		{parquet.ByteArrayValue([]byte("hello")), "hello"},
+	}
+
+	for _, test := range tests {
+		if s := test.value.String(); s != test.expect {
+			t.Errorf("%s: got %q, want %q", test.value.GoString(), s, test.expect)
+		}
+	}
+}
+
 func TestValueClone(t *testing.T) {
 	tests := []struct {
 		scenario string


### PR DESCRIPTION
Fixes #582.

`Value.String()` formatted `Double` values with `strconv.FormatFloat(..., 32)`, rounding float64 values to float32 precision (e.g. `1.0000000596046448` printed as `1.0000001`). This changes the `bitSize` argument to 64.

Also adds `TestValueString` covering all value kinds, including a regression case with a double that only round-trips at 64-bit precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)