### PR TITLE
fix: use signed sort order for BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY decimals

### DIFF
--- a/type_decimal.go
+++ b/type_decimal.go
@@ -1,13 +1,16 @@
 package parquet
 
 import (
+	"bytes"
 	"log"
 	"math"
 	"math/big"
 	"reflect"
+	"slices"
 	"strconv"
 
 	"github.com/parquet-go/parquet-go/deprecated"
+	"github.com/parquet-go/parquet-go/encoding"
 	"github.com/parquet-go/parquet-go/format"
 )
 
@@ -47,6 +50,290 @@ type decimalType struct {
 }
 
 func (t *decimalType) String() string { return t.decimal.String() }
+
+// isBinary returns true when the decimal values are stored as big-endian
+// two's-complement binary values, which is the case for the BYTE_ARRAY and
+// FIXED_LEN_BYTE_ARRAY physical types.
+//
+// The physical byte array types compare values as unsigned bytes, which does
+// not match the signed sort order that the parquet format defines for the
+// DECIMAL logical type; every negative value would sort above every positive
+// value. The decimalType methods below override the constructors of objects
+// involved in the computation of statistics (column buffers, pages,
+// dictionaries, column indexes) to apply the signed comparison instead.
+//
+// INT32 and INT64 backed decimals delegate to the physical type, which is
+// already signed.
+func (t *decimalType) isBinary() bool {
+	kind := t.Type.Kind()
+	return kind == ByteArray || kind == FixedLenByteArray
+}
+
+// Compare implements the DECIMAL sort order defined by the parquet format:
+// signed comparison of the big-endian two's-complement values for decimals
+// backed by BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY.
+//
+// https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal
+func (t *decimalType) Compare(a, b Value) int {
+	if t.isBinary() {
+		return compareDecimalByteArrays(a.byteArray(), b.byteArray())
+	}
+	return t.Type.Compare(a, b)
+}
+
+func (t *decimalType) NewColumnBuffer(columnIndex, numValues int) ColumnBuffer {
+	if t.isBinary() {
+		return &decimalColumnBuffer{
+			ColumnBuffer: t.Type.NewColumnBuffer(columnIndex, numValues),
+			typ:          t,
+		}
+	}
+	return t.Type.NewColumnBuffer(columnIndex, numValues)
+}
+
+func (t *decimalType) NewPage(columnIndex, numValues int, data encoding.Values) Page {
+	if t.isBinary() {
+		return &decimalPage{
+			Page: t.Type.NewPage(columnIndex, numValues, data),
+			typ:  t,
+		}
+	}
+	return t.Type.NewPage(columnIndex, numValues, data)
+}
+
+func (t *decimalType) NewDictionary(columnIndex, numValues int, data encoding.Values) Dictionary {
+	if t.isBinary() {
+		return &decimalDictionary{
+			Dictionary: t.Type.NewDictionary(columnIndex, numValues, data),
+			typ:        t,
+		}
+	}
+	return t.Type.NewDictionary(columnIndex, numValues, data)
+}
+
+func (t *decimalType) NewColumnIndexer(sizeLimit int) ColumnIndexer {
+	if t.isBinary() {
+		return &decimalColumnIndexer{}
+	}
+	return t.Type.NewColumnIndexer(sizeLimit)
+}
+
+// compareDecimalByteArrays compares two big-endian two's-complement values,
+// which may have different lengths for decimals backed by BYTE_ARRAY.
+func compareDecimalByteArrays(a, b []byte) int {
+	negA := len(a) > 0 && a[0]&0x80 != 0
+	negB := len(b) > 0 && b[0]&0x80 != 0
+	switch {
+	case negA && !negB:
+		return -1
+	case !negA && negB:
+		return +1
+	}
+	pad := byte(0x00)
+	if negA {
+		pad = 0xFF
+	}
+	if len(a) < len(b) {
+		return -compareDecimalPadded(b, a, pad)
+	}
+	return compareDecimalPadded(a, b, pad)
+}
+
+// compareDecimalPadded compares a to b sign-extended to the length of a,
+// assuming len(a) >= len(b) and both values have the same sign, in which case
+// the comparison of the sign-extended representations reduces to an unsigned
+// byte-wise comparison.
+func compareDecimalPadded(a, b []byte, pad byte) int {
+	for _, c := range a[:len(a)-len(b)] {
+		switch {
+		case c < pad:
+			return -1
+		case c > pad:
+			return +1
+		}
+	}
+	return bytes.Compare(a[len(a)-len(b):], b)
+}
+
+// decimalColumnBuffer wraps the column buffer of the underlying physical type
+// to apply the signed decimal sort order when computing page bounds and
+// sorting values.
+type decimalColumnBuffer struct {
+	ColumnBuffer
+	typ *decimalType
+}
+
+func (col *decimalColumnBuffer) Clone() ColumnBuffer {
+	return &decimalColumnBuffer{
+		ColumnBuffer: col.ColumnBuffer.Clone(),
+		typ:          col.typ,
+	}
+}
+
+func (col *decimalColumnBuffer) Page() Page {
+	return &decimalPage{Page: col.ColumnBuffer.Page(), typ: col.typ}
+}
+
+func (col *decimalColumnBuffer) Pages() Pages { return onePage(col.Page()) }
+
+func (col *decimalColumnBuffer) ColumnIndex() (ColumnIndex, error) {
+	return decimalColumnIndex{page: col.Page().(*decimalPage)}, nil
+}
+
+func (col *decimalColumnBuffer) Less(i, j int) bool {
+	u := [1]Value{}
+	v := [1]Value{}
+	col.ColumnBuffer.ReadValuesAt(u[:], int64(i))
+	col.ColumnBuffer.ReadValuesAt(v[:], int64(j))
+	return compareDecimalByteArrays(u[0].byteArray(), v[0].byteArray()) < 0
+}
+
+// decimalPage wraps a page of the underlying physical type to compute bounds
+// with the signed decimal sort order.
+type decimalPage struct {
+	Page
+	typ *decimalType
+}
+
+func (page *decimalPage) Bounds() (min, max Value, ok bool) {
+	values := page.Page.Values()
+	buffer := make([]Value, 64)
+	for {
+		n, err := values.ReadValues(buffer)
+		for _, v := range buffer[:n] {
+			if !ok {
+				min, max, ok = v, v, true
+				continue
+			}
+			if compareDecimalByteArrays(v.byteArray(), min.byteArray()) < 0 {
+				min = v
+			}
+			if compareDecimalByteArrays(v.byteArray(), max.byteArray()) > 0 {
+				max = v
+			}
+		}
+		if err != nil || n == 0 {
+			break
+		}
+	}
+	return min, max, ok
+}
+
+func (page *decimalPage) Slice(i, j int64) Page {
+	return &decimalPage{Page: page.Page.Slice(i, j), typ: page.typ}
+}
+
+// decimalDictionary wraps the dictionary of the underlying physical type to
+// compute bounds with the signed decimal sort order.
+type decimalDictionary struct {
+	Dictionary
+	typ *decimalType
+}
+
+func (d *decimalDictionary) Type() Type { return newIndexedType(d.typ, d) }
+
+func (d *decimalDictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) == 0 {
+		return min, max
+	}
+	min = d.Index(indexes[0])
+	max = min
+	for _, i := range indexes[1:] {
+		v := d.Index(i)
+		switch {
+		case compareDecimalByteArrays(v.byteArray(), min.byteArray()) < 0:
+			min = v
+		case compareDecimalByteArrays(v.byteArray(), max.byteArray()) > 0:
+			max = v
+		}
+	}
+	return min, max
+}
+
+// decimalColumnIndex is the column index of a single in-memory page of binary
+// decimal values.
+type decimalColumnIndex struct{ page *decimalPage }
+
+func (i decimalColumnIndex) NumPages() int       { return 1 }
+func (i decimalColumnIndex) NullCount(int) int64 { return 0 }
+func (i decimalColumnIndex) NullPage(int) bool   { return false }
+func (i decimalColumnIndex) MinValue(int) Value {
+	min, _, _ := i.page.Bounds()
+	return min
+}
+func (i decimalColumnIndex) MaxValue(int) Value {
+	_, max, _ := i.page.Bounds()
+	return max
+}
+func (i decimalColumnIndex) IsAscending() bool  { return false }
+func (i decimalColumnIndex) IsDescending() bool { return false }
+
+// decimalColumnIndexer computes the column index of binary decimal columns,
+// determining the boundary order with the signed decimal sort order.
+//
+// Unlike the indexers of the physical byte array types, min/max values are
+// never truncated: prefix truncation does not preserve the ordering of
+// two's-complement values.
+type decimalColumnIndexer struct {
+	baseColumnIndexer
+	minValues [][]byte
+	maxValues [][]byte
+}
+
+func (i *decimalColumnIndexer) Reset() {
+	i.reset()
+	i.minValues = i.minValues[:0]
+	i.maxValues = i.maxValues[:0]
+}
+
+func (i *decimalColumnIndexer) IndexPage(numValues, numNulls int64, min, max Value) {
+	i.observe(numValues, numNulls)
+	i.minValues = append(i.minValues, copyBytes(min.byteArray()))
+	i.maxValues = append(i.maxValues, copyBytes(max.byteArray()))
+}
+
+func (i *decimalColumnIndexer) ColumnIndex() format.ColumnIndex {
+	return i.columnIndex(
+		slices.Clone(i.minValues),
+		slices.Clone(i.maxValues),
+		orderOfDecimalBytes(i.minValues),
+		orderOfDecimalBytes(i.maxValues),
+	)
+}
+
+// orderOfDecimalBytes mirrors orderOfBytes but uses the signed decimal sort
+// order instead of the unsigned byte order.
+func orderOfDecimalBytes(data [][]byte) int {
+	switch len(data) {
+	case 0, 1:
+		return 0
+	}
+	i := 1
+	for i < len(data) && compareDecimalByteArrays(data[i-1], data[i]) == 0 {
+		i++
+	}
+	data = data[i-1:]
+	if len(data) < 2 {
+		return 1
+	}
+	switch ordering := compareDecimalByteArrays(data[0], data[1]); {
+	case ordering < 0:
+		for j := 2; j < len(data); j++ {
+			if compareDecimalByteArrays(data[j-1], data[j]) > 0 {
+				return 0
+			}
+		}
+		return +1
+	case ordering > 0:
+		for j := 2; j < len(data); j++ {
+			if compareDecimalByteArrays(data[j-1], data[j]) < 0 {
+				return 0
+			}
+		}
+		return -1
+	}
+	return 0
+}
 
 func (t *decimalType) LogicalType() *format.LogicalType {
 	return &format.LogicalType{Value: &t.decimal}

--- a/type_decimal_test.go
+++ b/type_decimal_test.go
@@ -1,8 +1,12 @@
 package parquet
 
 import (
+	"bytes"
 	"fmt"
+	"sort"
 	"testing"
+
+	"github.com/parquet-go/parquet-go/format"
 )
 
 func TestDecimalInt64PanicMessage(t *testing.T) {
@@ -21,5 +25,223 @@ func TestDecimalInt64PanicMessage(t *testing.T) {
 				t.Errorf("wrong panic message:\n got: %s\nwant: %s", got, want)
 			}
 		})
+	}
+}
+
+func TestCompareDecimalByteArrays(t *testing.T) {
+	tests := []struct {
+		a, b []byte
+		want int
+	}{
+		// equal lengths
+		{[]byte{0x00, 0x01}, []byte{0x00, 0x01}, 0},  // +1 == +1
+		{[]byte{0xFF, 0xFF}, []byte{0x00, 0x01}, -1}, // -1 < +1
+		{[]byte{0x00, 0x01}, []byte{0xFF, 0xFF}, +1}, // +1 > -1
+		{[]byte{0xFF, 0xFF}, []byte{0xFF, 0x00}, +1}, // -1 > -256
+		{[]byte{0x80, 0x00}, []byte{0xFF, 0xFF}, -1}, // -32768 < -1
+		{[]byte{0x00, 0x01}, []byte{0x7F, 0xFF}, -1}, // +1 < +32767
+		{[]byte{0x00, 0x00}, []byte{0xFF, 0xFF}, +1}, // 0 > -1
+		{[]byte{0x00, 0x00}, []byte{0x00, 0x01}, -1}, // 0 < +1
+		// different lengths (BYTE_ARRAY backed decimals)
+		{[]byte{0x01}, []byte{0x00, 0x01}, 0},  // +1 == +1
+		{[]byte{0xFF}, []byte{0xFF, 0xFF}, 0},  // -1 == -1
+		{[]byte{0xFF}, []byte{0xFF, 0x00}, +1}, // -1 > -256
+		{[]byte{0x01}, []byte{0x01, 0x00}, -1}, // +1 < +256
+		{[]byte{0xFF}, []byte{0x01}, -1},       // -1 < +1
+		{[]byte{0x00, 0x80}, []byte{0x7F}, +1}, // +128 > +127
+		{[]byte{0xFF, 0x80}, []byte{0x80}, 0},  // -128 == -128
+		{nil, nil, 0},                          // 0 == 0
+		{nil, []byte{0x01}, -1},                // 0 < +1
+		{nil, []byte{0xFF}, +1},                // 0 > -1
+	}
+
+	sign := func(k int) int {
+		switch {
+		case k < 0:
+			return -1
+		case k > 0:
+			return +1
+		default:
+			return 0
+		}
+	}
+
+	for _, tt := range tests {
+		if got := sign(compareDecimalByteArrays(tt.a, tt.b)); got != tt.want {
+			t.Errorf("compareDecimalByteArrays(%X, %X) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+		if got := sign(compareDecimalByteArrays(tt.b, tt.a)); got != -tt.want {
+			t.Errorf("compareDecimalByteArrays(%X, %X) = %d, want %d", tt.b, tt.a, got, -tt.want)
+		}
+	}
+}
+
+// TestDecimalStatistics verifies that decimals backed by BYTE_ARRAY and
+// FIXED_LEN_BYTE_ARRAY write column chunk statistics and column index bounds
+// using the signed sort order defined by the parquet format, instead of the
+// unsigned byte order of the physical type under which every negative value
+// sorts above every positive value.
+//
+// https://github.com/parquet-go/parquet-go/issues/592
+func TestDecimalStatistics(t *testing.T) {
+	tests := []struct {
+		name    string
+		node    Node
+		values  [][]byte
+		wantMin []byte
+		wantMax []byte
+	}{
+		{
+			name: "fixed length byte array",
+			node: Decimal(0, 4, FixedLenByteArrayType(2)),
+			values: [][]byte{
+				{0x00, 0x01}, // +1
+				{0xFF, 0xFF}, // -1
+				{0x01, 0x00}, // +256
+				{0xFF, 0x00}, // -256
+			},
+			wantMin: []byte{0xFF, 0x00},
+			wantMax: []byte{0x01, 0x00},
+		},
+		{
+			name: "fixed length byte array dictionary",
+			node: Encoded(Decimal(0, 4, FixedLenByteArrayType(2)), &RLEDictionary),
+			values: [][]byte{
+				{0x00, 0x01}, // +1
+				{0xFF, 0xFF}, // -1
+				{0x01, 0x00}, // +256
+				{0xFF, 0x00}, // -256
+			},
+			wantMin: []byte{0xFF, 0x00},
+			wantMax: []byte{0x01, 0x00},
+		},
+		{
+			name: "fixed length byte array 16",
+			node: Decimal(0, 38, FixedLenByteArrayType(16)),
+			values: [][]byte{
+				{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, // +1
+				{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // -1
+			},
+			wantMin: []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			wantMax: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+		},
+		{
+			name: "byte array",
+			node: Decimal(0, 18, ByteArrayType),
+			values: [][]byte{
+				{0x01},       // +1
+				{0xFF},       // -1
+				{0x01, 0x00}, // +256
+				{0xFF, 0x00}, // -256
+			},
+			wantMin: []byte{0xFF, 0x00},
+			wantMax: []byte{0x01, 0x00},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := NewSchema("t", Group{"d": Optional(tt.node)})
+
+			buf := new(bytes.Buffer)
+			writer := NewGenericWriter[any](buf, schema)
+			for _, v := range tt.values {
+				if _, err := writer.Write([]any{map[string]any{"d": v}}); err != nil {
+					t.Fatalf("failed to write: %v", err)
+				}
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatalf("failed to close writer: %v", err)
+			}
+
+			f, err := OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+			if err != nil {
+				t.Fatalf("failed to open file: %v", err)
+			}
+
+			stats := f.Metadata().RowGroups[0].Columns[0].MetaData.Statistics
+			if !bytes.Equal(stats.MinValue, tt.wantMin) {
+				t.Errorf("column chunk statistics min = %X, want %X", stats.MinValue, tt.wantMin)
+			}
+			if !bytes.Equal(stats.MaxValue, tt.wantMax) {
+				t.Errorf("column chunk statistics max = %X, want %X", stats.MaxValue, tt.wantMax)
+			}
+
+			columnIndexes := f.ColumnIndexes()
+			if len(columnIndexes) != 1 {
+				t.Fatalf("expected 1 column index, got %d", len(columnIndexes))
+			}
+			if got := columnIndexes[0].MinValues[0]; !bytes.Equal(got, tt.wantMin) {
+				t.Errorf("column index min = %X, want %X", got, tt.wantMin)
+			}
+			if got := columnIndexes[0].MaxValues[0]; !bytes.Equal(got, tt.wantMax) {
+				t.Errorf("column index max = %X, want %X", got, tt.wantMax)
+			}
+		})
+	}
+}
+
+// TestDecimalColumnIndexBoundaryOrder verifies that the boundary order of the
+// column index of binary decimal columns is determined with the signed sort
+// order: the pages below are descending under the signed order but would be
+// (incorrectly) ascending under the unsigned byte order.
+func TestDecimalColumnIndexBoundaryOrder(t *testing.T) {
+	typ := Decimal(0, 4, FixedLenByteArrayType(2)).Type()
+	indexer := typ.NewColumnIndexer(0)
+
+	// page 1: [+1, +2], page 2: [-5, -3]
+	indexer.IndexPage(2, 0,
+		makeValueBytes(FixedLenByteArray, []byte{0x00, 0x01}),
+		makeValueBytes(FixedLenByteArray, []byte{0x00, 0x02}),
+	)
+	indexer.IndexPage(2, 0,
+		makeValueBytes(FixedLenByteArray, []byte{0xFF, 0xFB}),
+		makeValueBytes(FixedLenByteArray, []byte{0xFF, 0xFD}),
+	)
+
+	columnIndex := indexer.ColumnIndex()
+	if columnIndex.BoundaryOrder != format.Descending {
+		t.Errorf("boundary order = %s, want %s", columnIndex.BoundaryOrder, format.Descending)
+	}
+}
+
+// TestDecimalSortingOrder verifies that sorting rows by a binary decimal
+// column applies the signed sort order.
+func TestDecimalSortingOrder(t *testing.T) {
+	schema := NewSchema("t", Group{"d": Decimal(0, 4, FixedLenByteArrayType(2))})
+	buffer := NewGenericBuffer[any](schema,
+		SortingRowGroupConfig(SortingColumns(Ascending("d"))),
+	)
+
+	values := [][]byte{
+		{0x00, 0x01}, // +1
+		{0xFF, 0x00}, // -256
+		{0x01, 0x00}, // +256
+		{0xFF, 0xFF}, // -1
+	}
+	for _, v := range values {
+		if _, err := buffer.Write([]any{map[string]any{"d": v}}); err != nil {
+			t.Fatalf("failed to write: %v", err)
+		}
+	}
+	sort.Sort(buffer)
+
+	rows := make([]Row, len(values))
+	reader := buffer.Rows()
+	defer reader.Close()
+	if n, err := reader.ReadRows(rows); n != len(values) {
+		t.Fatalf("expected to read %d rows, got %d (%v)", len(values), n, err)
+	}
+
+	want := [][]byte{
+		{0xFF, 0x00}, // -256
+		{0xFF, 0xFF}, // -1
+		{0x00, 0x01}, // +1
+		{0x01, 0x00}, // +256
+	}
+	for i, row := range rows {
+		if got := row[0].ByteArray(); !bytes.Equal(got, want[i]) {
+			t.Errorf("row %d = %X, want %X", i, got, want[i])
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #592.

The parquet format defines the [DECIMAL sort order as signed](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal), and binary decimals are stored as big-endian two's-complement. `decimalType` delegated everything to the embedded physical type, so BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY decimals were compared as unsigned bytes: every negative value sorted above every positive value, producing inverted min/max in column chunk statistics and the column index for any column containing both signs. Readers that trust the type-defined order (predicate pushdown, table-format manifest bounds) then prune incorrectly and silently drop matching rows. Same bug class as [PARQUET-1655](https://issues.apache.org/jira/browse/PARQUET-1655).

Since the unsigned comparison leaks in through several independent paths (type comparator, page bounds, dictionary bounds, column index boundary order, row sorting), `decimalType` now:

- overrides `Compare` with a signed two's-complement comparison that also handles the variable-length values of BYTE_ARRAY backed decimals (shorter operand is sign-extended);
- wraps the physical type's column buffers and pages so `Bounds()` (which feeds both chunk statistics and the column index) and `Less` use the signed order — this covers the plain FLBA, BE128 (FLBA(16)), and BYTE_ARRAY paths uniformly;
- wraps dictionaries so `Bounds(indexes)` on dictionary-encoded pages uses the signed order, and returns an `indexedType` carrying the decimal type so dictionary-path comparisons are signed too;
- provides a column indexer that determines `BoundaryOrder` with the signed order. Column index values of binary decimals are no longer truncated to the size limit, since prefix truncation does not preserve two's-complement ordering.

INT32/INT64 backed decimals delegate to the physical type as before (already signed). Non-decimal columns are unaffected: all wrappers are only installed when the decimal is backed by a byte array type.

## Test plan

- `TestCompareDecimalByteArrays`: unit tests for the signed comparator, including mixed lengths and empty values.
- `TestDecimalStatistics`: end-to-end write/read verifying footer statistics and column index min/max for FLBA(2) (issue repro), FLBA(2) with RLE_DICTIONARY, FLBA(16) (BE128 path), and variable-length BYTE_ARRAY decimals. All four fail against the previous behavior and pass with the fix.
- `TestDecimalColumnIndexBoundaryOrder`: pages that are unsigned-ascending but signed-descending now produce `DESCENDING`.
- `TestDecimalSortingOrder`: sorting a row group by a binary decimal column orders negatives before positives.
- `go test ./...` passes.

Made with [Cursor](https://cursor.com)