### PR TITLE
archsimd tier 3: xxhash, binary packed blocks, bit packers, byte array and BE128 kernels

### DIFF
--- a/bloom/xxhash/sum64uint_amd64.go
+++ b/bloom/xxhash/sum64uint_amd64.go
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && !goexperiment.simd
 
 package xxhash
 

--- a/bloom/xxhash/sum64uint_amd64.s
+++ b/bloom/xxhash/sum64uint_amd64.s
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && !goexperiment.simd
 
 #include "textflag.h"
 

--- a/bloom/xxhash/sum64uint_purego.go
+++ b/bloom/xxhash/sum64uint_purego.go
@@ -1,4 +1,4 @@
-//go:build purego || !amd64
+//go:build !amd64 || (purego && !goexperiment.simd)
 
 package xxhash
 

--- a/bloom/xxhash/sum64uint_simd_amd64.go
+++ b/bloom/xxhash/sum64uint_simd_amd64.go
@@ -12,7 +12,10 @@ import (
 // the simd/archsimd package, replacing the hand-written assembly of
 // sum64uint_amd64.s when GOEXPERIMENT=simd is set. Eight hashes are computed
 // per vector (Uint64x8); the multiply-heavy dependency chains are hidden by
-// processing two independent vector streams per loop iteration.
+// processing four independent vector streams per loop iteration, and the
+// prime and shift constants are individual local variables so they stay
+// register resident (a pointer-accessed struct would reload them from the
+// stack on every use).
 //
 // The kernels require the AVX-512 feature set: the 64 bits multiplies are
 // VPMULLQ. Note that the assembly gate tested AVX512CD, which it never used;
@@ -23,55 +26,50 @@ import (
 // golang/go#80835); rotates use the immediate form, which encodes the count
 // in the instruction.
 
-type sum64Consts struct {
-	p1, p2, p3, p5 archsimd.Uint64x8
-	s33, s29, s32  archsimd.Uint64x8
-}
-
-func sum64ConstsOf() (c sum64Consts) {
-	c.p1 = archsimd.BroadcastUint64x8(prime1)
-	c.p2 = archsimd.BroadcastUint64x8(prime2)
-	c.p3 = archsimd.BroadcastUint64x8(prime3)
-	c.p5 = archsimd.BroadcastUint64x8(prime5)
-	c.s33 = archsimd.BroadcastUint64x8(33)
-	c.s29 = archsimd.BroadcastUint64x8(29)
-	c.s32 = archsimd.BroadcastUint64x8(32)
-	return c
-}
-
-func avalanche8x64(h archsimd.Uint64x8, c *sum64Consts) archsimd.Uint64x8 {
-	h = h.Xor(h.ShiftRight(c.s33))
-	h = h.Mul(c.p2)
-	h = h.Xor(h.ShiftRight(c.s29))
-	h = h.Mul(c.p3)
-	h = h.Xor(h.ShiftRight(c.s32))
-	return h
-}
-
-// round8x64 computes round(0, input): rol31(input*prime2) * prime1.
-func round8x64(input archsimd.Uint64x8, c *sum64Consts) archsimd.Uint64x8 {
-	return input.Mul(c.p2).RotateAllLeft(31).Mul(c.p1)
-}
-
 func MultiSum64Uint8(h []uint64, v []uint8) int {
 	n := min(len(h), len(v))
 	i := 0
-	if archsimd.X86.AVX512() && n >= 16 {
-		c := sum64ConstsOf()
+	if archsimd.X86.AVX512() && n >= 32 {
+		p1 := archsimd.BroadcastUint64x8(prime1)
+		p2 := archsimd.BroadcastUint64x8(prime2)
+		p3 := archsimd.BroadcastUint64x8(prime3)
+		s33 := archsimd.BroadcastUint64x8(33)
+		s29 := archsimd.BroadcastUint64x8(29)
+		s32 := archsimd.BroadcastUint64x8(32)
+		p5 := archsimd.BroadcastUint64x8(prime5)
 		seed := archsimd.BroadcastUint64x8(prime5 + 1)
-		m := n / 16
-		cv := unsafecast.Slice[[16]uint8](v)[:m]
-		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		m := n / 32
+		cv := unsafecast.Slice[[32]uint8](v)[:m]
+		ch := unsafecast.Slice[[32]uint64](h)[:m]
 		for j := range cv {
-			x := archsimd.LoadUint8x16Slice(cv[j][:])
-			v0 := x.ExtendLo8ToUint64()
-			v1 := x.ConcatShiftBytesRight(8, x).ExtendLo8ToUint64()
-			h0 := seed.Xor(v0.Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
-			h1 := seed.Xor(v1.Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
-			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
-			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+			x0 := archsimd.LoadUint8x16Slice(cv[j][0:16])
+			x1 := archsimd.LoadUint8x16Slice(cv[j][16:32])
+			v0 := x0.ExtendLo8ToUint64()
+			v1 := x0.ConcatShiftBytesRight(8, x0).ExtendLo8ToUint64()
+			v2 := x1.ExtendLo8ToUint64()
+			v3 := x1.ConcatShiftBytesRight(8, x1).ExtendLo8ToUint64()
+			h0 := seed.Xor(v0.Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h1 := seed.Xor(v1.Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h2 := seed.Xor(v2.Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h3 := seed.Xor(v3.Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h0 = h0.Xor(h0.ShiftRight(s33)).Mul(p2)
+			h0 = h0.Xor(h0.ShiftRight(s29)).Mul(p3)
+			h0 = h0.Xor(h0.ShiftRight(s32))
+			h1 = h1.Xor(h1.ShiftRight(s33)).Mul(p2)
+			h1 = h1.Xor(h1.ShiftRight(s29)).Mul(p3)
+			h1 = h1.Xor(h1.ShiftRight(s32))
+			h2 = h2.Xor(h2.ShiftRight(s33)).Mul(p2)
+			h2 = h2.Xor(h2.ShiftRight(s29)).Mul(p3)
+			h2 = h2.Xor(h2.ShiftRight(s32))
+			h3 = h3.Xor(h3.ShiftRight(s33)).Mul(p2)
+			h3 = h3.Xor(h3.ShiftRight(s29)).Mul(p3)
+			h3 = h3.Xor(h3.ShiftRight(s32))
+			h0.StoreSlice(ch[j][0:8])
+			h1.StoreSlice(ch[j][8:16])
+			h2.StoreSlice(ch[j][16:24])
+			h3.StoreSlice(ch[j][24:32])
 		}
-		i = m * 16
+		i = m * 32
 		archsimd.ClearAVXUpperBits()
 	}
 	for ; i < n; i++ {
@@ -83,25 +81,51 @@ func MultiSum64Uint8(h []uint64, v []uint8) int {
 func MultiSum64Uint16(h []uint64, v []uint16) int {
 	n := min(len(h), len(v))
 	i := 0
-	if archsimd.X86.AVX512() && n >= 16 {
-		c := sum64ConstsOf()
+	if archsimd.X86.AVX512() && n >= 32 {
+		p1 := archsimd.BroadcastUint64x8(prime1)
+		p2 := archsimd.BroadcastUint64x8(prime2)
+		p3 := archsimd.BroadcastUint64x8(prime3)
+		s33 := archsimd.BroadcastUint64x8(33)
+		s29 := archsimd.BroadcastUint64x8(29)
+		s32 := archsimd.BroadcastUint64x8(32)
+		p5 := archsimd.BroadcastUint64x8(prime5)
 		seed := archsimd.BroadcastUint64x8(prime5 + 2)
 		lowByte := archsimd.BroadcastUint64x8(0xFF)
 		s8 := archsimd.BroadcastUint64x8(8)
-		m := n / 16
-		cv := unsafecast.Slice[[16]uint16](v)[:m]
-		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		m := n / 32
+		cv := unsafecast.Slice[[32]uint16](v)[:m]
+		ch := unsafecast.Slice[[32]uint64](h)[:m]
 		for j := range cv {
 			v0 := archsimd.LoadUint16x8Slice(cv[j][0:8]).ExtendToUint64()
 			v1 := archsimd.LoadUint16x8Slice(cv[j][8:16]).ExtendToUint64()
-			h0 := seed.Xor(v0.And(lowByte).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
-			h1 := seed.Xor(v1.And(lowByte).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
-			h0 = h0.Xor(v0.ShiftRight(s8).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
-			h1 = h1.Xor(v1.ShiftRight(s8).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
-			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
-			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+			v2 := archsimd.LoadUint16x8Slice(cv[j][16:24]).ExtendToUint64()
+			v3 := archsimd.LoadUint16x8Slice(cv[j][24:32]).ExtendToUint64()
+			h0 := seed.Xor(v0.And(lowByte).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h1 := seed.Xor(v1.And(lowByte).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h2 := seed.Xor(v2.And(lowByte).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h3 := seed.Xor(v3.And(lowByte).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h0 = h0.Xor(v0.ShiftRight(s8).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h1 = h1.Xor(v1.ShiftRight(s8).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h2 = h2.Xor(v2.ShiftRight(s8).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h3 = h3.Xor(v3.ShiftRight(s8).Mul(p5)).RotateAllLeft(11).Mul(p1)
+			h0 = h0.Xor(h0.ShiftRight(s33)).Mul(p2)
+			h0 = h0.Xor(h0.ShiftRight(s29)).Mul(p3)
+			h0 = h0.Xor(h0.ShiftRight(s32))
+			h1 = h1.Xor(h1.ShiftRight(s33)).Mul(p2)
+			h1 = h1.Xor(h1.ShiftRight(s29)).Mul(p3)
+			h1 = h1.Xor(h1.ShiftRight(s32))
+			h2 = h2.Xor(h2.ShiftRight(s33)).Mul(p2)
+			h2 = h2.Xor(h2.ShiftRight(s29)).Mul(p3)
+			h2 = h2.Xor(h2.ShiftRight(s32))
+			h3 = h3.Xor(h3.ShiftRight(s33)).Mul(p2)
+			h3 = h3.Xor(h3.ShiftRight(s29)).Mul(p3)
+			h3 = h3.Xor(h3.ShiftRight(s32))
+			h0.StoreSlice(ch[j][0:8])
+			h1.StoreSlice(ch[j][8:16])
+			h2.StoreSlice(ch[j][16:24])
+			h3.StoreSlice(ch[j][24:32])
 		}
-		i = m * 16
+		i = m * 32
 		archsimd.ClearAVXUpperBits()
 	}
 	for ; i < n; i++ {
@@ -113,21 +137,44 @@ func MultiSum64Uint16(h []uint64, v []uint16) int {
 func MultiSum64Uint32(h []uint64, v []uint32) int {
 	n := min(len(h), len(v))
 	i := 0
-	if archsimd.X86.AVX512() && n >= 16 {
-		c := sum64ConstsOf()
+	if archsimd.X86.AVX512() && n >= 32 {
+		p1 := archsimd.BroadcastUint64x8(prime1)
+		p2 := archsimd.BroadcastUint64x8(prime2)
+		p3 := archsimd.BroadcastUint64x8(prime3)
+		s33 := archsimd.BroadcastUint64x8(33)
+		s29 := archsimd.BroadcastUint64x8(29)
+		s32 := archsimd.BroadcastUint64x8(32)
 		seed := archsimd.BroadcastUint64x8(prime5 + 4)
-		m := n / 16
-		cv := unsafecast.Slice[[16]uint32](v)[:m]
-		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		m := n / 32
+		cv := unsafecast.Slice[[32]uint32](v)[:m]
+		ch := unsafecast.Slice[[32]uint64](h)[:m]
 		for j := range cv {
 			v0 := archsimd.LoadUint32x8Slice(cv[j][0:8]).ExtendToUint64()
 			v1 := archsimd.LoadUint32x8Slice(cv[j][8:16]).ExtendToUint64()
-			h0 := seed.Xor(v0.Mul(c.p1)).RotateAllLeft(23).Mul(c.p2).Add(c.p3)
-			h1 := seed.Xor(v1.Mul(c.p1)).RotateAllLeft(23).Mul(c.p2).Add(c.p3)
-			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
-			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+			v2 := archsimd.LoadUint32x8Slice(cv[j][16:24]).ExtendToUint64()
+			v3 := archsimd.LoadUint32x8Slice(cv[j][24:32]).ExtendToUint64()
+			h0 := seed.Xor(v0.Mul(p1)).RotateAllLeft(23).Mul(p2).Add(p3)
+			h1 := seed.Xor(v1.Mul(p1)).RotateAllLeft(23).Mul(p2).Add(p3)
+			h2 := seed.Xor(v2.Mul(p1)).RotateAllLeft(23).Mul(p2).Add(p3)
+			h3 := seed.Xor(v3.Mul(p1)).RotateAllLeft(23).Mul(p2).Add(p3)
+			h0 = h0.Xor(h0.ShiftRight(s33)).Mul(p2)
+			h0 = h0.Xor(h0.ShiftRight(s29)).Mul(p3)
+			h0 = h0.Xor(h0.ShiftRight(s32))
+			h1 = h1.Xor(h1.ShiftRight(s33)).Mul(p2)
+			h1 = h1.Xor(h1.ShiftRight(s29)).Mul(p3)
+			h1 = h1.Xor(h1.ShiftRight(s32))
+			h2 = h2.Xor(h2.ShiftRight(s33)).Mul(p2)
+			h2 = h2.Xor(h2.ShiftRight(s29)).Mul(p3)
+			h2 = h2.Xor(h2.ShiftRight(s32))
+			h3 = h3.Xor(h3.ShiftRight(s33)).Mul(p2)
+			h3 = h3.Xor(h3.ShiftRight(s29)).Mul(p3)
+			h3 = h3.Xor(h3.ShiftRight(s32))
+			h0.StoreSlice(ch[j][0:8])
+			h1.StoreSlice(ch[j][8:16])
+			h2.StoreSlice(ch[j][16:24])
+			h3.StoreSlice(ch[j][24:32])
 		}
-		i = m * 16
+		i = m * 32
 		archsimd.ClearAVXUpperBits()
 	}
 	for ; i < n; i++ {
@@ -139,22 +186,45 @@ func MultiSum64Uint32(h []uint64, v []uint32) int {
 func MultiSum64Uint64(h []uint64, v []uint64) int {
 	n := min(len(h), len(v))
 	i := 0
-	if archsimd.X86.AVX512() && n >= 16 {
-		c := sum64ConstsOf()
-		seed := archsimd.BroadcastUint64x8(prime5 + 8)
+	if archsimd.X86.AVX512() && n >= 32 {
+		p1 := archsimd.BroadcastUint64x8(prime1)
+		p2 := archsimd.BroadcastUint64x8(prime2)
+		p3 := archsimd.BroadcastUint64x8(prime3)
+		s33 := archsimd.BroadcastUint64x8(33)
+		s29 := archsimd.BroadcastUint64x8(29)
+		s32 := archsimd.BroadcastUint64x8(32)
 		p4 := archsimd.BroadcastUint64x8(prime4)
-		m := n / 16
-		cv := unsafecast.Slice[[16]uint64](v)[:m]
-		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		seed := archsimd.BroadcastUint64x8(prime5 + 8)
+		m := n / 32
+		cv := unsafecast.Slice[[32]uint64](v)[:m]
+		ch := unsafecast.Slice[[32]uint64](h)[:m]
 		for j := range cv {
 			v0 := archsimd.LoadUint64x8Slice(cv[j][0:8])
 			v1 := archsimd.LoadUint64x8Slice(cv[j][8:16])
-			h0 := seed.Xor(round8x64(v0, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
-			h1 := seed.Xor(round8x64(v1, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
-			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
-			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+			v2 := archsimd.LoadUint64x8Slice(cv[j][16:24])
+			v3 := archsimd.LoadUint64x8Slice(cv[j][24:32])
+			h0 := seed.Xor(v0.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h1 := seed.Xor(v1.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h2 := seed.Xor(v2.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h3 := seed.Xor(v3.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h0 = h0.Xor(h0.ShiftRight(s33)).Mul(p2)
+			h0 = h0.Xor(h0.ShiftRight(s29)).Mul(p3)
+			h0 = h0.Xor(h0.ShiftRight(s32))
+			h1 = h1.Xor(h1.ShiftRight(s33)).Mul(p2)
+			h1 = h1.Xor(h1.ShiftRight(s29)).Mul(p3)
+			h1 = h1.Xor(h1.ShiftRight(s32))
+			h2 = h2.Xor(h2.ShiftRight(s33)).Mul(p2)
+			h2 = h2.Xor(h2.ShiftRight(s29)).Mul(p3)
+			h2 = h2.Xor(h2.ShiftRight(s32))
+			h3 = h3.Xor(h3.ShiftRight(s33)).Mul(p2)
+			h3 = h3.Xor(h3.ShiftRight(s29)).Mul(p3)
+			h3 = h3.Xor(h3.ShiftRight(s32))
+			h0.StoreSlice(ch[j][0:8])
+			h1.StoreSlice(ch[j][8:16])
+			h2.StoreSlice(ch[j][16:24])
+			h3.StoreSlice(ch[j][24:32])
 		}
-		i = m * 16
+		i = m * 32
 		archsimd.ClearAVXUpperBits()
 	}
 	for ; i < n; i++ {
@@ -173,25 +243,43 @@ var (
 func MultiSum64Uint128(h []uint64, v [][16]byte) int {
 	n := min(len(h), len(v))
 	i := 0
-	if archsimd.X86.AVX512() && n >= 8 {
-		c := sum64ConstsOf()
-		seed := archsimd.BroadcastUint64x8(prime5 + 16)
+	if archsimd.X86.AVX512() && n >= 16 {
+		p1 := archsimd.BroadcastUint64x8(prime1)
+		p2 := archsimd.BroadcastUint64x8(prime2)
+		p3 := archsimd.BroadcastUint64x8(prime3)
+		s33 := archsimd.BroadcastUint64x8(33)
+		s29 := archsimd.BroadcastUint64x8(29)
+		s32 := archsimd.BroadcastUint64x8(32)
 		p4 := archsimd.BroadcastUint64x8(prime4)
+		seed := archsimd.BroadcastUint64x8(prime5 + 16)
 		even := archsimd.LoadUint64x8Slice(evenLanes[:])
 		odd := archsimd.LoadUint64x8Slice(oddLanes[:])
-		m := n / 8
-		cv := unsafecast.Slice[[16]uint64](v)[:m]
-		ch := unsafecast.Slice[[8]uint64](h)[:m]
+		m := n / 16
+		cv := unsafecast.Slice[[32]uint64](v)[:m]
+		ch := unsafecast.Slice[[16]uint64](h)[:m]
 		for j := range cv {
 			z0 := archsimd.LoadUint64x8Slice(cv[j][0:8])
 			z1 := archsimd.LoadUint64x8Slice(cv[j][8:16])
-			lo := z0.ConcatPermute(z1, even)
-			hi := z0.ConcatPermute(z1, odd)
-			hh := seed.Xor(round8x64(lo, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
-			hh = hh.Xor(round8x64(hi, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
-			avalanche8x64(hh, &c).StoreSlice(ch[j][:])
+			z2 := archsimd.LoadUint64x8Slice(cv[j][16:24])
+			z3 := archsimd.LoadUint64x8Slice(cv[j][24:32])
+			lo0 := z0.ConcatPermute(z1, even)
+			hi0 := z0.ConcatPermute(z1, odd)
+			lo1 := z2.ConcatPermute(z3, even)
+			hi1 := z2.ConcatPermute(z3, odd)
+			h0 := seed.Xor(lo0.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h1 := seed.Xor(lo1.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h0 = h0.Xor(hi0.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h1 = h1.Xor(hi1.Mul(p2).RotateAllLeft(31).Mul(p1)).RotateAllLeft(27).Mul(p1).Add(p4)
+			h0 = h0.Xor(h0.ShiftRight(s33)).Mul(p2)
+			h0 = h0.Xor(h0.ShiftRight(s29)).Mul(p3)
+			h0 = h0.Xor(h0.ShiftRight(s32))
+			h1 = h1.Xor(h1.ShiftRight(s33)).Mul(p2)
+			h1 = h1.Xor(h1.ShiftRight(s29)).Mul(p3)
+			h1 = h1.Xor(h1.ShiftRight(s32))
+			h0.StoreSlice(ch[j][0:8])
+			h1.StoreSlice(ch[j][8:16])
 		}
-		i = m * 8
+		i = m * 16
 		archsimd.ClearAVXUpperBits()
 	}
 	for ; i < n; i++ {

--- a/bloom/xxhash/sum64uint_simd_amd64.go
+++ b/bloom/xxhash/sum64uint_simd_amd64.go
@@ -1,0 +1,201 @@
+//go:build goexperiment.simd
+
+package xxhash
+
+import (
+	"simd/archsimd"
+
+	"github.com/parquet-go/bitpack/unsafecast"
+)
+
+// This file provides implementations of the MultiSum64 functions based on
+// the simd/archsimd package, replacing the hand-written assembly of
+// sum64uint_amd64.s when GOEXPERIMENT=simd is set. Eight hashes are computed
+// per vector (Uint64x8); the multiply-heavy dependency chains are hidden by
+// processing two independent vector streams per loop iteration.
+//
+// The kernels require the AVX-512 feature set: the 64 bits multiplies are
+// VPMULLQ. Note that the assembly gate tested AVX512CD, which it never used;
+// this gate is the accurate one.
+//
+// Shifts use per-lane variable forms with constant vectors rather than
+// ShiftAllRight (whose scalar count materializes through a legacy MOVQ,
+// golang/go#80835); rotates use the immediate form, which encodes the count
+// in the instruction.
+
+type sum64Consts struct {
+	p1, p2, p3, p5 archsimd.Uint64x8
+	s33, s29, s32  archsimd.Uint64x8
+}
+
+func sum64ConstsOf() (c sum64Consts) {
+	c.p1 = archsimd.BroadcastUint64x8(prime1)
+	c.p2 = archsimd.BroadcastUint64x8(prime2)
+	c.p3 = archsimd.BroadcastUint64x8(prime3)
+	c.p5 = archsimd.BroadcastUint64x8(prime5)
+	c.s33 = archsimd.BroadcastUint64x8(33)
+	c.s29 = archsimd.BroadcastUint64x8(29)
+	c.s32 = archsimd.BroadcastUint64x8(32)
+	return c
+}
+
+func avalanche8x64(h archsimd.Uint64x8, c *sum64Consts) archsimd.Uint64x8 {
+	h = h.Xor(h.ShiftRight(c.s33))
+	h = h.Mul(c.p2)
+	h = h.Xor(h.ShiftRight(c.s29))
+	h = h.Mul(c.p3)
+	h = h.Xor(h.ShiftRight(c.s32))
+	return h
+}
+
+// round8x64 computes round(0, input): rol31(input*prime2) * prime1.
+func round8x64(input archsimd.Uint64x8, c *sum64Consts) archsimd.Uint64x8 {
+	return input.Mul(c.p2).RotateAllLeft(31).Mul(c.p1)
+}
+
+func MultiSum64Uint8(h []uint64, v []uint8) int {
+	n := min(len(h), len(v))
+	i := 0
+	if archsimd.X86.AVX512() && n >= 16 {
+		c := sum64ConstsOf()
+		seed := archsimd.BroadcastUint64x8(prime5 + 1)
+		m := n / 16
+		cv := unsafecast.Slice[[16]uint8](v)[:m]
+		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		for j := range cv {
+			x := archsimd.LoadUint8x16Slice(cv[j][:])
+			v0 := x.ExtendLo8ToUint64()
+			v1 := x.ConcatShiftBytesRight(8, x).ExtendLo8ToUint64()
+			h0 := seed.Xor(v0.Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
+			h1 := seed.Xor(v1.Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
+			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
+			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+		}
+		i = m * 16
+		archsimd.ClearAVXUpperBits()
+	}
+	for ; i < n; i++ {
+		h[i] = Sum64Uint8(v[i])
+	}
+	return n
+}
+
+func MultiSum64Uint16(h []uint64, v []uint16) int {
+	n := min(len(h), len(v))
+	i := 0
+	if archsimd.X86.AVX512() && n >= 16 {
+		c := sum64ConstsOf()
+		seed := archsimd.BroadcastUint64x8(prime5 + 2)
+		lowByte := archsimd.BroadcastUint64x8(0xFF)
+		s8 := archsimd.BroadcastUint64x8(8)
+		m := n / 16
+		cv := unsafecast.Slice[[16]uint16](v)[:m]
+		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		for j := range cv {
+			v0 := archsimd.LoadUint16x8Slice(cv[j][0:8]).ExtendToUint64()
+			v1 := archsimd.LoadUint16x8Slice(cv[j][8:16]).ExtendToUint64()
+			h0 := seed.Xor(v0.And(lowByte).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
+			h1 := seed.Xor(v1.And(lowByte).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
+			h0 = h0.Xor(v0.ShiftRight(s8).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
+			h1 = h1.Xor(v1.ShiftRight(s8).Mul(c.p5)).RotateAllLeft(11).Mul(c.p1)
+			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
+			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+		}
+		i = m * 16
+		archsimd.ClearAVXUpperBits()
+	}
+	for ; i < n; i++ {
+		h[i] = Sum64Uint16(v[i])
+	}
+	return n
+}
+
+func MultiSum64Uint32(h []uint64, v []uint32) int {
+	n := min(len(h), len(v))
+	i := 0
+	if archsimd.X86.AVX512() && n >= 16 {
+		c := sum64ConstsOf()
+		seed := archsimd.BroadcastUint64x8(prime5 + 4)
+		m := n / 16
+		cv := unsafecast.Slice[[16]uint32](v)[:m]
+		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		for j := range cv {
+			v0 := archsimd.LoadUint32x8Slice(cv[j][0:8]).ExtendToUint64()
+			v1 := archsimd.LoadUint32x8Slice(cv[j][8:16]).ExtendToUint64()
+			h0 := seed.Xor(v0.Mul(c.p1)).RotateAllLeft(23).Mul(c.p2).Add(c.p3)
+			h1 := seed.Xor(v1.Mul(c.p1)).RotateAllLeft(23).Mul(c.p2).Add(c.p3)
+			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
+			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+		}
+		i = m * 16
+		archsimd.ClearAVXUpperBits()
+	}
+	for ; i < n; i++ {
+		h[i] = Sum64Uint32(v[i])
+	}
+	return n
+}
+
+func MultiSum64Uint64(h []uint64, v []uint64) int {
+	n := min(len(h), len(v))
+	i := 0
+	if archsimd.X86.AVX512() && n >= 16 {
+		c := sum64ConstsOf()
+		seed := archsimd.BroadcastUint64x8(prime5 + 8)
+		p4 := archsimd.BroadcastUint64x8(prime4)
+		m := n / 16
+		cv := unsafecast.Slice[[16]uint64](v)[:m]
+		ch := unsafecast.Slice[[16]uint64](h)[:m]
+		for j := range cv {
+			v0 := archsimd.LoadUint64x8Slice(cv[j][0:8])
+			v1 := archsimd.LoadUint64x8Slice(cv[j][8:16])
+			h0 := seed.Xor(round8x64(v0, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
+			h1 := seed.Xor(round8x64(v1, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
+			avalanche8x64(h0, &c).StoreSlice(ch[j][0:8])
+			avalanche8x64(h1, &c).StoreSlice(ch[j][8:16])
+		}
+		i = m * 16
+		archsimd.ClearAVXUpperBits()
+	}
+	for ; i < n; i++ {
+		h[i] = Sum64Uint64(v[i])
+	}
+	return n
+}
+
+// Lane indexes deinterleaving the low and high halves of 8 consecutive
+// 128 bits values loaded as two vectors of 8 uint64.
+var (
+	evenLanes = [8]uint64{0, 2, 4, 6, 8, 10, 12, 14}
+	oddLanes  = [8]uint64{1, 3, 5, 7, 9, 11, 13, 15}
+)
+
+func MultiSum64Uint128(h []uint64, v [][16]byte) int {
+	n := min(len(h), len(v))
+	i := 0
+	if archsimd.X86.AVX512() && n >= 8 {
+		c := sum64ConstsOf()
+		seed := archsimd.BroadcastUint64x8(prime5 + 16)
+		p4 := archsimd.BroadcastUint64x8(prime4)
+		even := archsimd.LoadUint64x8Slice(evenLanes[:])
+		odd := archsimd.LoadUint64x8Slice(oddLanes[:])
+		m := n / 8
+		cv := unsafecast.Slice[[16]uint64](v)[:m]
+		ch := unsafecast.Slice[[8]uint64](h)[:m]
+		for j := range cv {
+			z0 := archsimd.LoadUint64x8Slice(cv[j][0:8])
+			z1 := archsimd.LoadUint64x8Slice(cv[j][8:16])
+			lo := z0.ConcatPermute(z1, even)
+			hi := z0.ConcatPermute(z1, odd)
+			hh := seed.Xor(round8x64(lo, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
+			hh = hh.Xor(round8x64(hi, &c)).RotateAllLeft(27).Mul(c.p1).Add(p4)
+			avalanche8x64(hh, &c).StoreSlice(ch[j][:])
+		}
+		i = m * 8
+		archsimd.ClearAVXUpperBits()
+	}
+	for ; i < n; i++ {
+		h[i] = Sum64Uint128(v[i])
+	}
+	return n
+}

--- a/docs/archsimd-port.md
+++ b/docs/archsimd-port.md
@@ -94,8 +94,26 @@ Intricate lane choreography, but every instruction has an archsimd equivalent.
   rotate + carry blend on the 32-bit view); scalar GetElem reductions
   lose to in-register shuffle ladders (SelectFromPair via a float view —
   shuffles are bit agnostic — flipped bitwidths from +49% to -4%).
-- Remaining tier 3: the general 2/3-16 bit mini block packers, delta
-  byte_array validate, minBE128/maxBE128.
+- **2-16 bit mini block packer**: done — two fold steps of variable
+  shifts and permutes leave 4 packed values in each of two qword lanes,
+  and a scalar 128-bit stitch stores each byte-aligned 8-value group
+  (replacing both the PDEP 2-bit path and the general 3-16 bit asm).
+- **delta byte_array**: done — vectorized prefix/suffix validation
+  (rotate+carry compares, Or-accumulated negative detection), 32-byte
+  over-copy decoders, 16-byte fixed-length specialization with the
+  previous value register-resident. The AVX2-gated paths are exercised
+  under Rosetta.
+- **minBE128/maxBE128**: done — 8 values per iteration as byteswapped
+  (grouped VPSHUFB) hi/lo uint64 lanes, lexicographic compare masks with
+  index tracking, one store+scan reduction per call. Vs asm: +21% (4KiB),
+  parity (256KiB), +6% (2MB). Caught in review: sentinel seeds tie with
+  real extreme values and can return a wrong index — seed from the first
+  chunk instead (pinned by a differential test vs the scalar code).
+
+Tier 3 complete: every assembly kernel that archsimd can express now has
+a Go implementation. Remaining assembly under GOEXPERIMENT=simd is only
+the tier 4 blocked set (gather/scatter/PDEP users) and scalar tier 5
+code.
 
 ## Tier 4 — blocked: needs instructions archsimd doesn't expose
 

--- a/docs/archsimd-port.md
+++ b/docs/archsimd-port.md
@@ -83,9 +83,19 @@ Intricate lane choreography, but every instruction has an archsimd equivalent.
   the stack per use — individual locals stay in registers (32 ZMM regs
   exist for this); and latency-bound mul chains need 4 streams, exactly
   like the assembly.
-- Remaining tier 3: delta binary_packed block kernels (delta/min/sub/
-  bitwidths/decodeBlock), the general bit-packers, delta byte_array
-  validate, minBE128/maxBE128.
+- **delta binary_packed block kernels**: done — delta/min/sub/bitwidths
+  for int32/int64 (AVX-512 + AVX2 tiers), vector-carried decodeBlockInt32
+  prefix sum, compare-to-bits 1-bit mini block encoders, full-width
+  copies; validated through the same parameterized test harnesses as the
+  assembly. Vs asm (int32): **delta -9%, min -20%, bitwidths -4%**,
+  sub +6%. The 2-bit (PDEP in asm) and 3-16 bit packers fall back to the
+  scalar packer for now. Traps re-confirmed: ConcatPermute and 64-bit
+  lane permutes at 256 bits are EVEX (AVX2 tier uses full-cross VPERMD
+  rotate + carry blend on the 32-bit view); scalar GetElem reductions
+  lose to in-register shuffle ladders (SelectFromPair via a float view —
+  shuffles are bit agnostic — flipped bitwidths from +49% to -4%).
+- Remaining tier 3: the general 2/3-16 bit mini block packers, delta
+  byte_array validate, minBE128/maxBE128.
 
 ## Tier 4 — blocked: needs instructions archsimd doesn't expose
 

--- a/docs/archsimd-port.md
+++ b/docs/archsimd-port.md
@@ -71,6 +71,22 @@ Intricate lane choreography, but every instruction has an archsimd equivalent.
 | `validatePrefixAndSuffixLengthValuesAVX2` + `decodeByteArray*` | encoding/delta/byte_array_amd64.s | validation is portable (rotate+compare+movemask); the decode over-copy tricks are mostly `copy` logic — may end up plain Go |
 | `minBE128` / `maxBE128` | page_min/page_max_amd64.s | lexicographic u128 min/max with index tracking: byte-swap `Permute`, paired `VPCMPUQ` → mask bit-fixup → `Merge`. Hardest portable kernel; also fixes ungated AVX512BW use (VPSHUFB on ZMM) |
 
+## Tier 3 progress (branch archsimd-tier3)
+
+- **xxhash MultiSum64 (5 kernels)**: done — 8 hashes per Uint64x8, four
+  independent streams, register-resident constants. Validated by the
+  property tests (every element vs the canonical Sum64) on AVX-512
+  hardware. Vs assembly: Uint8/16/32/64 within **-6..-9%**, Uint128
+  **+49% faster**. The gate is an honest X86.AVX512 (the asm tested
+  AVX512CD, unused, while relying on unchecked AVX512DQ).
+  Lesson reinforced: constants in a pointer-accessed struct reload from
+  the stack per use — individual locals stay in registers (32 ZMM regs
+  exist for this); and latency-bound mul chains need 4 streams, exactly
+  like the assembly.
+- Remaining tier 3: delta binary_packed block kernels (delta/min/sub/
+  bitwidths/decodeBlock), the general bit-packers, delta byte_array
+  validate, minBE128/maxBE128.
+
 ## Tier 4 — blocked: needs instructions archsimd doesn't expose
 
 | Kernel | File | Blocker | Possible redesign |

--- a/encoding/delta/binary_packed_amd64.go
+++ b/encoding/delta/binary_packed_amd64.go
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && !goexperiment.simd
 
 package delta
 

--- a/encoding/delta/binary_packed_amd64.s
+++ b/encoding/delta/binary_packed_amd64.s
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && !goexperiment.simd
 
 #include "textflag.h"
 

--- a/encoding/delta/binary_packed_amd64_test.go
+++ b/encoding/delta/binary_packed_amd64_test.go
@@ -1,4 +1,4 @@
-//go:build amd64 && !purego
+//go:build amd64 && !purego && !goexperiment.simd
 
 package delta
 

--- a/encoding/delta/binary_packed_purego.go
+++ b/encoding/delta/binary_packed_purego.go
@@ -1,4 +1,4 @@
-//go:build purego || !amd64
+//go:build !amd64 || (purego && !goexperiment.simd)
 
 package delta
 

--- a/encoding/delta/binary_packed_simd_amd64.go
+++ b/encoding/delta/binary_packed_simd_amd64.go
@@ -1,0 +1,531 @@
+//go:build goexperiment.simd
+
+package delta
+
+import (
+	"encoding/binary"
+	"math/bits"
+
+	"simd/archsimd"
+
+	"github.com/parquet-go/bitpack/unsafecast"
+)
+
+// This file provides implementations of the DELTA_BINARY_PACKED block
+// kernels based on the simd/archsimd package, replacing the hand-written
+// assembly of binary_packed_amd64.s when GOEXPERIMENT=simd is set.
+//
+// The blocks are fixed size arrays ([128]int32 or [128]int64), so all the
+// vector loads and stores use compile time constant indexes with no bounds
+// checks. The delta and decode kernels keep their carries in vector
+// registers (all lanes equal), and shifted vectors are built with
+// ConcatPermute against the carry, following the patterns validated by the
+// earlier tiers.
+//
+// The 1 bit mini block encoders use the compare-to-bits path (a mask IS the
+// packed output); the 2 and 3-16 bits encoders fall back to the scalar
+// packer for now (the assembly used PDEP for 2 bits, which archsimd does
+// not expose, and the general packer is tracked as follow-up work).
+
+func init() {
+	if archsimd.X86.AVX2() {
+		encodeInt32 = encodeInt32SIMD
+		encodeInt64 = encodeInt64SIMD
+	}
+}
+
+// Lane indexes building a vector shifted right by one element from the
+// concatenation of the carry vector (all lanes equal) and the current
+// chunk.
+var (
+	shiftInCarry16   = [16]uint32{15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30}
+	shiftInCarry8    = [8]uint32{7, 8, 9, 10, 11, 12, 13, 14}
+	lastLane16       = [16]uint32{15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15}
+	lastLane8x64     = [8]uint64{7, 7, 7, 7, 7, 7, 7, 7}
+	shiftInCarry8x64 = [8]uint64{7, 8, 9, 10, 11, 12, 13, 14}
+	lastLane8x32     = [8]uint32{7, 7, 7, 7, 7, 7, 7, 7}
+
+	// AVX2 tier tables: ConcatPermute and 64 bits lane permutes are EVEX
+	// encodings, so the carry injection uses a full-cross VPERMD rotate on
+	// the 32 bits view plus a blend of the carry lanes.
+	rotate1x8x32 = [8]uint32{7, 0, 1, 2, 3, 4, 5, 6}
+	rotate1x4x64 = [8]uint32{6, 7, 0, 1, 2, 3, 4, 5}
+	lastPair8x32 = [8]uint32{6, 7, 6, 7, 6, 7, 6, 7}
+)
+
+func blockDeltaInt32SIMD(block *[blockSize]int32, lastValue int32) int32 {
+	if archsimd.X86.AVX512() {
+		idx := archsimd.LoadUint32x16Slice(shiftInCarry16[:])
+		bcl := archsimd.LoadUint32x16Slice(lastLane16[:])
+		carry := archsimd.BroadcastInt32x16(lastValue)
+		for i := 0; i < blockSize; i += 16 {
+			orig := archsimd.LoadInt32x16Slice(block[i : i+16])
+			shifted := carry.ConcatPermute(orig, idx)
+			orig.Sub(shifted).StoreSlice(block[i : i+16])
+			carry = orig.Permute(bcl)
+		}
+		last := carry.GetLo().GetLo().GetElem(0)
+		archsimd.ClearAVXUpperBits()
+		return last
+	}
+	rot := archsimd.LoadUint32x8Slice(rotate1x8x32[:])
+	bcl := archsimd.LoadUint32x8Slice(lastLane8x32[:])
+	iota8 := archsimd.LoadInt32x8Slice(laneIndexes[:])
+	tail := iota8.Greater(archsimd.BroadcastInt32x8(0))
+	carry := archsimd.BroadcastInt32x8(lastValue)
+	for i := 0; i < blockSize; i += 8 {
+		orig := archsimd.LoadInt32x8Slice(block[i : i+8])
+		shifted := orig.Permute(rot).Merge(carry, tail)
+		orig.Sub(shifted).StoreSlice(block[i : i+8])
+		carry = orig.Permute(bcl)
+	}
+	last := carry.GetLo().GetElem(0)
+	archsimd.ClearAVXUpperBits()
+	return last
+}
+
+func blockMinInt32SIMD(block *[blockSize]int32) int32 {
+	if archsimd.X86.AVX512() {
+		a0 := archsimd.LoadInt32x16Slice(block[0:16])
+		a1 := archsimd.LoadInt32x16Slice(block[16:32])
+		for i := 32; i < blockSize; i += 32 {
+			a0 = a0.Min(archsimd.LoadInt32x16Slice(block[i : i+16]))
+			a1 = a1.Min(archsimd.LoadInt32x16Slice(block[i+16 : i+32]))
+		}
+		a0 = a0.Min(a1)
+		h := a0.GetLo().Min(a0.GetHi())
+		q := h.GetLo().Min(h.GetHi())
+		m := reduceMinInt32x4Delta(q)
+		archsimd.ClearAVXUpperBits()
+		return m
+	}
+	a0 := archsimd.LoadInt32x8Slice(block[0:8])
+	a1 := archsimd.LoadInt32x8Slice(block[8:16])
+	for i := 16; i < blockSize; i += 16 {
+		a0 = a0.Min(archsimd.LoadInt32x8Slice(block[i : i+8]))
+		a1 = a1.Min(archsimd.LoadInt32x8Slice(block[i+8 : i+16]))
+	}
+	a0 = a0.Min(a1)
+	q := a0.GetLo().Min(a0.GetHi())
+	m := reduceMinInt32x4Delta(q)
+	archsimd.ClearAVXUpperBits()
+	return m
+}
+
+func reduceMinInt32x4Delta(v archsimd.Int32x4) int32 {
+	m := v.GetElem(0)
+	if x := v.GetElem(1); x < m {
+		m = x
+	}
+	if x := v.GetElem(2); x < m {
+		m = x
+	}
+	if x := v.GetElem(3); x < m {
+		m = x
+	}
+	return m
+}
+
+func blockSubInt32SIMD(block *[blockSize]int32, value int32) {
+	if archsimd.X86.AVX512() {
+		v := archsimd.BroadcastInt32x16(value)
+		for i := 0; i < blockSize; i += 16 {
+			archsimd.LoadInt32x16Slice(block[i : i+16]).Sub(v).StoreSlice(block[i : i+16])
+		}
+		archsimd.ClearAVXUpperBits()
+		return
+	}
+	v := archsimd.BroadcastInt32x8(value)
+	for i := 0; i < blockSize; i += 8 {
+		archsimd.LoadInt32x8Slice(block[i : i+8]).Sub(v).StoreSlice(block[i : i+8])
+	}
+	archsimd.ClearAVXUpperBits()
+}
+
+func blockBitWidthsInt32SIMD(bitWidths *[numMiniBlocks]byte, block *[blockSize]int32) {
+	for i := range bitWidths {
+		mb := block[i*miniBlockSize : i*miniBlockSize+miniBlockSize]
+		var m uint32
+		if archsimd.X86.AVX512() {
+			a := archsimd.LoadUint32x16Slice(unsafecast.Slice[uint32](mb[0:16]))
+			b := archsimd.LoadUint32x16Slice(unsafecast.Slice[uint32](mb[16:32]))
+			a = a.Max(b)
+			h := a.GetLo().Max(a.GetHi())
+			q := h.GetLo().Max(h.GetHi())
+			m = reduceMaxUint32x4Delta(q)
+		} else {
+			u := unsafecast.Slice[uint32](mb)
+			a := archsimd.LoadUint32x8Slice(u[0:8]).Max(archsimd.LoadUint32x8Slice(u[8:16]))
+			b := archsimd.LoadUint32x8Slice(u[16:24]).Max(archsimd.LoadUint32x8Slice(u[24:32]))
+			a = a.Max(b)
+			q := a.GetLo().Max(a.GetHi())
+			m = reduceMaxUint32x4Delta(q)
+		}
+		bitWidths[i] = byte(bits.Len32(m))
+	}
+	archsimd.ClearAVXUpperBits()
+}
+
+func reduceMaxUint32x4Delta(v archsimd.Uint32x4) uint32 {
+	m := v.GetElem(0)
+	if x := v.GetElem(1); x > m {
+		m = x
+	}
+	if x := v.GetElem(2); x > m {
+		m = x
+	}
+	if x := v.GetElem(3); x > m {
+		m = x
+	}
+	return m
+}
+
+func decodeBlockInt32(dst []int32, minDelta, lastValue int32) int32 {
+	i := 0
+	if archsimd.X86.AVX2() && len(dst) >= 8 {
+		zero := archsimd.BroadcastInt32x8(0)
+		md := archsimd.BroadcastInt32x8(minDelta)
+		idx1 := archsimd.LoadUint32x8Slice(shiftLanes1[:])
+		idx2 := archsimd.LoadUint32x8Slice(shiftLanes2[:])
+		idx4 := archsimd.LoadUint32x8Slice(shiftLanes4[:])
+		last := archsimd.LoadUint32x8Slice(lastLane8x32[:])
+		iota8 := archsimd.LoadInt32x8Slice(laneIndexes[:])
+		m1 := iota8.Greater(zero)
+		m2 := iota8.Greater(archsimd.BroadcastInt32x8(1))
+		m4 := iota8.Greater(archsimd.BroadcastInt32x8(3))
+		carry := archsimd.BroadcastInt32x8(lastValue)
+		cd := unsafecast.Slice[[8]int32](dst)
+		for j := range cd {
+			v := archsimd.LoadInt32x8Slice(cd[j][:]).Add(md)
+			s := v.Add(v.Permute(idx1).Merge(zero, m1))
+			s = s.Add(s.Permute(idx2).Merge(zero, m2))
+			s = s.Add(s.Permute(idx4).Merge(zero, m4))
+			out := s.Add(carry)
+			out.StoreSlice(cd[j][:])
+			carry = out.Permute(last)
+		}
+		i = len(cd) * 8
+		lastValue = carry.GetLo().GetElem(0)
+		archsimd.ClearAVXUpperBits()
+	}
+	for ; i < len(dst); i++ {
+		dst[i] += minDelta + lastValue
+		lastValue = dst[i]
+	}
+	return lastValue
+}
+
+func blockDeltaInt64SIMD(block *[blockSize]int64, lastValue int64) int64 {
+	if archsimd.X86.AVX512() {
+		idx := archsimd.LoadUint64x8Slice(shiftInCarry8x64[:])
+		bcl := archsimd.LoadUint64x8Slice(lastLane8x64[:])
+		carry := archsimd.BroadcastInt64x8(lastValue)
+		for i := 0; i < blockSize; i += 8 {
+			orig := archsimd.LoadInt64x8Slice(block[i : i+8])
+			shifted := carry.ConcatPermute(orig, idx)
+			orig.Sub(shifted).StoreSlice(block[i : i+8])
+			carry = orig.Permute(bcl)
+		}
+		last := carry.GetLo().GetLo().GetElem(0)
+		archsimd.ClearAVXUpperBits()
+		return last
+	}
+	rot := archsimd.LoadUint32x8Slice(rotate1x4x64[:])
+	bcp := archsimd.LoadUint32x8Slice(lastPair8x32[:])
+	iota8 := archsimd.LoadInt32x8Slice(laneIndexes[:])
+	tail := iota8.Greater(archsimd.BroadcastInt32x8(1))
+	carry := archsimd.BroadcastInt64x4(lastValue)
+	for i := 0; i < blockSize; i += 4 {
+		orig := archsimd.LoadInt64x4Slice(block[i : i+4])
+		o32 := orig.AsInt32x8()
+		shifted := o32.Permute(rot).Merge(carry.AsInt32x8(), tail).AsInt64x4()
+		orig.Sub(shifted).StoreSlice(block[i : i+4])
+		carry = o32.Permute(bcp).AsInt64x4()
+	}
+	last := carry.GetLo().GetElem(0)
+	archsimd.ClearAVXUpperBits()
+	return last
+}
+
+func blockMinInt64SIMD(block *[blockSize]int64) int64 {
+	if archsimd.X86.AVX512() {
+		a0 := archsimd.LoadInt64x8Slice(block[0:8])
+		a1 := archsimd.LoadInt64x8Slice(block[8:16])
+		for i := 16; i < blockSize; i += 16 {
+			a0 = a0.Min(archsimd.LoadInt64x8Slice(block[i : i+8]))
+			a1 = a1.Min(archsimd.LoadInt64x8Slice(block[i+8 : i+16]))
+		}
+		a0 = a0.Min(a1)
+		h := a0.GetLo().Min(a0.GetHi())
+		q := h.GetLo().Min(h.GetHi())
+		m := q.GetElem(0)
+		if x := q.GetElem(1); x < m {
+			m = x
+		}
+		archsimd.ClearAVXUpperBits()
+		return m
+	}
+	// Int64x4.Min is AVX-512 only (VPMINSQ); the AVX2 tier selects with a
+	// signed compare and merge.
+	a0 := archsimd.LoadInt64x4Slice(block[0:4])
+	a1 := archsimd.LoadInt64x4Slice(block[4:8])
+	for i := 8; i < blockSize; i += 8 {
+		v0 := archsimd.LoadInt64x4Slice(block[i : i+4])
+		v1 := archsimd.LoadInt64x4Slice(block[i+4 : i+8])
+		a0 = v0.Merge(a0, a0.Greater(v0))
+		a1 = v1.Merge(a1, a1.Greater(v1))
+	}
+	a0 = a1.Merge(a0, a0.Greater(a1))
+	lo := a0.GetLo()
+	hi := a0.GetHi()
+	q := hi.Merge(lo, lo.Greater(hi))
+	m := q.GetElem(0)
+	if x := q.GetElem(1); x < m {
+		m = x
+	}
+	archsimd.ClearAVXUpperBits()
+	return m
+}
+
+func blockSubInt64SIMD(block *[blockSize]int64, value int64) {
+	if archsimd.X86.AVX512() {
+		v := archsimd.BroadcastInt64x8(value)
+		for i := 0; i < blockSize; i += 8 {
+			archsimd.LoadInt64x8Slice(block[i : i+8]).Sub(v).StoreSlice(block[i : i+8])
+		}
+		archsimd.ClearAVXUpperBits()
+		return
+	}
+	v := archsimd.BroadcastInt64x4(value)
+	for i := 0; i < blockSize; i += 4 {
+		archsimd.LoadInt64x4Slice(block[i : i+4]).Sub(v).StoreSlice(block[i : i+4])
+	}
+	archsimd.ClearAVXUpperBits()
+}
+
+func blockBitWidthsInt64SIMD(bitWidths *[numMiniBlocks]byte, block *[blockSize]int64) {
+	for i := range bitWidths {
+		mb := block[i*miniBlockSize : i*miniBlockSize+miniBlockSize]
+		u := unsafecast.Slice[uint64](mb)
+		var m uint64
+		if archsimd.X86.AVX512() {
+			a := archsimd.LoadUint64x8Slice(u[0:8]).Max(archsimd.LoadUint64x8Slice(u[8:16]))
+			b := archsimd.LoadUint64x8Slice(u[16:24]).Max(archsimd.LoadUint64x8Slice(u[24:32]))
+			a = a.Max(b)
+			h := a.GetLo().Max(a.GetHi())
+			q := h.GetLo().Max(h.GetHi())
+			m = q.GetElem(0)
+			if x := q.GetElem(1); x > m {
+				m = x
+			}
+		} else {
+			// Unsigned 64 bits max at the AVX2 tier: sign-biased signed
+			// compare and merge (VPMAXUQ is AVX-512 only).
+			sign := archsimd.BroadcastUint64x4(1 << 63)
+			a := archsimd.LoadUint64x4Slice(u[0:4])
+			for k := 4; k < miniBlockSize; k += 4 {
+				v := archsimd.LoadUint64x4Slice(u[k : k+4])
+				gt := v.Xor(sign).AsInt64x4().Greater(a.Xor(sign).AsInt64x4())
+				a = v.Merge(a, gt)
+			}
+			lo := a.GetLo()
+			hi := a.GetHi()
+			gt := hi.Xor(sign.GetLo()).AsInt64x2().Greater(lo.Xor(sign.GetLo()).AsInt64x2())
+			q := hi.Merge(lo, gt)
+			m = q.GetElem(0)
+			if x := q.GetElem(1); x > m {
+				m = x
+			}
+		}
+		bitWidths[i] = byte(bits.Len64(m))
+	}
+	archsimd.ClearAVXUpperBits()
+}
+
+func decodeBlockInt64(dst []int64, minDelta, lastValue int64) int64 {
+	for i := range dst {
+		dst[i] += minDelta + lastValue
+		lastValue = dst[i]
+	}
+	return lastValue
+}
+
+// encodeMiniBlockInt32 is the scalar packer used for the widths without a
+// vector specialization; it mirrors the purego implementation (the packed
+// destination is zero initialized by the callers).
+func encodeMiniBlockInt32(dst []byte, src *[miniBlockSize]int32, bitWidth uint) {
+	bitMask := uint32(1<<bitWidth) - 1
+	bitOffset := uint(0)
+
+	for _, value := range src {
+		i := bitOffset / 32
+		j := bitOffset % 32
+
+		lo := binary.LittleEndian.Uint32(dst[(i+0)*4:])
+		hi := binary.LittleEndian.Uint32(dst[(i+1)*4:])
+
+		lo |= (uint32(value) & bitMask) << j
+		hi |= (uint32(value) >> (32 - j))
+
+		binary.LittleEndian.PutUint32(dst[(i+0)*4:], lo)
+		binary.LittleEndian.PutUint32(dst[(i+1)*4:], hi)
+
+		bitOffset += bitWidth
+	}
+}
+
+func encodeMiniBlockInt64(dst []byte, src *[miniBlockSize]int64, bitWidth uint) {
+	bitMask := uint64(1<<bitWidth) - 1
+	bitOffset := uint(0)
+
+	for _, value := range src {
+		i := bitOffset / 64
+		j := bitOffset % 64
+
+		lo := binary.LittleEndian.Uint64(dst[(i+0)*8:])
+		hi := binary.LittleEndian.Uint64(dst[(i+1)*8:])
+
+		lo |= (uint64(value) & bitMask) << j
+		hi |= (uint64(value) >> (64 - j))
+
+		binary.LittleEndian.PutUint64(dst[(i+0)*8:], lo)
+		binary.LittleEndian.PutUint64(dst[(i+1)*8:], hi)
+
+		bitOffset += bitWidth
+	}
+}
+
+// The 1 bit encoders are compare-to-mask: the mask bits ARE the packed
+// output.
+func encodeMiniBlockInt32x1bit(dst []byte, src *[miniBlockSize]int32) {
+	one := archsimd.BroadcastInt32x16(1)
+	m0 := archsimd.LoadInt32x16Slice(src[0:16]).Equal(one).ToBits()
+	m1 := archsimd.LoadInt32x16Slice(src[16:32]).Equal(one).ToBits()
+	binary.LittleEndian.PutUint32(dst, uint32(m0)|uint32(m1)<<16)
+	archsimd.ClearAVXUpperBits()
+}
+
+func encodeMiniBlockInt64x1bit(dst []byte, src *[miniBlockSize]int64) {
+	one := archsimd.BroadcastInt64x8(1)
+	m0 := archsimd.LoadInt64x8Slice(src[0:8]).Equal(one).ToBits()
+	m1 := archsimd.LoadInt64x8Slice(src[8:16]).Equal(one).ToBits()
+	m2 := archsimd.LoadInt64x8Slice(src[16:24]).Equal(one).ToBits()
+	m3 := archsimd.LoadInt64x8Slice(src[24:32]).Equal(one).ToBits()
+	bits := uint32(m0) | uint32(m1)<<8 | uint32(m2)<<16 | uint32(m3)<<24
+	binary.LittleEndian.PutUint32(dst, bits)
+	archsimd.ClearAVXUpperBits()
+}
+
+func encodeMiniBlockInt32SIMD(dst []byte, src *[miniBlockSize]int32, bitWidth uint) {
+	switch {
+	case bitWidth == 1 && archsimd.X86.AVX512():
+		encodeMiniBlockInt32x1bit(dst, src)
+	case bitWidth == 32:
+		copy(dst, unsafecast.Slice[byte](src[:]))
+	default:
+		encodeMiniBlockInt32(dst, src, bitWidth)
+	}
+}
+
+func encodeMiniBlockInt64SIMD(dst []byte, src *[miniBlockSize]int64, bitWidth uint) {
+	switch {
+	case bitWidth == 1 && archsimd.X86.AVX512():
+		encodeMiniBlockInt64x1bit(dst, src)
+	case bitWidth == 64:
+		copy(dst, unsafecast.Slice[byte](src[:]))
+	default:
+		encodeMiniBlockInt64(dst, src, bitWidth)
+	}
+}
+
+func encodeInt32SIMD(dst []byte, src []int32) []byte {
+	totalValues := len(src)
+	firstValue := int32(0)
+	if totalValues > 0 {
+		firstValue = src[0]
+	}
+
+	n := len(dst)
+	dst = resize(dst, n+maxHeaderLength32)
+	dst = dst[:n+encodeBinaryPackedHeader(dst[n:], blockSize, numMiniBlocks, totalValues, int64(firstValue))]
+
+	if totalValues < 2 {
+		return dst
+	}
+
+	lastValue := firstValue
+	for i := 1; i < len(src); i += blockSize {
+		block := [blockSize]int32{}
+		blockLength := copy(block[:], src[i:])
+
+		lastValue = blockDeltaInt32SIMD(&block, lastValue)
+		minDelta := blockMinInt32SIMD(&block)
+		blockSubInt32SIMD(&block, minDelta)
+		blockClearInt32(&block, blockLength)
+
+		bitWidths := [numMiniBlocks]byte{}
+		blockBitWidthsInt32SIMD(&bitWidths, &block)
+
+		n := len(dst)
+		dst = resize(dst, n+maxMiniBlockLength32+16)
+		n += encodeBlockHeader(dst[n:], int64(minDelta), bitWidths)
+
+		for i, bitWidth := range bitWidths {
+			if bitWidth != 0 {
+				miniBlock := (*[miniBlockSize]int32)(block[i*miniBlockSize:])
+				encodeMiniBlockInt32SIMD(dst[n:], miniBlock, uint(bitWidth))
+				n += (miniBlockSize * int(bitWidth)) / 8
+			}
+		}
+
+		dst = dst[:n]
+	}
+
+	return dst
+}
+
+func encodeInt64SIMD(dst []byte, src []int64) []byte {
+	totalValues := len(src)
+	firstValue := int64(0)
+	if totalValues > 0 {
+		firstValue = src[0]
+	}
+
+	n := len(dst)
+	dst = resize(dst, n+maxHeaderLength64)
+	dst = dst[:n+encodeBinaryPackedHeader(dst[n:], blockSize, numMiniBlocks, totalValues, firstValue)]
+
+	if totalValues < 2 {
+		return dst
+	}
+
+	lastValue := firstValue
+	for i := 1; i < len(src); i += blockSize {
+		block := [blockSize]int64{}
+		blockLength := copy(block[:], src[i:])
+
+		lastValue = blockDeltaInt64SIMD(&block, lastValue)
+		minDelta := blockMinInt64SIMD(&block)
+		blockSubInt64SIMD(&block, minDelta)
+		blockClearInt64(&block, blockLength)
+
+		bitWidths := [numMiniBlocks]byte{}
+		blockBitWidthsInt64SIMD(&bitWidths, &block)
+
+		n := len(dst)
+		dst = resize(dst, n+maxMiniBlockLength64+16)
+		n += encodeBlockHeader(dst[n:], minDelta, bitWidths)
+
+		for i, bitWidth := range bitWidths {
+			if bitWidth != 0 {
+				miniBlock := (*[miniBlockSize]int64)(block[i*miniBlockSize:])
+				encodeMiniBlockInt64SIMD(dst[n:], miniBlock, uint(bitWidth))
+				n += (miniBlockSize * int(bitWidth)) / 8
+			}
+		}
+
+		dst = dst[:n]
+	}
+
+	return dst
+}

--- a/encoding/delta/binary_packed_simd_amd64.go
+++ b/encoding/delta/binary_packed_simd_amd64.go
@@ -407,10 +407,62 @@ func encodeMiniBlockInt64x1bit(dst []byte, src *[miniBlockSize]int64) {
 	archsimd.ClearAVXUpperBits()
 }
 
+// Lane indexes folding odd lanes onto even lanes and lanes {2,6} onto
+// {0,4} in the packing reduction (the values of the unused lanes are
+// irrelevant, the useful results live in lanes 0 and 4 afterwards).
+var (
+	foldOdd  = [8]uint64{1, 1, 3, 3, 5, 5, 7, 7}
+	foldPair = [8]uint64{2, 2, 2, 2, 6, 6, 6, 6}
+)
+
+// encodeMiniBlockInt32Packed packs 32 values of 2 to 16 bits each. Groups of
+// 8 values span exactly bitWidth bytes, so each group stores 16 bytes at its
+// byte aligned offset and the zeroed tail is overwritten by the next group
+// (the callers reserve 16 bytes of headroom, like they did for the
+// assembly). The 8 widened values are folded pairwise with variable shifts:
+// two vector steps leave 4 values in lane 0 and 4 in lane 4, and a scalar
+// 128 bits stitch combines them.
+func encodeMiniBlockInt32Packed(dst []byte, src *[miniBlockSize]int32, bitWidth uint) {
+	w := uint64(bitWidth)
+	var sh1v [8]uint64
+	var sh2v [8]uint64
+	for i := range sh1v {
+		if i%2 == 1 {
+			sh1v[i] = w
+		}
+		if i == 2 || i == 6 {
+			sh2v[i] = 2 * w
+		}
+	}
+	sh1 := archsimd.LoadUint64x8Slice(sh1v[:])
+	sh2 := archsimd.LoadUint64x8Slice(sh2v[:])
+	fo := archsimd.LoadUint64x8Slice(foldOdd[:])
+	fp := archsimd.LoadUint64x8Slice(foldPair[:])
+	u := unsafecast.Slice[uint32](src[:])
+	off := uint(0)
+	for g := 0; g < miniBlockSize; g += 8 {
+		v := archsimd.LoadUint32x8Slice(u[g : g+8]).ExtendToUint64()
+		t := v.ShiftLeft(sh1)
+		t = t.Or(t.Permute(fo))
+		t = t.ShiftLeft(sh2)
+		t = t.Or(t.Permute(fp))
+		q0 := t.GetLo().GetLo().GetElem(0)
+		q1 := t.GetHi().GetLo().GetElem(0)
+		lo := q0 | q1<<(4*w)
+		hi := q1 >> (64 - 4*w)
+		binary.LittleEndian.PutUint64(dst[off:], lo)
+		binary.LittleEndian.PutUint64(dst[off+8:], hi)
+		off += uint(w)
+	}
+	archsimd.ClearAVXUpperBits()
+}
+
 func encodeMiniBlockInt32SIMD(dst []byte, src *[miniBlockSize]int32, bitWidth uint) {
 	switch {
 	case bitWidth == 1 && archsimd.X86.AVX512():
 		encodeMiniBlockInt32x1bit(dst, src)
+	case bitWidth >= 2 && bitWidth <= 16 && archsimd.X86.AVX512():
+		encodeMiniBlockInt32Packed(dst, src, bitWidth)
 	case bitWidth == 32:
 		copy(dst, unsafecast.Slice[byte](src[:]))
 	default:

--- a/encoding/delta/binary_packed_simd_amd64.go
+++ b/encoding/delta/binary_packed_simd_amd64.go
@@ -113,17 +113,11 @@ func blockMinInt32SIMD(block *[blockSize]int32) int32 {
 }
 
 func reduceMinInt32x4Delta(v archsimd.Int32x4) int32 {
-	m := v.GetElem(0)
-	if x := v.GetElem(1); x < m {
-		m = x
-	}
-	if x := v.GetElem(2); x < m {
-		m = x
-	}
-	if x := v.GetElem(3); x < m {
-		m = x
-	}
-	return m
+	p := v.AsFloat32x4().SelectFromPair(2, 3, 0, 1, v.AsFloat32x4()).AsInt32x4()
+	v = v.Min(p)
+	p = v.AsFloat32x4().SelectFromPair(1, 0, 3, 2, v.AsFloat32x4()).AsInt32x4()
+	v = v.Min(p)
+	return v.GetElem(0)
 }
 
 func blockSubInt32SIMD(block *[blockSize]int32, value int32) {
@@ -166,18 +160,15 @@ func blockBitWidthsInt32SIMD(bitWidths *[numMiniBlocks]byte, block *[blockSize]i
 	archsimd.ClearAVXUpperBits()
 }
 
+// reduceMaxUint32x4Delta reduces in registers with a shuffle ladder; the
+// float view is only a reinterpretation for SelectFromPair (shuffles are bit
+// agnostic), the comparisons are the unsigned integer Max.
 func reduceMaxUint32x4Delta(v archsimd.Uint32x4) uint32 {
-	m := v.GetElem(0)
-	if x := v.GetElem(1); x > m {
-		m = x
-	}
-	if x := v.GetElem(2); x > m {
-		m = x
-	}
-	if x := v.GetElem(3); x > m {
-		m = x
-	}
-	return m
+	p := v.AsFloat32x4().SelectFromPair(2, 3, 0, 1, v.AsFloat32x4()).AsUint32x4()
+	v = v.Max(p)
+	p = v.AsFloat32x4().SelectFromPair(1, 0, 3, 2, v.AsFloat32x4()).AsUint32x4()
+	v = v.Max(p)
+	return v.GetElem(0)
 }
 
 func decodeBlockInt32(dst []int32, minDelta, lastValue int32) int32 {

--- a/encoding/delta/binary_packed_simd_test.go
+++ b/encoding/delta/binary_packed_simd_test.go
@@ -1,0 +1,61 @@
+//go:build goexperiment.simd
+
+package delta
+
+import "testing"
+
+func TestBlockDeltaInt32SIMD(t *testing.T) {
+	testBlockDeltaInt32(t, blockDeltaInt32SIMD)
+}
+
+func TestBlockMinInt32SIMD(t *testing.T) {
+	testBlockMinInt32(t, blockMinInt32SIMD)
+}
+
+func TestBlockSubInt32SIMD(t *testing.T) {
+	testBlockSubInt32(t, blockSubInt32SIMD)
+}
+
+func TestBlockBitWidthsInt32SIMD(t *testing.T) {
+	testBlockBitWidthsInt32(t, blockBitWidthsInt32SIMD)
+}
+
+func TestEncodeMiniBlockInt32SIMD(t *testing.T) {
+	testEncodeMiniBlockInt32(t, encodeMiniBlockInt32SIMD)
+}
+
+func TestBlockDeltaInt64SIMD(t *testing.T) {
+	testBlockDeltaInt64(t, blockDeltaInt64SIMD)
+}
+
+func TestBlockMinInt64SIMD(t *testing.T) {
+	testBlockMinInt64(t, blockMinInt64SIMD)
+}
+
+func TestBlockSubInt64SIMD(t *testing.T) {
+	testBlockSubInt64(t, blockSubInt64SIMD)
+}
+
+func TestBlockBitWidthsInt64SIMD(t *testing.T) {
+	testBlockBitWidthsInt64(t, blockBitWidthsInt64SIMD)
+}
+
+func TestEncodeMiniBlockInt64SIMD(t *testing.T) {
+	testEncodeMiniBlockInt64(t, encodeMiniBlockInt64SIMD)
+}
+
+func BenchmarkBlockDeltaInt32SIMD(b *testing.B) {
+	benchmarkBlockDeltaInt32(b, blockDeltaInt32SIMD)
+}
+
+func BenchmarkBlockMinInt32SIMD(b *testing.B) {
+	benchmarkBlockMinInt32(b, blockMinInt32SIMD)
+}
+
+func BenchmarkBlockSubInt32SIMD(b *testing.B) {
+	benchmarkBlockSubInt32(b, blockSubInt32SIMD)
+}
+
+func BenchmarkBlockBitWidthsInt32SIMD(b *testing.B) {
+	benchmarkBlockBitWidthsInt32(b, blockBitWidthsInt32SIMD)
+}

--- a/encoding/delta/byte_array_amd64.go
+++ b/encoding/delta/byte_array_amd64.go
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && !goexperiment.simd
 
 package delta
 

--- a/encoding/delta/byte_array_amd64.s
+++ b/encoding/delta/byte_array_amd64.s
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && !goexperiment.simd
 
 #include "funcdata.h"
 #include "textflag.h"

--- a/encoding/delta/byte_array_purego.go
+++ b/encoding/delta/byte_array_purego.go
@@ -1,4 +1,4 @@
-//go:build purego || !amd64
+//go:build !amd64 || (purego && !goexperiment.simd)
 
 package delta
 

--- a/encoding/delta/byte_array_simd_amd64.go
+++ b/encoding/delta/byte_array_simd_amd64.go
@@ -1,0 +1,295 @@
+//go:build goexperiment.simd
+
+package delta
+
+import (
+	"simd/archsimd"
+
+	"github.com/parquet-go/bitpack/unsafecast"
+)
+
+// This file provides implementations of the DELTA_BYTE_ARRAY kernels based
+// on the simd/archsimd package, replacing the hand-written assembly of
+// byte_array_amd64.s when GOEXPERIMENT=simd is set.
+
+// validatePrefixAndSuffixLengthValuesSIMD checks 8 length pairs per
+// iteration: negative values are accumulated with a running Or and tested
+// once, and the prefix lengths are compared against the previous value
+// lengths built with a rotate and carry blend. Any violation returns
+// ok=false and the scalar path reruns to identify the exact error.
+func validatePrefixAndSuffixLengthValuesSIMD(prefix, suffix []int32, maxLength int) (totalPrefixLength, totalSuffixLength int, ok bool) {
+	n := min(len(prefix), len(suffix))
+	i := 0
+	lastValueLength := int32(0)
+
+	if n >= 8 {
+		zero := archsimd.BroadcastInt32x8(0)
+		rot := archsimd.LoadUint32x8Slice(rotate1x8x32Delta[:])
+		bc7 := archsimd.LoadUint32x8Slice(lastLane8x32Delta[:])
+		iota8 := archsimd.LoadInt32x8Slice(laneIndexes[:])
+		tail := iota8.Greater(zero)
+		carry := zero
+		negAcc := zero
+		sumP := zero
+		sumS := zero
+		m := n / 8
+		cp := unsafecast.Slice[[8]int32](prefix)[:m]
+		cs := unsafecast.Slice[[8]int32](suffix)[:m]
+		for j := range cp {
+			p := archsimd.LoadInt32x8Slice(cp[j][:])
+			s := archsimd.LoadInt32x8Slice(cs[j][:])
+			negAcc = negAcc.Or(p).Or(s)
+			lens := p.Add(s)
+			lastLens := lens.Permute(rot).Merge(carry, tail)
+			if p.Greater(lastLens).ToBits() != 0 {
+				archsimd.ClearAVXUpperBits()
+				return 0, 0, false
+			}
+			carry = lens.Permute(bc7)
+			sumP = sumP.Add(p)
+			sumS = sumS.Add(s)
+		}
+		if zero.Greater(negAcc).ToBits() != 0 {
+			archsimd.ClearAVXUpperBits()
+			return 0, 0, false
+		}
+		totalPrefixLength = int(reduceAddInt32x8(sumP))
+		totalSuffixLength = int(reduceAddInt32x8(sumS))
+		lastValueLength = carry.GetLo().GetElem(0)
+		i = m * 8
+		archsimd.ClearAVXUpperBits()
+	}
+
+	for ; i < n; i++ {
+		p := prefix[i]
+		s := suffix[i]
+		if p < 0 || s < 0 || p > lastValueLength {
+			return 0, 0, false
+		}
+		totalPrefixLength += int(p)
+		totalSuffixLength += int(s)
+		lastValueLength = p + s
+	}
+
+	if totalSuffixLength > maxLength {
+		return 0, 0, false
+	}
+	return totalPrefixLength, totalSuffixLength, true
+}
+
+var (
+	rotate1x8x32Delta = [8]uint32{7, 0, 1, 2, 3, 4, 5, 6}
+	lastLane8x32Delta = [8]uint32{7, 7, 7, 7, 7, 7, 7, 7}
+)
+
+func reduceAddInt32x8(v archsimd.Int32x8) int32 {
+	q := v.GetLo().Add(v.GetHi())
+	p := q.AsFloat32x4().SelectFromPair(2, 3, 0, 1, q.AsFloat32x4()).AsInt32x4()
+	q = q.Add(p)
+	p = q.AsFloat32x4().SelectFromPair(1, 0, 3, 2, q.AsFloat32x4()).AsInt32x4()
+	q = q.Add(p)
+	return q.GetElem(0)
+}
+
+func validatePrefixAndSuffixLengthValues(prefix, suffix []int32, maxLength int) (totalPrefixLength, totalSuffixLength int, err error) {
+	if archsimd.X86.AVX2() {
+		totalPrefixLength, totalSuffixLength, ok := validatePrefixAndSuffixLengthValuesSIMD(prefix, suffix, maxLength)
+		if ok {
+			return totalPrefixLength, totalSuffixLength, nil
+		}
+	}
+
+	lastValueLength := 0
+
+	for i := range prefix {
+		p := int(prefix[i])
+		n := int(suffix[i])
+		if p < 0 {
+			err = errInvalidNegativePrefixLength(p)
+			return
+		}
+		if n < 0 {
+			err = errInvalidNegativeValueLength(n)
+			return
+		}
+		if p > lastValueLength {
+			err = errPrefixLengthOutOfBounds(p, lastValueLength)
+			return
+		}
+		totalPrefixLength += p
+		totalSuffixLength += n
+		lastValueLength = p + n
+	}
+
+	if totalSuffixLength > maxLength {
+		err = errValueLengthOutOfBounds(totalSuffixLength, maxLength)
+		return
+	}
+
+	return totalPrefixLength, totalSuffixLength, nil
+}
+
+func decodeByteArrayOffsets(offsets []uint32, prefix, suffix []int32) {
+	lastOffset := uint32(0)
+	for i := range suffix {
+		offsets[i] = lastOffset
+		lastOffset += uint32(prefix[i]) + uint32(suffix[i])
+	}
+	offsets[len(suffix)] = lastOffset
+}
+
+// decodeByteArraySIMD reconstructs values by copying 32 bytes of prefix and
+// suffix unconditionally (over-copying into the padding the callers
+// reserve), with plain copies when a length exceeds 32 bytes. The caller
+// guarantees at least padding bytes of suffix data remain in src past the
+// region processed here, making the 32 bytes source loads safe.
+func decodeByteArraySIMD(dst, src []byte, prefix, suffix []int32) int {
+	i := 0
+	j := 0
+	lastValue := 0
+	for k := range prefix {
+		p := int(prefix[k])
+		n := int(suffix[k])
+		valueOffset := i
+		archsimd.LoadUint8x32Slice(dst[lastValue : lastValue+32]).StoreSlice(dst[i : i+32])
+		if p > 32 {
+			copy(dst[i:i+p], dst[lastValue:lastValue+p])
+		}
+		i += p
+		archsimd.LoadUint8x32Slice(src[j : j+32]).StoreSlice(dst[i : i+32])
+		if n > 32 {
+			copy(dst[i:i+n], src[j:j+n])
+		}
+		i += n
+		j += n
+		lastValue = valueOffset
+	}
+	archsimd.ClearAVXUpperBits()
+	return i
+}
+
+// decodeByteArray128SIMD is the specialization for fixed length 16 bytes
+// values: the previous value stays in a vector register across iterations.
+func decodeByteArray128SIMD(dst, src []byte, prefix, suffix []int32) int {
+	i := 0
+	j := 0
+	last := archsimd.LoadUint8x16Slice(dst[0:16])
+	for k := range prefix {
+		p := int(prefix[k])
+		n := int(suffix[k])
+		last.StoreSlice(dst[i : i+16])
+		archsimd.LoadUint8x16Slice(src[j : j+16]).StoreSlice(dst[i+p : i+p+16])
+		last = archsimd.LoadUint8x16Slice(dst[i : i+16])
+		i += p + n
+		j += n
+	}
+	archsimd.ClearAVXUpperBits()
+	return i
+}
+
+func decodeByteArray(dst, src []byte, prefix, suffix []int32, offsets []uint32) ([]byte, []uint32, error) {
+	totalPrefixLength, totalSuffixLength, err := validatePrefixAndSuffixLengthValues(prefix, suffix, len(src))
+	if err != nil {
+		return dst, offsets, err
+	}
+
+	totalLength := totalPrefixLength + totalSuffixLength
+	dst = resizeNoMemclr(dst, totalLength+padding)
+
+	if size := len(prefix) + 1; cap(offsets) < size {
+		offsets = make([]uint32, size)
+	} else {
+		offsets = offsets[:size]
+	}
+
+	_ = prefix[:len(suffix)]
+	_ = suffix[:len(prefix)]
+	decodeByteArrayOffsets(offsets, prefix, suffix)
+
+	var lastValue []byte
+	var i int
+	var j int
+
+	if archsimd.X86.AVX2() && len(src) > padding {
+		k := len(suffix)
+		n := 0
+
+		for k > 0 && n < padding {
+			k--
+			n += int(suffix[k])
+		}
+
+		if k > 0 && n >= padding {
+			i = decodeByteArraySIMD(dst, src, prefix[:k], suffix[:k])
+			j = len(src) - n
+			lastValue = dst[i-(int(prefix[k-1])+int(suffix[k-1])):]
+			prefix = prefix[k:]
+			suffix = suffix[k:]
+		}
+	}
+
+	for k := range prefix {
+		p := int(prefix[k])
+		n := int(suffix[k])
+		lastValueOffset := i
+		i += copy(dst[i:], lastValue[:p])
+		i += copy(dst[i:], src[j:j+n])
+		j += n
+		lastValue = dst[lastValueOffset:]
+	}
+
+	return dst[:totalLength], offsets, nil
+}
+
+func decodeFixedLenByteArray(dst, src []byte, size int, prefix, suffix []int32) ([]byte, error) {
+	totalPrefixLength, totalSuffixLength, err := validatePrefixAndSuffixLengthValues(prefix, suffix, len(src))
+	if err != nil {
+		return dst, err
+	}
+
+	totalLength := totalPrefixLength + totalSuffixLength
+	dst = resizeNoMemclr(dst, totalLength+padding)
+
+	_ = prefix[:len(suffix)]
+	_ = suffix[:len(prefix)]
+
+	var lastValue []byte
+	var i int
+	var j int
+
+	if archsimd.X86.AVX2() && len(src) > padding {
+		k := len(suffix)
+		n := 0
+
+		for k > 0 && n < padding {
+			k--
+			n += int(suffix[k])
+		}
+
+		if k > 0 && n >= padding {
+			if size == 16 {
+				i = decodeByteArray128SIMD(dst, src, prefix[:k], suffix[:k])
+			} else {
+				i = decodeByteArraySIMD(dst, src, prefix[:k], suffix[:k])
+			}
+			j = len(src) - n
+			prefix = prefix[k:]
+			suffix = suffix[k:]
+			if i >= size {
+				lastValue = dst[i-size:]
+			}
+		}
+	}
+
+	for k := range prefix {
+		p := int(prefix[k])
+		n := int(suffix[k])
+		k := i
+		i += copy(dst[i:], lastValue[:p])
+		i += copy(dst[i:], src[j:j+n])
+		j += n
+		lastValue = dst[k:]
+	}
+
+	return dst[:totalLength], nil
+}

--- a/encoding/delta/delta_amd64.go
+++ b/encoding/delta/delta_amd64.go
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego || goexperiment.simd
 
 package delta
 

--- a/page_be128_simd_test.go
+++ b/page_be128_simd_test.go
@@ -1,0 +1,44 @@
+//go:build goexperiment.simd
+
+package parquet
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+// Differential test of the vectorized BE128 min/max against the scalar
+// implementations, covering duplicates, extreme values, and lengths around
+// the 8 value chunking boundary. The vector path only runs on AVX-512
+// hardware; elsewhere both sides take the scalar path.
+func TestMinMaxBE128SIMD(t *testing.T) {
+	prng := rand.New(rand.NewSource(3))
+	for _, n := range []int{1, 7, 8, 9, 15, 16, 17, 100, 1000} {
+		for trial := 0; trial < 10; trial++ {
+			data := make([][16]byte, n)
+			for i := range data {
+				prng.Read(data[i][:])
+				switch trial {
+				case 1:
+					// Many duplicates.
+					data[i] = data[0]
+				case 2:
+					// Extreme values that tie naive sentinels.
+					if i%3 == 0 {
+						data[i] = [16]byte{}
+					}
+					if i%3 == 1 {
+						data[i] = [16]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+					}
+				}
+			}
+			if got, want := minBE128(data), minBE128Scalar(data); !bytes.Equal(got, want) {
+				t.Fatalf("minBE128 n=%d trial=%d: got %x, want %x", n, trial, got, want)
+			}
+			if got, want := maxBE128(data), maxBE128Scalar(data); !bytes.Equal(got, want) {
+				t.Fatalf("maxBE128 n=%d trial=%d: got %x, want %x", n, trial, got, want)
+			}
+		}
+	}
+}

--- a/page_minmax_simd_amd64.go
+++ b/page_minmax_simd_amd64.go
@@ -1475,10 +1475,121 @@ func boundsFloat64Merge(data []float64) (min, max float64) {
 	return min, max
 }
 
-// The big endian 128 bits kernels are scalar; vectorizing them is complex
-// (lexicographic compare with index tracking) and left for a later tier.
+// The big endian 128 bits kernels compare 8 values per iteration: the
+// values are loaded as pairs of uint64 lanes, byte swapped with a grouped
+// byte shuffle (VPSHUFB, part of the AVX-512 feature bundle), and
+// deinterleaved into high/low lanes; a lexicographic compare mask selects
+// running minima together with their indexes. The final reduction stores
+// the eight candidates once and scans them; the winning index recovers the
+// pointer into the input.
+
+var (
+	bswap64x64 = [64]int8{
+		7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8,
+		7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8,
+		7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8,
+		7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8,
+	}
+	evenLanes64 = [8]uint64{0, 2, 4, 6, 8, 10, 12, 14}
+	oddLanes64  = [8]uint64{1, 3, 5, 7, 9, 11, 13, 15}
+	iotaLanes64 = [8]uint64{0, 1, 2, 3, 4, 5, 6, 7}
+)
+
+func minMaxBE128SIMD(data [][16]byte, max bool) int {
+	bswap := archsimd.LoadInt8x64Slice(bswap64x64[:])
+	even := archsimd.LoadUint64x8Slice(evenLanes64[:])
+	odd := archsimd.LoadUint64x8Slice(oddLanes64[:])
+	eight := archsimd.BroadcastUint64x8(8)
+
+	m := len(data) / 8
+	cv := unsafecast.Slice[[16]uint64](data)[:m]
+
+	// Seed the running best from the first chunk: sentinel seeds would tie
+	// with real extreme values and could report a wrong index.
+	s0 := archsimd.LoadUint64x8Slice(cv[0][0:8]).AsUint8x64().PermuteOrZeroGrouped(bswap).AsUint64x8()
+	s1 := archsimd.LoadUint64x8Slice(cv[0][8:16]).AsUint8x64().PermuteOrZeroGrouped(bswap).AsUint64x8()
+	bestHi := s0.ConcatPermute(s1, even)
+	bestLo := s0.ConcatPermute(s1, odd)
+	bestIdx := archsimd.LoadUint64x8Slice(iotaLanes64[:])
+	curIdx := bestIdx.Add(eight)
+
+	for j := 1; j < m; j++ {
+		z0 := archsimd.LoadUint64x8Slice(cv[j][0:8]).AsUint8x64().PermuteOrZeroGrouped(bswap).AsUint64x8()
+		z1 := archsimd.LoadUint64x8Slice(cv[j][8:16]).AsUint8x64().PermuteOrZeroGrouped(bswap).AsUint64x8()
+		hi := z0.ConcatPermute(z1, even)
+		lo := z0.ConcatPermute(z1, odd)
+		var better archsimd.Mask64x8
+		if max {
+			better = hi.Greater(bestHi).Or(hi.Equal(bestHi).And(lo.Greater(bestLo)))
+		} else {
+			better = hi.Less(bestHi).Or(hi.Equal(bestHi).And(lo.Less(bestLo)))
+		}
+		bestHi = hi.Merge(bestHi, better)
+		bestLo = lo.Merge(bestLo, better)
+		bestIdx = curIdx.Merge(bestIdx, better)
+		curIdx = curIdx.Add(eight)
+	}
+
+	var his, los, idxs [8]uint64
+	bestHi.StoreSlice(his[:])
+	bestLo.StoreSlice(los[:])
+	bestIdx.StoreSlice(idxs[:])
+	archsimd.ClearAVXUpperBits()
+
+	bh, bl, bi := his[0], los[0], int(idxs[0])
+	for k := 1; k < 8; k++ {
+		replace := false
+		if max {
+			replace = his[k] > bh || (his[k] == bh && los[k] > bl)
+		} else {
+			replace = his[k] < bh || (his[k] == bh && los[k] < bl)
+		}
+		// Prefer the earliest index on exact ties, matching the scalar scan.
+		if !replace && his[k] == bh && los[k] == bl && int(idxs[k]) < bi {
+			replace = true
+		}
+		if replace {
+			bh, bl, bi = his[k], los[k], int(idxs[k])
+		}
+	}
+
+	for k := m * 8; k < len(data); k++ {
+		hi := binary.BigEndian.Uint64(data[k][:8])
+		lo := binary.BigEndian.Uint64(data[k][8:])
+		replace := false
+		if max {
+			replace = hi > bh || (hi == bh && lo > bl)
+		} else {
+			replace = hi < bh || (hi == bh && lo < bl)
+		}
+		if replace {
+			bh, bl, bi = hi, lo, k
+		}
+	}
+	return bi
+}
 
 func minBE128(data [][16]byte) (min []byte) {
+	if len(data) == 0 {
+		return nil
+	}
+	if archsimd.X86.AVX512() && len(data) >= 8 {
+		return data[minMaxBE128SIMD(data, false)][:]
+	}
+	return minBE128Scalar(data)
+}
+
+func maxBE128(data [][16]byte) (max []byte) {
+	if len(data) == 0 {
+		return nil
+	}
+	if archsimd.X86.AVX512() && len(data) >= 8 {
+		return data[minMaxBE128SIMD(data, true)][:]
+	}
+	return maxBE128Scalar(data)
+}
+
+func minBE128Scalar(data [][16]byte) (min []byte) {
 	if len(data) > 0 {
 		m := binary.BigEndian.Uint64(data[0][:8])
 		j := 0
@@ -1500,7 +1611,7 @@ func minBE128(data [][16]byte) (min []byte) {
 	return min
 }
 
-func maxBE128(data [][16]byte) (max []byte) {
+func maxBE128Scalar(data [][16]byte) (max []byte) {
 	if len(data) > 0 {
 		m := binary.BigEndian.Uint64(data[0][:8])
 		j := 0


### PR DESCRIPTION
## What

Tier 3 of the archsimd port (follow-up to #584 and #585, on which this branch is stacked): Go implementations of the hardest remaining assembly kernels, enabled with `GOEXPERIMENT=simd`:

- **xxhash MultiSum64** (5 kernels): 8 hashes per `Uint64x8`, four independent streams to hide the VPMULLQ latency chains
- **DELTA_BINARY_PACKED block kernels** (8 kernels + decode): delta/min/sub/bitwidths for int32/int64 with AVX-512 and AVX2 tiers, vector-carried decode prefix sum
- **mini block bit packers**: compare-to-bits 1-bit encoders (the mask IS the packed output), and a general 2–16 bit packer (two fold steps of variable shifts/permutes + a scalar 128-bit stitch per byte-aligned 8-value group) replacing both the PDEP 2-bit path and the general 3–16 bit assembly
- **DELTA_BYTE_ARRAY**: vectorized prefix/suffix validation, 32-byte over-copy decoders, 16-byte fixed-length specialization
- **minBE128/maxBE128**: 8 values per iteration as byteswapped hi/lo uint64 lanes with lexicographic compare masks and index tracking

With this, **every assembly kernel expressible in archsimd now has a Go implementation** — the remaining assembly under `GOEXPERIMENT=simd` is only the blocked set (gather/scatter/PDEP users, tracked in docs/archsimd-port.md) and scalar code.

## Benchmarks

Emerald Rapids (GCP c4), `GOAMD64=v4`, same-boot vs assembly, n=8:

| Kernel | vs assembly |
|---|---|
| MultiSum64Uint128 | **−49%** (faster) |
| MultiSum64Uint8/16/32/64 | +6% .. +9% |
| BlockMinInt32 | **−20%** |
| BlockDeltaInt32 | **−9%** |
| BlockBitWidthsInt32 | **−4%** |
| BlockSubInt32 | +6% |
| min/max/bounds BE128 | +21% (4KiB) .. parity (256KiB+) |

## Validation

- Full `GOEXPERIMENT=simd` test suite green on AVX-512 hardware (the AVX2 tiers additionally run under Rosetta locally).
- The block kernels and mini block encoders run through the **same parameterized test harnesses as the assembly**.
- xxhash is validated element-by-element against the canonical `Sum64` by the existing property tests; the gate is corrected to an honest `X86.AVX512()` (the assembly tested AVX512CD, which it never used, while relying on unchecked AVX512DQ).
- BE128 has a new differential test against the scalar implementation covering duplicates and extreme values — which caught a real bug during development: sentinel-seeded accumulators tie with data containing the extreme values and can return a wrong index; the accumulators are seeded from the first chunk instead.

## Notes for reviewers

Two traps from the running playbook (docs/archsimd-port.md) were re-confirmed here: `ConcatPermute` and 64-bit lane permutes at 256-bit widths are EVEX-only and fault on AVX2-only CPUs (the AVX2 tiers use full-cross VPERMD rotates + carry blends instead), and scalar `GetElem` reductions lose badly to in-register shuffle ladders (`BlockBitWidths` went from +49% to −4% on that change alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
