### PR TITLE
perf: 4-accumulator float bounds kernels for small pages

### DIFF
--- a/docs/archsimd-port.md
+++ b/docs/archsimd-port.md
@@ -174,6 +174,43 @@ copies itself (`*(*[16]byte)(p)` assignments compile to MOVUPS pairs;
 wrapping them in unsafe.Slice + archsimd loads added per-element setup
 worth +40% on its own).
 
+## SIMD library survey (kelindar/simd, viterin/vek, pehringer/simd, axiomhq/simd-go)
+
+Studied 2026-08-15 for transplantable techniques. Most of their surface
+(sums, dots, transcendentals) has no parquet use, and their best tricks
+(VPSADBW byte sums, sign-bias unsigned compares, CMGT+BIT lane select)
+were already in our kernels — often in stronger form (they lack AVX-512,
+NaN correctness, masked/overlap tails; vek's CumSum is scalar where our
+prefix sums are vector-resident). Three experiments came out of it:
+
+- **4-accumulator float bounds (shipped)**: vek and kelindar both run 4
+  accumulator sets (clang's default). Small compute-bound pages measured
+  -9.7%/-9.2% at 4KiB; cache-resident sizes measured up to +33% WORSE
+  with the wide unroll, so it is fenced to pages <= 32KiB and the 2-set
+  loop keeps larger inputs. Lesson: unroll width is size-dependent —
+  wider is not free once the working set leaves L1.
+- **AVX2 xxhash tier (uint32 shipped, uint64 rejected)**: the 3x
+  VPMULUDQ 64-bit multiply decomposition (kelindar's clang recipe) wins
+  -12.5% for uint32 hashes (first multiply needs only 2 products) and
+  ties scalar MULQ for uint64 (+2.5%) — five full 3-product multiplies
+  per hash have no headroom over superscalar IMUL. The first version of
+  these kernels used ShiftAll* with constant counts and measured **37x
+  slower than scalar** — the tier-1 legacy-MOVQ rule (golang/go#80835)
+  applies to constant counts too; per-lane shifts with broadcast count
+  vectors fixed it.
+- **Two-pass BE128 min/max (rejected)**: vek computes ArgMax as a lean
+  value pass plus a bitwise-equality find pass. For 16-byte
+  lexicographic values this measured +30..+73% (worst at DRAM-bound
+  sizes): the value pass only sheds 3 of ~11 ops while the second pass
+  re-reads up to the whole input. The two-pass trick needs a cheap
+  rescan to amortize; wide keys make the rescan the cost.
+
+Not pursued: vek Find (no parquet op searches unsorted values),
+kelindar vphminposuw funnels (no 8/16-bit physical types), NEON/SVE
+(archsimd is amd64-only; axiomhq/simd-go is the reference if that
+changes — including their per-microarchitecture measured dispatch
+thresholds, a methodology worth adopting wholesale).
+
 ## Dead code found during the audit (delete regardless)
 
 - `dictionaryLookupByteArrayString` / `dictionaryLookupFixedLenByteArray{String,Pointer}`

--- a/page_minmax_simd_amd64.go
+++ b/page_minmax_simd_amd64.go
@@ -1655,6 +1655,82 @@ func boundsFloat32(data []float32) (min, max float32) {
 	}
 	d := data
 	switch {
+	case archsimd.X86.AVX512() && len(d) >= 64 && len(d) <= 8192:
+		// Small inputs are compute bound and profit from four accumulator
+		// sets (the clang generated kernels of viterin/vek and
+		// kelindar/simd both run four); at cache resident sizes above the
+		// threshold the two set loop below measured up to 33% faster, so
+		// the wider unroll is fenced to small pages.
+		minB0 := archsimd.BroadcastFloat32x16(data[0])
+		minB1 := minB0
+		minB2 := minB0
+		minB3 := minB0
+		maxB0 := minB0
+		maxB1 := minB0
+		maxB2 := minB0
+		maxB3 := minB0
+		sumB0 := archsimd.BroadcastUint32x16(0).AsFloat32x16()
+		sumB1 := sumB0
+		sumB2 := sumB0
+		sumB3 := sumB0
+		bchunks := unsafecast.Slice[[64]float32](d)
+		for i := range bchunks {
+			c := &bchunks[i]
+			v0 := archsimd.LoadFloat32x16Slice(c[0:16])
+			v1 := archsimd.LoadFloat32x16Slice(c[16:32])
+			v2 := archsimd.LoadFloat32x16Slice(c[32:48])
+			v3 := archsimd.LoadFloat32x16Slice(c[48:64])
+			minB0 = minB0.Min(v0)
+			minB1 = minB1.Min(v1)
+			minB2 = minB2.Min(v2)
+			minB3 = minB3.Min(v3)
+			maxB0 = maxB0.Max(v0)
+			maxB1 = maxB1.Max(v1)
+			maxB2 = maxB2.Max(v2)
+			maxB3 = maxB3.Max(v3)
+			sumB0 = sumB0.Add(v0)
+			sumB1 = sumB1.Add(v1)
+			sumB2 = sumB2.Add(v2)
+			sumB3 = sumB3.Add(v3)
+		}
+		if rem := len(d) - len(bchunks)*64; rem > 0 {
+			t0 := archsimd.LoadFloat32x16Slice(d[len(d)-16:])
+			minB0 = minB0.Min(t0)
+			maxB0 = maxB0.Max(t0)
+			sumB0 = sumB0.Add(t0)
+			if rem > 16 {
+				t1 := archsimd.LoadFloat32x16Slice(d[len(d)-32:])
+				minB1 = minB1.Min(t1)
+				maxB1 = maxB1.Max(t1)
+				sumB1 = sumB1.Add(t1)
+			}
+			if rem > 32 {
+				t2 := archsimd.LoadFloat32x16Slice(d[len(d)-48:])
+				minB2 = minB2.Min(t2)
+				maxB2 = maxB2.Max(t2)
+				sumB2 = sumB2.Add(t2)
+			}
+			if rem > 48 {
+				t3 := archsimd.LoadFloat32x16Slice(d[len(d)-64:])
+				minB3 = minB3.Min(t3)
+				maxB3 = maxB3.Max(t3)
+				sumB3 = sumB3.Add(t3)
+			}
+		}
+		if sumB0.Add(sumB1).Add(sumB2.Add(sumB3)).IsNaN().ToBits() != 0 {
+			archsimd.ClearAVXUpperBits()
+			return boundsFloat32Merge(data)
+		}
+		minB0 = minB0.Min(minB1).Min(minB2.Min(minB3))
+		maxB0 = maxB0.Max(maxB1).Max(maxB2.Max(maxB3))
+		minH := minB0.GetLo().Min(minB0.GetHi())
+		maxH := maxB0.GetLo().Max(maxB0.GetHi())
+		minQ := minH.GetLo().Min(minH.GetHi())
+		maxQ := maxH.GetLo().Max(maxH.GetHi())
+		min = reduceMinFloat32x4(minQ)
+		max = reduceMaxFloat32x4(maxQ)
+		archsimd.ClearAVXUpperBits()
+		return min, max
 	case archsimd.X86.AVX512() && len(d) >= 32:
 		minA0 := archsimd.BroadcastFloat32x16(data[0])
 		minA1 := minA0
@@ -1756,6 +1832,82 @@ func boundsFloat64(data []float64) (min, max float64) {
 	}
 	d := data
 	switch {
+	case archsimd.X86.AVX512() && len(d) >= 32 && len(d) <= 4096:
+		// Small inputs are compute bound and profit from four accumulator
+		// sets (the clang generated kernels of viterin/vek and
+		// kelindar/simd both run four); at cache resident sizes above the
+		// threshold the two set loop below measured up to 33% faster, so
+		// the wider unroll is fenced to small pages.
+		minB0 := archsimd.BroadcastFloat64x8(data[0])
+		minB1 := minB0
+		minB2 := minB0
+		minB3 := minB0
+		maxB0 := minB0
+		maxB1 := minB0
+		maxB2 := minB0
+		maxB3 := minB0
+		sumB0 := archsimd.BroadcastUint64x8(0).AsFloat64x8()
+		sumB1 := sumB0
+		sumB2 := sumB0
+		sumB3 := sumB0
+		bchunks := unsafecast.Slice[[32]float64](d)
+		for i := range bchunks {
+			c := &bchunks[i]
+			v0 := archsimd.LoadFloat64x8Slice(c[0:8])
+			v1 := archsimd.LoadFloat64x8Slice(c[8:16])
+			v2 := archsimd.LoadFloat64x8Slice(c[16:24])
+			v3 := archsimd.LoadFloat64x8Slice(c[24:32])
+			minB0 = minB0.Min(v0)
+			minB1 = minB1.Min(v1)
+			minB2 = minB2.Min(v2)
+			minB3 = minB3.Min(v3)
+			maxB0 = maxB0.Max(v0)
+			maxB1 = maxB1.Max(v1)
+			maxB2 = maxB2.Max(v2)
+			maxB3 = maxB3.Max(v3)
+			sumB0 = sumB0.Add(v0)
+			sumB1 = sumB1.Add(v1)
+			sumB2 = sumB2.Add(v2)
+			sumB3 = sumB3.Add(v3)
+		}
+		if rem := len(d) - len(bchunks)*32; rem > 0 {
+			t0 := archsimd.LoadFloat64x8Slice(d[len(d)-8:])
+			minB0 = minB0.Min(t0)
+			maxB0 = maxB0.Max(t0)
+			sumB0 = sumB0.Add(t0)
+			if rem > 8 {
+				t1 := archsimd.LoadFloat64x8Slice(d[len(d)-16:])
+				minB1 = minB1.Min(t1)
+				maxB1 = maxB1.Max(t1)
+				sumB1 = sumB1.Add(t1)
+			}
+			if rem > 16 {
+				t2 := archsimd.LoadFloat64x8Slice(d[len(d)-24:])
+				minB2 = minB2.Min(t2)
+				maxB2 = maxB2.Max(t2)
+				sumB2 = sumB2.Add(t2)
+			}
+			if rem > 24 {
+				t3 := archsimd.LoadFloat64x8Slice(d[len(d)-32:])
+				minB3 = minB3.Min(t3)
+				maxB3 = maxB3.Max(t3)
+				sumB3 = sumB3.Add(t3)
+			}
+		}
+		if sumB0.Add(sumB1).Add(sumB2.Add(sumB3)).IsNaN().ToBits() != 0 {
+			archsimd.ClearAVXUpperBits()
+			return boundsFloat64Merge(data)
+		}
+		minB0 = minB0.Min(minB1).Min(minB2.Min(minB3))
+		maxB0 = maxB0.Max(maxB1).Max(maxB2.Max(maxB3))
+		minH := minB0.GetLo().Min(minB0.GetHi())
+		maxH := maxB0.GetLo().Max(maxB0.GetHi())
+		minQ := minH.GetLo().Min(minH.GetHi())
+		maxQ := maxH.GetLo().Max(maxH.GetHi())
+		min = reduceMinFloat64x2(minQ)
+		max = reduceMaxFloat64x2(maxQ)
+		archsimd.ClearAVXUpperBits()
+		return min, max
 	case archsimd.X86.AVX512() && len(d) >= 16:
 		minA0 := archsimd.BroadcastFloat64x8(data[0])
 		minA1 := minA0


### PR DESCRIPTION
The optimistic NaN-witness float bounds kernels gain a four-accumulator-set variant (64 floats / 32 doubles per iteration), dispatched for pages up to 32KiB.

Measured on c4-standard-8 Emerald Rapids (`GOAMD64=v4`, simd build, n=8):

| Benchmark | vs main |
|---|---|
| BoundsFloat32/4KiB | **−9.7%** |
| BoundsFloat64/4KiB | **−9.2%** |
| BoundsFloat32/256KiB | −0.6% (unchanged 2-set path) |
| BoundsFloat64/256KiB | ~ |

The unfenced version measured up to **+33% worse** at 256KiB — unroll width is size-dependent, so the wide variant is limited to compute-bound small pages and the existing two-set loop keeps everything larger. Prompted by a survey of viterin/vek and kelindar/simd, whose clang-generated kernels both run four accumulators; the survey's full results (including two rejected experiments) are recorded in `docs/archsimd-port.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)