### PR TITLE
perf(delta): word-parallel prefix search in DELTA_BYTE_ARRAY encoding

### DIFF
--- a/docs/delta-byte-array-prefix.md
+++ b/docs/delta-byte-array-prefix.md
@@ -181,21 +181,38 @@ arm64 purego path. The remaining checks are load-bearing: the per-value
 caller-provided offsets and of prefix/suffix lengths read from the page, and
 `lastValue = dst[j:]` after appends is unprovable but negligible.
 
-Possible follow-ups:
+## 6. SIMD prefix search (GOEXPERIMENT=simd, amd64)
 
-- SIMD-widening the compare to 16/32-byte blocks is *not* a free win: the
-  portable version (`bytes.Equal` on 32B chunks, as arrow-rs did with
-  `chunks_exact(32)`) measured slower than the word loop at every size on
-  Apple M4 (4.0 vs 3.5 ns at 128B, 22 vs 18 ns at 1000B) because `memequal`
-  is an out-of-line call while the word loop is 4 inline load/xor pairs per
-  32B. A real vector kernel needs inline SIMD (AVX2 `VPCMPEQB`+`VPMOVMSKB`+
-  `TZCNT`, or NEON `CMEQ`+`SHRN`) via asm or the Go 1.26 `simd` experiment,
-  must handle tails without over-reading caller memory (AVX-512 masked
-  loads), and only engages on long shared prefixes. A CPU profile after this
-  change bounds the payoff: the prefix search is ~19% of encode on
-  prefix-heavy data, so even an infinitely fast kernel caps at ~1.2x; the
-  larger targets are the DELTA_BINARY_PACKED encoding of the two length
-  streams (~48%, pure Go on arm64) and the suffix memmoves (~11%).
+SIMD-widening the compare is *not* a free win in portable Go: 32B chunks via
+`bytes.Equal` (as arrow-rs did with `chunks_exact(32)`) measured slower than
+the word loop at every size on Apple M4 (4.0 vs 3.5 ns at 128B, 22 vs 18 ns
+at 1000B) because `memequal` is an out-of-line call while the word loop is 4
+inline load/xor pairs per 32B. On arm64 the word loop stays the best shape.
+The prefix search is also only ~19% of encode on prefix-heavy data (the
+DELTA_BINARY_PACKED encoding of the two length streams is ~48%, suffix
+memmoves ~11%), bounding any kernel's end-to-end payoff at ~1.2x there.
+
+On amd64 the picture differs: benchmarked on real x86 (GCE c3, Xeon Platinum
+8481C Sapphire Rapids — Rosetta on Apple silicon is not representative), the
+word loop is ~3x slower per byte than on M4 (10.3 ns at 100B), so a real
+vector kernel pays. `searchPrefixLengthSIMD` (goexperiment.simd build) uses
+`Uint8x32.Equal` + `ToBits` + `TrailingZeros32(^mask)` — the classic
+VPCMPEQB/VPMOVMSKB idiom — gated to values ≥32B, with the word loop for
+short values and tails (encode inputs are caller memory: no over-read
+allowed). Results on the c3: isolated search −22% at LCP 500 (30.9→24.0 ns),
+end-to-end prefix-heavy encode +17% (1.82→2.12 GB/s). Correctness verified
+on-host under both builds.
+
+The same session found and fixed a regression in the tier-1
+`decodeByteArraySIMD` (#584): when a prefix or suffix exceeded 32 bytes —
+the common case on prefix-heavy pages, where LCPs run 24–53B — it fell back
+to `copy(dst[i:i+p], ...)`, an overlapping memmove per value re-copying from
+byte 0 (43% of decode CPU). Replacing the fallback with 32B vector-chunk
+extension (mirroring the asm's `copyPrefix`/`copySuffix`) took prefix-heavy
+decode from 0.50 to 3.61 GB/s on the c3. A general ~2x gap vs the
+hand-written asm remains in the simd decode build (`Uint8x32.StoreSlice` is
+44% flat in the profile, random-data decode 1.97 vs 4.03 GB/s) — that is
+archsimd codegen overhead, tracked separately by the archsimd port.
 - Velox-style in-place decode to eliminate the prefix copy in
   `decodeByteArray`.
 - Skip the copy when `p == 0` / `n == 0` in decoders (arrow#37873's

--- a/docs/delta-byte-array-prefix.md
+++ b/docs/delta-byte-array-prefix.md
@@ -220,9 +220,26 @@ gains 11% at long prefixes (24.1→21.4 ns at LCP 500); the decode kernels use
 pointer-based `LoadUint8x32(*[32]uint8)`/`Store` helpers instead because
 their offsets are not 32-aligned — decode gained 17–27% across benchmarks
 (prefix-heavy 3.61→4.24 GB/s, random 1.97→2.36, FLBA 3.67→4.67). Even fully
-check-free, the simd decode build remains ~1.6x behind the hand-written asm
-(4.24 vs 6.82 GB/s prefix-heavy) — the residual is archsimd codegen
-overhead, tracked by the archsimd port.
+check-free, the simd decode build remained ~1.4-1.6x behind the hand-written
+asm (4.24 vs 6.82 GB/s prefix-heavy).
+
+That residual was root-caused (GCE c4, Emerald Rapids, hardware counters):
+identical instructions per op but IPC 4.5 vs 2.0, with ~400 stalled cycles
+per miniblock landing on the first instruction of bitpack's
+`unpackInt32x1to16bitsAVX2`. The culprit is `MOVQ R8, X0` in bitpack's
+unpack kernels: Go assembles it to the legacy SSE encoding, and SSE writes
+preserve the destination's upper ymm bits — a false dependency on the last
+AVX producer of that register. The GOEXPERIMENT=simd DELTA_BINARY_PACKED
+block-reconstruct kernel keeps a long serial prefix-sum chain in flight, so
+every unpack call serialized against it (the hand-asm build never exposes
+the window). Changing the one instruction to `VMOVQ` (VEX zeroes the
+uppers, no dependency) recovers isolated decodeInt32 from 16.0 to 6.2 µs
+(hand-asm build: 6.7) and full prefix-heavy decode from 5.8 to 7.8 GB/s
+(hand-asm: 8.3) — fix in parquet-go/bitpack#12. Diagnosis trail:
+`BenchmarkDecodeInt32PrefixLengths` and `BenchmarkBitpackUnpackInt32` in
+`binary_packed_decode_bench_test.go` isolate the effect (the raw unpack
+micro is unaffected — the stall only exists when interleaved with AVX
+chains, which is why per-function benchmarks never caught it).
 - Velox-style in-place decode to eliminate the prefix copy in
   `decodeByteArray`.
 - Skip the copy when `p == 0` / `n == 0` in decoders (arrow#37873's

--- a/docs/delta-byte-array-prefix.md
+++ b/docs/delta-byte-array-prefix.md
@@ -209,10 +209,20 @@ the common case on prefix-heavy pages, where LCPs run 24–53B — it fell back
 to `copy(dst[i:i+p], ...)`, an overlapping memmove per value re-copying from
 byte 0 (43% of decode CPU). Replacing the fallback with 32B vector-chunk
 extension (mirroring the asm's `copyPrefix`/`copySuffix`) took prefix-heavy
-decode from 0.50 to 3.61 GB/s on the c3. A general ~2x gap vs the
-hand-written asm remains in the simd decode build (`Uint8x32.StoreSlice` is
-44% flat in the profile, random-data decode 1.97 vs 4.03 GB/s) — that is
-archsimd codegen overhead, tracked separately by the archsimd port.
+decode from 0.50 to 3.61 GB/s on the c3.
+
+Bounds checks in the simd kernels were the next measurable slice: the
+`LoadUint8x32Slice(b[i:i+32])` pattern carries an `IsSliceInBounds` per
+operation (~8 per decoded value). Casting to `[32]byte` chunks with
+`unsafecast.Slice` (the pattern `validatePrefixAndSuffixLengthValuesSIMD`
+already uses for `[8]int32`) makes the prefix-search loop check-free and
+gains 11% at long prefixes (24.1→21.4 ns at LCP 500); the decode kernels use
+pointer-based `LoadUint8x32(*[32]uint8)`/`Store` helpers instead because
+their offsets are not 32-aligned — decode gained 17–27% across benchmarks
+(prefix-heavy 3.61→4.24 GB/s, random 1.97→2.36, FLBA 3.67→4.67). Even fully
+check-free, the simd decode build remains ~1.6x behind the hand-written asm
+(4.24 vs 6.82 GB/s prefix-heavy) — the residual is archsimd codegen
+overhead, tracked by the archsimd port.
 - Velox-style in-place decode to eliminate the prefix copy in
   `decodeByteArray`.
 - Skip the copy when `p == 0` / `n == 0` in decoders (arrow#37873's

--- a/docs/delta-byte-array-prefix.md
+++ b/docs/delta-byte-array-prefix.md
@@ -1,0 +1,192 @@
+# DELTA_BYTE_ARRAY prefix computation: fixed-length prefixes vs word-parallel exact LCP
+
+Research notes on an idea to speed up `DELTA_BYTE_ARRAY` by quantizing common
+prefix lengths to fixed sizes (8, 16, 32, 64 bytes, ...) so that matching,
+encoding, and decoding can rely on fixed-width operations.
+
+**Conclusion: the encode-side speedup attributed to fixed-length prefixes is
+almost entirely achievable with an *exact* longest-common-prefix (LCP)
+computed word-at-a-time (XOR + trailing-zero-count), without giving up any
+compression ratio. Quantization measured 0% faster than exact word-parallel
+LCP while degrading the encoded size by ~3.4% on prefix-heavy data. The
+word-parallel exact LCP is prototyped on this branch: +61% encode throughput
+at identical output.**
+
+## 1. The idea and its spec-legality
+
+`DELTA_BYTE_ARRAY` stores, per value, the length of a prefix shared with the
+previous value (`DELTA_BINARY_PACKED`) plus the remaining suffix
+(`DELTA_LENGTH_BYTE_ARRAY`). The parquet-format spec
+([Encodings.md](https://github.com/apache/parquet-format/blob/master/Encodings.md))
+says only "store the prefix length of the previous entry plus the suffix" —
+it never requires the *longest* prefix. The PARQUET-246 history (readers must
+honor a nonzero prefix length on the first value of a page) confirms readers
+treat prefix lengths as arbitrary valid data. So a writer quantizing prefix
+lengths is spec-legal and every reader stays correct.
+
+## 2. Prior art
+
+### Computer science literature
+
+- **Front coding / compressed string dictionaries** (Brisaboa, Martínez-Prieto,
+  Navarro et al., SEA 2011 / Inf. Systems 2016 / CIKM 2019): Plain Front
+  Coding always stores *exact* LCPs; the tunable knob in this literature is
+  the restart-bucket size, never the prefix-length grid. Quantized prefix
+  lengths do not appear as a named technique anywhere we could find.
+- **FSST** (Boncz, Neumann, Leis, VLDB 2020): strongest precedent for the
+  "fixed-width copies beat variable-width" principle — symbols capped at 8
+  bytes precisely so decode is a branch-free 8-byte word write per code.
+  Applied to substring symbols, not prefix lengths.
+- **German strings / Umbra, Arrow StringView** (in DuckDB, Velox, Polars):
+  fixed 4-byte inline prefix; ~95% of equality checks short-circuit on it.
+  Quantizes the *comparison-relevant* prefix, not the stored encoding.
+- **LevelDB/RocksDB restart points, Druid incremental encoding, Lucene
+  BlockTree**: quantize *restart positions* (shared length forced to 0 every
+  N entries) for random access — a different axis than quantizing lengths.
+- **The LZ match-length idiom** (`ZSTD_count`, LZ4, zlib-rs `compare256`):
+  exact LCP computed 8–32 bytes at a time via wide loads + XOR/compare +
+  trailing-zero-count. This is the well-established fast path for exact LCP,
+  and the reason quantization gains ~nothing at encode time: the exact
+  version is the same loop plus one `TZCNT` at the mismatch.
+
+### Parquet / Arrow / columnar ecosystems
+
+- **arrow-rs PR [#10549](https://github.com/apache/arrow-rs/pull/10549)**
+  (merged 2026-08): closest prior art. Replaced the byte-at-a-time LCP in the
+  DELTA_BYTE_ARRAY encoder with 32-byte block compares (`chunks_exact(32)`)
+  plus a byte-wise tail — ~15x faster LCP on long prefixes, DBA encode became
+  cheaper than PLAIN. **Kept the prefix exact; quantization was not
+  discussed.** (Note: 64-byte blocks regressed to an out-of-line `bcmp` call
+  in Rust; 32 was the sweet spot.)
+- **parquet-java** `DeltaByteArrayWriter` uses `Arrays.mismatch`, which the
+  JVM intrinsifies to SIMD — exact LCP, SIMD for free.
+- **Arrow C++** encoder still uses a scalar byte loop; decoder does two
+  variable-length memcpys per value (open issue
+  [arrow#37873](https://github.com/apache/arrow/issues/37873) about skipping
+  zero-length copies).
+- **DuckDB** doesn't write DELTA_BYTE_ARRAY at all (prefers
+  DELTA_LENGTH_BYTE_ARRAY / DICT_FSST); its reader transcodes DBA pages to
+  PLAIN layout up front.
+- **Velox** decoder avoids the prefix copy entirely by decoding in place over
+  the previous value (only suffix bytes are copied); their 2026 blog post on
+  DELTA decoding attacked the decoder around the format, keeping exact
+  prefixes.
+- **Trino PR [#15923](https://github.com/trinodb/trino/pull/15923)**: batched
+  DBA decode, 3.5–9x; even optimized, DBA decodes ~2x PLAIN vs DLBA's ~5x —
+  the chained variable-length prefix copy is the structural decode
+  bottleneck.
+- **cuDF** computes LCP byte-per-thread on GPU; their in-source comment notes
+  the string copy dominates, not the LCP.
+- **ORC, Lance, Vortex, BtrBlocks, FastLanes**: none use front coding for
+  strings at all — they reach for FSST/dictionary instead of making prefixes
+  fixed-width.
+- **No Parquet Jira, mailing-list thread, or format issue** proposes capping,
+  rounding, or quantizing prefix lengths. The idea appears untried and
+  undiscussed.
+
+## 3. Measurements (Apple M4 Max, arm64, Go 1.26)
+
+Data: 10k values resembling sorted URLs/paths (5 hot prefixes of 24–53 bytes
++ 8-digit suffix), the workload DELTA_BYTE_ARRAY exists for. The generic
+benchmarks in `encoding_test.go` use *random* byte arrays with ~no shared
+prefixes, so they do not exercise the prefix search at all.
+
+Isolated prefix-search strategies (higher is better):
+
+| strategy                          | throughput | suffix bytes kept |
+|-----------------------------------|-----------:|------------------:|
+| byte-by-byte (current)            |   4.7 GB/s |             68.7% |
+| exact LCP, 8B words + XOR/TZCNT   |  13.3 GB/s |             68.7% |
+| quantized to multiples of 8       |  13.6 GB/s |             71.2% |
+| quantized to powers of two (8..64)|  10.7 GB/s |             76.6% |
+
+End-to-end `ByteArrayEncoding.EncodeByteArray` on the same data
+(`BenchmarkEncodeByteArrayPrefixHeavy`):
+
+| encoder LCP                | encode      | encoded/raw ratio |
+|----------------------------|------------:|------------------:|
+| byte-by-byte (baseline)    |  2.56 GB/s  |            0.7266 |
+| word-exact (prototype)     |  4.11 GB/s  |            0.7266 |
+| quantized multiples of 8   |  4.10 GB/s  |            0.7512 |
+
+Decode was unchanged in all cases (~6.7 GB/s on the arm64 pure-Go path):
+quantized prefixes don't help decode here because the cost is per-value
+`memmove` dispatch, not copy alignment — and the amd64 AVX2 decoder already
+copies 32-byte blocks unconditionally regardless of the stored length.
+
+Also of note: the prefix-length stream did not get cheaper under
+quantization. Lengths that are multiples of 8 have deltas that are multiples
+of 8, which need *more* bits in DELTA_BINARY_PACKED than exact-LCP deltas of
+similar magnitude (the format offers no way to store `length/8`).
+
+## 4. Why quantization loses to exact word-parallel LCP
+
+The quantized search and the exact search run the *same* 8-byte compare loop;
+they differ only at the mismatched word, where the exact version spends one
+`XOR` + `TZCNT` to recover the last 0–7 matching bytes. That single
+instruction pair buys back all of the compression ratio. Rounding down a
+grid of k costs up to k−1 suffix bytes per value ((k−1)/2 expected), moves
+them into the suffix stream, and slightly worsens the prefix-length stream.
+Page compression (zstd/snappy) would claw some of that back, but there is no
+speed left to pay for it with.
+
+The one place a fixed grid could still pay off is decode-side: prefix lengths
+guaranteed ≤N and word-aligned would allow a branchless fixed-width prefix
+copy. But (a) a reader can never assume it (other writers produce exact
+LCPs), so it needs a per-page "all lengths grid-aligned" check plus fallback,
+and (b) the existing AVX2 decoder already gets the same effect by copying 32
+bytes unconditionally with a rarely-taken branch for longer prefixes.
+Velox-style in-place decode (retain the prefix in the output buffer, copy
+only suffix bytes) is the stronger decode-side idea and needs no format
+tricks.
+
+## 5. Prototype on this branch
+
+`encoding/delta/byte_array.go` now uses `wordSearchPrefixLength` (8-byte
+words + `bits.TrailingZeros64`) for both `EncodeByteArray` and
+`EncodeFixedLenByteArray`, replacing the byte loop and the
+`binarySearchPrefixLength` path (which compared O(n log n) bytes via
+`sort.Search` + `bytes.Equal`). `byte_array_prefix_bench_test.go` adds the
+prefix-heavy benchmarks. Output is byte-identical to the previous encoder;
+all tests pass with `-race`.
+
+Bounds checks: the naive `Uint64(base[i:])` form carries 4 checks per
+iteration. Reslicing both inputs to `n` and using the closed range
+`base[i:i+8]` eliminates 3 of them, but one `IsSliceInBounds` on `base`
+survives — prove tracks the `min` relation for one operand only. A fully
+check-free shape that advances both slices by 8 each iteration measured ~10%
+*slower* (two pointer+length updates per iteration cost more than the
+residual predicted-not-taken check).
+
+The final implementation casts both inputs to `[]uint64` with
+`bitpack/unsafecast.Slice` (header reinterpretation, which also dodges
+`checkptr` under `-race`; misaligned 8-byte loads are fine on amd64/arm64)
+and indexes words: the hot loop is fully check-free, with only two per-call
+`[:nw]` reslice checks left. Verified with `-gcflags='-d=ssa/check_bce'`.
+Isolated cost vs the byte-indexed form: ~equal at ≤100B (values shorter than
+8 bytes go straight to the byte tail and pay ~0.3 ns for the unused casts),
+−19% at 1000B; end-to-end encode is unchanged to slightly better. Mismatch
+location uses `TrailingZeros64` on little-endian and `LeadingZeros64` under
+`cpu.IsBigEndian`, since the cast reads native-endian words.
+
+Two more per-iteration checks were eliminated in the same pass: the
+`_ = length.values[:len(prefix.values)]`-style hints in the encoder's copy
+loop and the purego decoders did not actually work — for the encoder because
+`values` is a heap-object field the compiler reloads after every `copy` call,
+fixed by hoisting the slices into locals; for the decoders because prove
+tracks the discarded-reslice fact for one operand only, fixed by assigning
+the reslice back (`prefix = prefix[:len(suffix)]`). Decode gained ~3% on the
+arm64 purego path. The remaining checks are load-bearing: the per-value
+`src[baseOffset:endOffset]` slices and copy bounds are the only validation of
+caller-provided offsets and of prefix/suffix lengths read from the page, and
+`lastValue = dst[j:]` after appends is unprovable but negligible.
+
+Possible follow-ups:
+
+- Widen the compare to 16/32-byte blocks (`bytes.Equal` on chunks, or
+  NEON/AVX2, or the Go 1.26 `simd` experiment) with a word-wise tail, as
+  arrow-rs did — helps values with very long shared prefixes.
+- Velox-style in-place decode to eliminate the prefix copy in
+  `decodeByteArray`.
+- Skip the copy when `p == 0` / `n == 0` in decoders (arrow#37873's
+  observation).

--- a/docs/delta-byte-array-prefix.md
+++ b/docs/delta-byte-array-prefix.md
@@ -183,9 +183,19 @@ caller-provided offsets and of prefix/suffix lengths read from the page, and
 
 Possible follow-ups:
 
-- Widen the compare to 16/32-byte blocks (`bytes.Equal` on chunks, or
-  NEON/AVX2, or the Go 1.26 `simd` experiment) with a word-wise tail, as
-  arrow-rs did — helps values with very long shared prefixes.
+- SIMD-widening the compare to 16/32-byte blocks is *not* a free win: the
+  portable version (`bytes.Equal` on 32B chunks, as arrow-rs did with
+  `chunks_exact(32)`) measured slower than the word loop at every size on
+  Apple M4 (4.0 vs 3.5 ns at 128B, 22 vs 18 ns at 1000B) because `memequal`
+  is an out-of-line call while the word loop is 4 inline load/xor pairs per
+  32B. A real vector kernel needs inline SIMD (AVX2 `VPCMPEQB`+`VPMOVMSKB`+
+  `TZCNT`, or NEON `CMEQ`+`SHRN`) via asm or the Go 1.26 `simd` experiment,
+  must handle tails without over-reading caller memory (AVX-512 masked
+  loads), and only engages on long shared prefixes. A CPU profile after this
+  change bounds the payoff: the prefix search is ~19% of encode on
+  prefix-heavy data, so even an infinitely fast kernel caps at ~1.2x; the
+  larger targets are the DELTA_BINARY_PACKED encoding of the two length
+  streams (~48%, pure Go on arm64) and the suffix memmoves (~11%).
 - Velox-style in-place decode to eliminate the prefix copy in
   `decodeByteArray`.
 - Skip the copy when `p == 0` / `n == 0` in decoders (arrow#37873's

--- a/encoding/delta/binary_packed_decode_bench_test.go
+++ b/encoding/delta/binary_packed_decode_bench_test.go
@@ -1,0 +1,41 @@
+package delta
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/parquet-go/bitpack"
+)
+
+// BenchmarkDecodeInt32PrefixLengths reproduces the prefix-length stream of
+// the prefix-heavy byte array benchmark in isolation: 10k small values,
+// delta binary packed.
+func BenchmarkDecodeInt32PrefixLengths(b *testing.B) {
+	r := rand.New(rand.NewSource(1))
+	values := make([]int32, 10000)
+	for i := range values {
+		values[i] = int32(r.Intn(64))
+	}
+	src, err := (&BinaryPackedEncoding{}).EncodeInt32(nil, values)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dst := make([]byte, 0, 4*len(values))
+	b.SetBytes(int64(4 * len(values)))
+	for b.Loop() {
+		dst, _, _ = decodeInt32(dst[:0], src)
+	}
+}
+
+// BenchmarkBitpackUnpackInt32 measures the raw bitpack kernel on one
+// miniblock, isolating it from the decodeInt32 caller.
+func BenchmarkBitpackUnpackInt32(b *testing.B) {
+	src := make([]byte, 32*6+bitpack.PaddingInt32)
+	r := rand.New(rand.NewSource(1))
+	r.Read(src)
+	dst := make([]int32, 128)
+	b.SetBytes(int64(4 * len(dst)))
+	for b.Loop() {
+		bitpack.Unpack(dst, src[:32*6], 6)
+	}
+}

--- a/encoding/delta/byte_array.go
+++ b/encoding/delta/byte_array.go
@@ -2,14 +2,13 @@ package delta
 
 import (
 	"bytes"
+	"math/bits"
 	"sort"
 
+	"github.com/parquet-go/bitpack/unsafecast"
 	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
-)
-
-const (
-	maxLinearSearchPrefixLength = 64 // arbitrary
+	"golang.org/x/sys/cpu"
 )
 
 type ByteArrayEncoding struct {
@@ -42,11 +41,7 @@ func (e *ByteArrayEncoding) EncodeByteArray(dst []byte, src []byte, offsets []ui
 			p := 0
 			baseOffset = endOffset
 
-			if len(v) <= maxLinearSearchPrefixLength {
-				p = linearSearchPrefixLength(lastValue, v)
-			} else {
-				p = binarySearchPrefixLength(lastValue, v)
-			}
+			p = wordSearchPrefixLength(lastValue, v)
 
 			prefix.values = append(prefix.values, int32(p))
 			length.values = append(length.values, int32(n-p))
@@ -65,10 +60,11 @@ func (e *ByteArrayEncoding) EncodeByteArray(dst []byte, src []byte, offsets []ui
 		i := int(offsets[0])
 		j := 0
 
-		_ = length.values[:len(prefix.values)]
+		prefixValues := prefix.values
+		lengthValues := length.values[:len(prefixValues)]
 
-		for k, p := range prefix.values {
-			n := p + length.values[k]
+		for k, p := range prefixValues {
+			n := p + lengthValues[k]
 			j += copy(b[j:], src[i+int(p):i+int(n)])
 			i += int(n)
 		}
@@ -100,7 +96,7 @@ func (e *ByteArrayEncoding) EncodeFixedLenByteArray(dst []byte, src []byte, size
 
 	for i := size; i <= len(src); i += size {
 		v := src[i-size : i : i]
-		p := linearSearchPrefixLength(lastValue, v)
+		p := wordSearchPrefixLength(lastValue, v)
 		n := size - p
 		prefix.values = append(prefix.values, int32(p))
 		length.values = append(length.values, int32(n))
@@ -202,6 +198,33 @@ func linearSearchPrefixLength(base, data []byte) (n int) {
 		n++
 	}
 	return n
+}
+
+// wordSearchPrefixLength returns the length of the longest common prefix of
+// base and data, comparing 8 bytes at a time and locating the first mismatch
+// with a zero count of the xored words.
+func wordSearchPrefixLength(base, data []byte) int {
+	n := min(len(base), len(data))
+	nw := n / 8
+	bw := unsafecast.Slice[uint64](base)[:nw]
+	dw := unsafecast.Slice[uint64](data)[:nw]
+
+	for i := range bw {
+		if x := bw[i] ^ dw[i]; x != 0 {
+			if cpu.IsBigEndian {
+				return i*8 + bits.LeadingZeros64(x)/8
+			}
+			return i*8 + bits.TrailingZeros64(x)/8
+		}
+	}
+
+	i := nw * 8
+	for ; i < n; i++ {
+		if base[i] != data[i] {
+			break
+		}
+	}
+	return i
 }
 
 func binarySearchPrefixLength(base, data []byte) int {

--- a/encoding/delta/byte_array.go
+++ b/encoding/delta/byte_array.go
@@ -41,7 +41,7 @@ func (e *ByteArrayEncoding) EncodeByteArray(dst []byte, src []byte, offsets []ui
 			p := 0
 			baseOffset = endOffset
 
-			p = wordSearchPrefixLength(lastValue, v)
+			p = searchPrefixLength(lastValue, v)
 
 			prefix.values = append(prefix.values, int32(p))
 			length.values = append(length.values, int32(n-p))
@@ -96,7 +96,7 @@ func (e *ByteArrayEncoding) EncodeFixedLenByteArray(dst []byte, src []byte, size
 
 	for i := size; i <= len(src); i += size {
 		v := src[i-size : i : i]
-		p := wordSearchPrefixLength(lastValue, v)
+		p := searchPrefixLength(lastValue, v)
 		n := size - p
 		prefix.values = append(prefix.values, int32(p))
 		length.values = append(length.values, int32(n))

--- a/encoding/delta/byte_array_prefix.go
+++ b/encoding/delta/byte_array_prefix.go
@@ -1,0 +1,7 @@
+//go:build !amd64 || !goexperiment.simd
+
+package delta
+
+func searchPrefixLength(base, data []byte) int {
+	return wordSearchPrefixLength(base, data)
+}

--- a/encoding/delta/byte_array_prefix_bench_test.go
+++ b/encoding/delta/byte_array_prefix_bench_test.go
@@ -1,0 +1,55 @@
+package delta
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// generatePrefixHeavyByteArrays produces values resembling sorted URLs/paths,
+// where DELTA_BYTE_ARRAY's prefix compression actually kicks in (the generic
+// benchmarks use random bytes, which have no shared prefixes).
+func generatePrefixHeavyByteArrays(n int, r *rand.Rand) ([]byte, []uint32) {
+	prefixes := []string{
+		"https://example.com/api/v1/users/",
+		"https://example.com/api/v1/orders/",
+		"https://example.com/api/v2/products/electronics/",
+		"s3://data-lake-production/tables/events/date=2026-08-",
+		"/var/log/containers/app-",
+	}
+	values := make([]byte, 0, n*64)
+	offsets := make([]uint32, 0, n+1)
+	for range n {
+		offsets = append(offsets, uint32(len(values)))
+		values = append(values, prefixes[r.Intn(len(prefixes))]...)
+		values = fmt.Appendf(values, "%08d", r.Intn(1000000))
+	}
+	offsets = append(offsets, uint32(len(values)))
+	return values, offsets
+}
+
+func BenchmarkEncodeByteArrayPrefixHeavy(b *testing.B) {
+	e := &ByteArrayEncoding{}
+	values, offsets := generatePrefixHeavyByteArrays(10000, rand.New(rand.NewSource(1)))
+	buffer := make([]byte, 0, 2*len(values))
+	b.SetBytes(int64(len(values)))
+	for b.Loop() {
+		buffer, _ = e.EncodeByteArray(buffer, values, offsets)
+	}
+	b.ReportMetric(float64(len(buffer))/float64(len(values)), "ratio")
+}
+
+func BenchmarkDecodeByteArrayPrefixHeavy(b *testing.B) {
+	e := &ByteArrayEncoding{}
+	values, offsets := generatePrefixHeavyByteArrays(10000, rand.New(rand.NewSource(1)))
+	encoded, err := e.EncodeByteArray(nil, values, offsets)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dst := make([]byte, 0, len(values))
+	dstOffsets := make([]uint32, 0, len(offsets))
+	b.SetBytes(int64(len(values)))
+	for b.Loop() {
+		dst, dstOffsets, _ = e.DecodeByteArray(dst, encoded, dstOffsets)
+	}
+}

--- a/encoding/delta/byte_array_purego.go
+++ b/encoding/delta/byte_array_purego.go
@@ -3,8 +3,8 @@
 package delta
 
 func decodeByteArray(dst, src []byte, prefix, suffix []int32, offsets []uint32) ([]byte, []uint32, error) {
-	_ = prefix[:len(suffix)]
-	_ = suffix[:len(prefix)]
+	prefix = prefix[:len(suffix)]
+	suffix = suffix[:len(prefix)]
 
 	var lastValue []byte
 	for i := range suffix {
@@ -34,8 +34,8 @@ func decodeByteArray(dst, src []byte, prefix, suffix []int32, offsets []uint32) 
 }
 
 func decodeFixedLenByteArray(dst, src []byte, size int, prefix, suffix []int32) ([]byte, error) {
-	_ = prefix[:len(suffix)]
-	_ = suffix[:len(prefix)]
+	prefix = prefix[:len(suffix)]
+	suffix = suffix[:len(prefix)]
 
 	var lastValue []byte
 	for i := range suffix {

--- a/encoding/delta/byte_array_simd_amd64.go
+++ b/encoding/delta/byte_array_simd_amd64.go
@@ -3,6 +3,7 @@
 package delta
 
 import (
+	"math/bits"
 	"simd/archsimd"
 
 	"github.com/parquet-go/bitpack/unsafecast"
@@ -82,6 +83,31 @@ var (
 	lastLane8x32Delta = [8]uint32{7, 7, 7, 7, 7, 7, 7, 7}
 )
 
+// searchPrefixLengthSIMD returns the length of the longest common prefix of
+// base and data, comparing 32 bytes at a time; the first mismatching byte is
+// recovered from the movemask of the byte equality.
+func searchPrefixLengthSIMD(base, data []byte) int {
+	n := min(len(base), len(data))
+	i := 0
+	for ; i+32 <= n; i += 32 {
+		b := archsimd.LoadUint8x32Slice(base[i : i+32])
+		d := archsimd.LoadUint8x32Slice(data[i : i+32])
+		if eq := b.Equal(d).ToBits(); eq != 0xFFFFFFFF {
+			archsimd.ClearAVXUpperBits()
+			return i + bits.TrailingZeros32(^eq)
+		}
+	}
+	archsimd.ClearAVXUpperBits()
+	return i + wordSearchPrefixLength(base[i:], data[i:])
+}
+
+func searchPrefixLength(base, data []byte) int {
+	if archsimd.X86.AVX2() && min(len(base), len(data)) >= 32 {
+		return searchPrefixLengthSIMD(base, data)
+	}
+	return wordSearchPrefixLength(base, data)
+}
+
 func reduceAddInt32x8(v archsimd.Int32x8) int32 {
 	q := v.GetLo().Add(v.GetHi())
 	p := q.AsFloat32x4().SelectFromPair(2, 3, 0, 1, q.AsFloat32x4()).AsInt32x4()
@@ -152,13 +178,13 @@ func decodeByteArraySIMD(dst, src []byte, prefix, suffix []int32) int {
 		n := int(suffix[k])
 		valueOffset := i
 		archsimd.LoadUint8x32Slice(dst[lastValue : lastValue+32]).StoreSlice(dst[i : i+32])
-		if p > 32 {
-			copy(dst[i:i+p], dst[lastValue:lastValue+p])
+		for m := 32; m < p; m += 32 {
+			archsimd.LoadUint8x32Slice(dst[lastValue+m : lastValue+m+32]).StoreSlice(dst[i+m : i+m+32])
 		}
 		i += p
 		archsimd.LoadUint8x32Slice(src[j : j+32]).StoreSlice(dst[i : i+32])
-		if n > 32 {
-			copy(dst[i:i+n], src[j:j+n])
+		for m := 32; m < n; m += 32 {
+			archsimd.LoadUint8x32Slice(src[j+m : j+m+32]).StoreSlice(dst[i+m : i+m+32])
 		}
 		i += n
 		j += n

--- a/encoding/delta/byte_array_simd_amd64.go
+++ b/encoding/delta/byte_array_simd_amd64.go
@@ -5,6 +5,7 @@ package delta
 import (
 	"math/bits"
 	"simd/archsimd"
+	"unsafe"
 
 	"github.com/parquet-go/bitpack/unsafecast"
 )
@@ -88,15 +89,20 @@ var (
 // recovered from the movemask of the byte equality.
 func searchPrefixLengthSIMD(base, data []byte) int {
 	n := min(len(base), len(data))
-	i := 0
-	for ; i+32 <= n; i += 32 {
-		b := archsimd.LoadUint8x32Slice(base[i : i+32])
-		d := archsimd.LoadUint8x32Slice(data[i : i+32])
+	m := n / 32
+	bc := unsafecast.Slice[[32]byte](base)[:m]
+	dc := unsafecast.Slice[[32]byte](data)[:m]
+
+	for k := range bc {
+		b := archsimd.LoadUint8x32(&bc[k])
+		d := archsimd.LoadUint8x32(&dc[k])
 		if eq := b.Equal(d).ToBits(); eq != 0xFFFFFFFF {
 			archsimd.ClearAVXUpperBits()
-			return i + bits.TrailingZeros32(^eq)
+			return k*32 + bits.TrailingZeros32(^eq)
 		}
 	}
+
+	i := m * 32
 	archsimd.ClearAVXUpperBits()
 	return i + wordSearchPrefixLength(base[i:], data[i:])
 }
@@ -164,12 +170,32 @@ func decodeByteArrayOffsets(offsets []uint32, prefix, suffix []int32) {
 	offsets[len(suffix)] = lastOffset
 }
 
-// decodeByteArraySIMD reconstructs values by copying 32 bytes of prefix and
-// suffix unconditionally (over-copying into the padding the callers
-// reserve), with plain copies when a length exceeds 32 bytes. The caller
-// guarantees at least padding bytes of suffix data remain in src past the
-// region processed here, making the 32 bytes source loads safe.
+// loadUint8x32 and storeUint8x32 access 32 bytes at arbitrary byte offsets
+// of a slice without bounds checks; the callers guarantee that i+32 stays
+// within the padding their buffers reserve.
+func loadUint8x32(b []byte, i int) archsimd.Uint8x32 {
+	return archsimd.LoadUint8x32((*[32]uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)))
+}
+
+func storeUint8x32(v archsimd.Uint8x32, b []byte, i int) {
+	v.Store((*[32]uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)))
+}
+
+func loadUint8x16(b []byte, i int) archsimd.Uint8x16 {
+	return archsimd.LoadUint8x16((*[16]uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)))
+}
+
+func storeUint8x16(v archsimd.Uint8x16, b []byte, i int) {
+	v.Store((*[16]uint8)(unsafe.Add(unsafe.Pointer(unsafe.SliceData(b)), i)))
+}
+
+// decodeByteArraySIMD reconstructs values by copying prefixes and suffixes
+// in unconditional 32 bytes chunks (over-copying into the padding the
+// callers reserve). The caller guarantees at least padding bytes of suffix
+// data remain in src past the region processed here, making the 32 bytes
+// source loads safe.
 func decodeByteArraySIMD(dst, src []byte, prefix, suffix []int32) int {
+	suffix = suffix[:len(prefix)]
 	i := 0
 	j := 0
 	lastValue := 0
@@ -177,14 +203,14 @@ func decodeByteArraySIMD(dst, src []byte, prefix, suffix []int32) int {
 		p := int(prefix[k])
 		n := int(suffix[k])
 		valueOffset := i
-		archsimd.LoadUint8x32Slice(dst[lastValue : lastValue+32]).StoreSlice(dst[i : i+32])
+		storeUint8x32(loadUint8x32(dst, lastValue), dst, i)
 		for m := 32; m < p; m += 32 {
-			archsimd.LoadUint8x32Slice(dst[lastValue+m : lastValue+m+32]).StoreSlice(dst[i+m : i+m+32])
+			storeUint8x32(loadUint8x32(dst, lastValue+m), dst, i+m)
 		}
 		i += p
-		archsimd.LoadUint8x32Slice(src[j : j+32]).StoreSlice(dst[i : i+32])
+		storeUint8x32(loadUint8x32(src, j), dst, i)
 		for m := 32; m < n; m += 32 {
-			archsimd.LoadUint8x32Slice(src[j+m : j+m+32]).StoreSlice(dst[i+m : i+m+32])
+			storeUint8x32(loadUint8x32(src, j+m), dst, i+m)
 		}
 		i += n
 		j += n
@@ -197,15 +223,16 @@ func decodeByteArraySIMD(dst, src []byte, prefix, suffix []int32) int {
 // decodeByteArray128SIMD is the specialization for fixed length 16 bytes
 // values: the previous value stays in a vector register across iterations.
 func decodeByteArray128SIMD(dst, src []byte, prefix, suffix []int32) int {
+	suffix = suffix[:len(prefix)]
 	i := 0
 	j := 0
-	last := archsimd.LoadUint8x16Slice(dst[0:16])
+	last := loadUint8x16(dst, 0)
 	for k := range prefix {
 		p := int(prefix[k])
 		n := int(suffix[k])
-		last.StoreSlice(dst[i : i+16])
-		archsimd.LoadUint8x16Slice(src[j : j+16]).StoreSlice(dst[i+p : i+p+16])
-		last = archsimd.LoadUint8x16Slice(dst[i : i+16])
+		storeUint8x16(last, dst, i)
+		storeUint8x16(loadUint8x16(src, j), dst, i+p)
+		last = loadUint8x16(dst, i)
 		i += p + n
 		j += n
 	}

--- a/encoding/delta/byte_array_simd_amd64.go
+++ b/encoding/delta/byte_array_simd_amd64.go
@@ -194,30 +194,39 @@ func storeUint8x16(v archsimd.Uint8x16, b []byte, i int) {
 // callers reserve). The caller guarantees at least padding bytes of suffix
 // data remain in src past the region processed here, making the 32 bytes
 // source loads safe.
+//
+// The loop advances raw pointer cursors instead of byte indexes: deriving
+// each access from base+index costs an extra LEA per operation, which made
+// the generated loop ~1.7x the instruction count of the equivalent
+// hand-written assembly.
 func decodeByteArraySIMD(dst, src []byte, prefix, suffix []int32) int {
 	suffix = suffix[:len(prefix)]
-	i := 0
-	j := 0
-	lastValue := 0
+	pd := unsafe.Pointer(unsafe.SliceData(dst))
+	ps := unsafe.Pointer(unsafe.SliceData(src))
+	pl := pd
 	for k := range prefix {
-		p := int(prefix[k])
-		n := int(suffix[k])
-		valueOffset := i
-		storeUint8x32(loadUint8x32(dst, lastValue), dst, i)
-		for m := 32; m < p; m += 32 {
-			storeUint8x32(loadUint8x32(dst, lastValue+m), dst, i+m)
+		p := uintptr(uint32(prefix[k]))
+		n := uintptr(uint32(suffix[k]))
+		valueOffset := pd
+		archsimd.LoadUint8x32((*[32]uint8)(pl)).Store((*[32]uint8)(pd))
+		if p > 32 {
+			for m := uintptr(32); m < p; m += 32 {
+				archsimd.LoadUint8x32((*[32]uint8)(unsafe.Add(pl, m))).Store((*[32]uint8)(unsafe.Add(pd, m)))
+			}
 		}
-		i += p
-		storeUint8x32(loadUint8x32(src, j), dst, i)
-		for m := 32; m < n; m += 32 {
-			storeUint8x32(loadUint8x32(src, j+m), dst, i+m)
+		pd = unsafe.Add(pd, p)
+		archsimd.LoadUint8x32((*[32]uint8)(ps)).Store((*[32]uint8)(pd))
+		if n > 32 {
+			for m := uintptr(32); m < n; m += 32 {
+				archsimd.LoadUint8x32((*[32]uint8)(unsafe.Add(ps, m))).Store((*[32]uint8)(unsafe.Add(pd, m)))
+			}
 		}
-		i += n
-		j += n
-		lastValue = valueOffset
+		pd = unsafe.Add(pd, n)
+		ps = unsafe.Add(ps, n)
+		pl = valueOffset
 	}
 	archsimd.ClearAVXUpperBits()
-	return i
+	return int(uintptr(pd) - uintptr(unsafe.Pointer(unsafe.SliceData(dst))))
 }
 
 // decodeByteArray128SIMD is the specialization for fixed length 16 bytes

--- a/encoding/delta/byte_array_test.go
+++ b/encoding/delta/byte_array_test.go
@@ -14,6 +14,10 @@ func TestWordSearchPrefixLength(t *testing.T) {
 	testSearchPrefixLength(t, wordSearchPrefixLength)
 }
 
+func TestSearchPrefixLength(t *testing.T) {
+	testSearchPrefixLength(t, searchPrefixLength)
+}
+
 func TestBinarySearchPrefixLength(t *testing.T) {
 	testSearchPrefixLength(t, func(base, data []byte) int {
 		return binarySearchPrefixLength(base, data)
@@ -139,6 +143,10 @@ func BenchmarkLinearSearchPrefixLength(b *testing.B) {
 
 func BenchmarkWordSearchPrefixLength(b *testing.B) {
 	benchmarkSearchPrefixLength(b, wordSearchPrefixLength)
+}
+
+func BenchmarkSearchPrefixLength(b *testing.B) {
+	benchmarkSearchPrefixLength(b, searchPrefixLength)
 }
 
 func BenchmarkBinarySearchPrefixLength(b *testing.B) {

--- a/encoding/delta/byte_array_test.go
+++ b/encoding/delta/byte_array_test.go
@@ -10,6 +10,10 @@ func TestLinearSearchPrefixLength(t *testing.T) {
 	testSearchPrefixLength(t, linearSearchPrefixLength)
 }
 
+func TestWordSearchPrefixLength(t *testing.T) {
+	testSearchPrefixLength(t, wordSearchPrefixLength)
+}
+
 func TestBinarySearchPrefixLength(t *testing.T) {
 	testSearchPrefixLength(t, func(base, data []byte) int {
 		return binarySearchPrefixLength(base, data)
@@ -131,6 +135,10 @@ func testSearchPrefixLength(t *testing.T, prefixLength func(base, data []byte) i
 
 func BenchmarkLinearSearchPrefixLength(b *testing.B) {
 	benchmarkSearchPrefixLength(b, linearSearchPrefixLength)
+}
+
+func BenchmarkWordSearchPrefixLength(b *testing.B) {
+	benchmarkSearchPrefixLength(b, wordSearchPrefixLength)
 }
 
 func BenchmarkBinarySearchPrefixLength(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/klauspost/compress v1.17.9
-	github.com/parquet-go/bitpack v1.0.0
+	github.com/parquet-go/bitpack v1.0.2-0.20260813172022-07bd0673c72d
 	github.com/parquet-go/jsonlite v1.0.0
 	github.com/pierrec/lz4/v4 v4.1.21
 	github.com/twpayne/go-geom v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/klauspost/compress v1.17.9
-	github.com/parquet-go/bitpack v1.0.2
+	github.com/parquet-go/bitpack v1.0.3
 	github.com/parquet-go/jsonlite v1.0.0
 	github.com/pierrec/lz4/v4 v4.1.21
 	github.com/twpayne/go-geom v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/klauspost/compress v1.17.9
-	github.com/parquet-go/bitpack v1.0.2-0.20260813172022-07bd0673c72d
+	github.com/parquet-go/bitpack v1.0.2
 	github.com/parquet-go/jsonlite v1.0.0
 	github.com/pierrec/lz4/v4 v4.1.21
 	github.com/twpayne/go-geom v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/parquet-go/bitpack v1.0.2 h1:vikkxP7GyycuqTUrY6N8OESsCKNPBZmwBlMy+oWoezs=
-github.com/parquet-go/bitpack v1.0.2/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
+github.com/parquet-go/bitpack v1.0.3 h1:ZbzJ4Mjzrjp+ZNvY99XsJIxAKL+b04uxIb02+l4HbkE=
+github.com/parquet-go/bitpack v1.0.3/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.0.0 h1:87QNdi56wOfsE5bdgas0vRzHPxfJgzrXGml1zZdd7VU=
 github.com/parquet-go/jsonlite v1.0.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/parquet-go/bitpack v1.0.0 h1:AUqzlKzPPXf2bCdjfj4sTeacrUwsT7NlcYDMUQxPcQA=
-github.com/parquet-go/bitpack v1.0.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
+github.com/parquet-go/bitpack v1.0.2-0.20260813172022-07bd0673c72d h1:je/8ThSUMwcc7My9WedjvT+guymBqDSIZzk2/1nR5gQ=
+github.com/parquet-go/bitpack v1.0.2-0.20260813172022-07bd0673c72d/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.0.0 h1:87QNdi56wOfsE5bdgas0vRzHPxfJgzrXGml1zZdd7VU=
 github.com/parquet-go/jsonlite v1.0.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/parquet-go/bitpack v1.0.2-0.20260813172022-07bd0673c72d h1:je/8ThSUMwcc7My9WedjvT+guymBqDSIZzk2/1nR5gQ=
-github.com/parquet-go/bitpack v1.0.2-0.20260813172022-07bd0673c72d/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
+github.com/parquet-go/bitpack v1.0.2 h1:vikkxP7GyycuqTUrY6N8OESsCKNPBZmwBlMy+oWoezs=
+github.com/parquet-go/bitpack v1.0.2/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.0.0 h1:87QNdi56wOfsE5bdgas0vRzHPxfJgzrXGml1zZdd7VU=
 github.com/parquet-go/jsonlite v1.0.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=


### PR DESCRIPTION
## What

Replaces the byte-at-a-time common prefix search in the `DELTA_BYTE_ARRAY` encoder (and the `sort.Search`-based variant for values >64B) with an exact longest-common-prefix computed 8 bytes at a time: both values are cast to `[]uint64` via `bitpack/unsafecast`, words are XORed, and the first mismatching byte is located with a zero count — `TrailingZeros64` on little-endian, `LeadingZeros64` under `cpu.IsBigEndian`. Output is byte-identical to the previous encoder.

Two ineffective bounds-check-elimination hints are also fixed:
- the encoder's suffix-copy loop hoists `prefix.values`/`length.values` into locals — the `_ = length.values[:len(prefix.values)]` hint was silently discarded because the field is reloaded after every `copy` call;
- the purego decoders turn `_ = prefix[:len(suffix)]` into real assignments — prove only tracked the discarded-reslice fact for one operand, leaving a per-value check on the other.

With these, the prefix-search hot loop and the decoder's length loops compile with no per-iteration bounds checks (verified with `-gcflags='-d=ssa/check_bce'`); the remaining checks are the ones validating caller-provided offsets and page data, which are load-bearing.

## Why

The prefix search is the dominant cost when encoding sorted/prefix-heavy string columns — exactly the data `DELTA_BYTE_ARRAY` exists for. The existing generic benchmarks use random byte arrays with ~no shared prefixes, so this cost was invisible; this PR adds a prefix-heavy benchmark (sorted URL/path-like values).

This matches what other implementations converged on: parquet-java uses the SIMD-intrinsified `Arrays.mismatch`, and arrow-rs recently switched to 32-byte block compares (apache/arrow-rs#10549). Research notes on the design space — including why quantizing prefix lengths to fixed sizes (8/16/32/64) is spec-legal but loses to exact word-parallel LCP on both speed and compression — are included in `docs/delta-byte-array-prefix.md`.

## Benchmarks (Apple M4 Max, arm64)

`BenchmarkEncodeByteArrayPrefixHeavy` (10k sorted URL/path-like values):

| | encode | decode (purego) | encoded/raw |
|---|---:|---:|---:|
| before | 2.56 GB/s | 6.70 GB/s | 0.7266 |
| after | 3.92 GB/s (+53%) | 6.90 GB/s (+3%) | 0.7266 |

Isolated prefix search (`BenchmarkWordSearchPrefixLength` vs `BenchmarkLinearSearchPrefixLength`): 5.2→3.8 ns at 100B, 140→18 ns at 1000B.

## Notes

- `unsafecast.Slice[uint64]` reinterprets the slice header, so `checkptr` under `-race` does not observe misaligned pointer conversions; unaligned 8-byte loads are handled by amd64/arm64. Verified with `go test -race ./...` (full suite passes).
- `linearSearchPrefixLength`/`binarySearchPrefixLength` are kept as test/benchmark baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)