### PR TITLE
perf: AVX2 tier for xxhash MultiSum64Uint32

### DIFF
--- a/bloom/xxhash/sum64uint_avx2_bench_test.go
+++ b/bloom/xxhash/sum64uint_avx2_bench_test.go
@@ -1,0 +1,72 @@
+//go:build goexperiment.simd
+
+package xxhash
+
+import (
+	"testing"
+
+	"simd/archsimd"
+)
+
+// Direct benchmarks of the AVX2 tier kernels: the dispatcher prefers the
+// AVX-512 tier on machines that have it, so these call the AVX2 kernels
+// explicitly to compare them against the scalar fallback they replace on
+// AVX2-only hosts.
+
+func BenchmarkMultiSum64Uint64AVX2(b *testing.B) {
+	if !archsimd.X86.AVX2() {
+		b.Skip("requires AVX2")
+	}
+	h := make([]uint64, 512)
+	v := make([]uint64, 512)
+	for i := range v {
+		v[i] = uint64(i) * 0x9E3779B97F4A7C15
+	}
+	b.SetBytes(8 * int64(len(v)))
+	for b.Loop() {
+		multiSum64Uint64AVX2(h, v, len(v))
+	}
+}
+
+func BenchmarkMultiSum64Uint32AVX2(b *testing.B) {
+	if !archsimd.X86.AVX2() {
+		b.Skip("requires AVX2")
+	}
+	h := make([]uint64, 512)
+	v := make([]uint32, 512)
+	for i := range v {
+		v[i] = uint32(i) * 0x9E3779B9
+	}
+	b.SetBytes(4 * int64(len(v)))
+	for b.Loop() {
+		multiSum64Uint32AVX2(h, v, len(v))
+	}
+}
+
+func BenchmarkMultiSum64Uint64Scalar(b *testing.B) {
+	h := make([]uint64, 512)
+	v := make([]uint64, 512)
+	for i := range v {
+		v[i] = uint64(i) * 0x9E3779B97F4A7C15
+	}
+	b.SetBytes(8 * int64(len(v)))
+	for b.Loop() {
+		for i := range v {
+			h[i] = Sum64Uint64(v[i])
+		}
+	}
+}
+
+func BenchmarkMultiSum64Uint32Scalar(b *testing.B) {
+	h := make([]uint64, 512)
+	v := make([]uint32, 512)
+	for i := range v {
+		v[i] = uint32(i) * 0x9E3779B9
+	}
+	b.SetBytes(4 * int64(len(v)))
+	for b.Loop() {
+		for i := range v {
+			h[i] = Sum64Uint32(v[i])
+		}
+	}
+}

--- a/bloom/xxhash/sum64uint_avx2_bench_test.go
+++ b/bloom/xxhash/sum64uint_avx2_bench_test.go
@@ -13,21 +13,6 @@ import (
 // explicitly to compare them against the scalar fallback they replace on
 // AVX2-only hosts.
 
-func BenchmarkMultiSum64Uint64AVX2(b *testing.B) {
-	if !archsimd.X86.AVX2() {
-		b.Skip("requires AVX2")
-	}
-	h := make([]uint64, 512)
-	v := make([]uint64, 512)
-	for i := range v {
-		v[i] = uint64(i) * 0x9E3779B97F4A7C15
-	}
-	b.SetBytes(8 * int64(len(v)))
-	for b.Loop() {
-		multiSum64Uint64AVX2(h, v, len(v))
-	}
-}
-
 func BenchmarkMultiSum64Uint32AVX2(b *testing.B) {
 	if !archsimd.X86.AVX2() {
 		b.Skip("requires AVX2")

--- a/bloom/xxhash/sum64uint_avx2_test.go
+++ b/bloom/xxhash/sum64uint_avx2_test.go
@@ -1,0 +1,37 @@
+//go:build goexperiment.simd
+
+package xxhash
+
+import (
+	"testing"
+
+	"simd/archsimd"
+)
+
+// The dispatcher prefers the AVX-512 tier wherever it exists, so the AVX2
+// kernels are validated directly against the scalar reference.
+
+func TestMultiSum64AVX2Kernels(t *testing.T) {
+	if !archsimd.X86.AVX2() {
+		t.Skip("requires AVX2")
+	}
+	v64 := make([]uint64, 259)
+	v32 := make([]uint32, 259)
+	for i := range v64 {
+		v64[i] = uint64(i) * 0x9E3779B97F4A7C15
+		v32[i] = uint32(i) * 0x9E3779B9
+	}
+	h := make([]uint64, len(v64))
+	n := multiSum64Uint64AVX2(h, v64, len(v64))
+	for i := range n {
+		if want := Sum64Uint64(v64[i]); h[i] != want {
+			t.Fatalf("uint64 kernel: h[%d] = %016x, want %016x", i, h[i], want)
+		}
+	}
+	n = multiSum64Uint32AVX2(h, v32, len(v32))
+	for i := range n {
+		if want := Sum64Uint32(v32[i]); h[i] != want {
+			t.Fatalf("uint32 kernel: h[%d] = %016x, want %016x", i, h[i], want)
+		}
+	}
+}

--- a/bloom/xxhash/sum64uint_avx2_test.go
+++ b/bloom/xxhash/sum64uint_avx2_test.go
@@ -15,20 +15,12 @@ func TestMultiSum64AVX2Kernels(t *testing.T) {
 	if !archsimd.X86.AVX2() {
 		t.Skip("requires AVX2")
 	}
-	v64 := make([]uint64, 259)
 	v32 := make([]uint32, 259)
-	for i := range v64 {
-		v64[i] = uint64(i) * 0x9E3779B97F4A7C15
+	for i := range v32 {
 		v32[i] = uint32(i) * 0x9E3779B9
 	}
-	h := make([]uint64, len(v64))
-	n := multiSum64Uint64AVX2(h, v64, len(v64))
-	for i := range n {
-		if want := Sum64Uint64(v64[i]); h[i] != want {
-			t.Fatalf("uint64 kernel: h[%d] = %016x, want %016x", i, h[i], want)
-		}
-	}
-	n = multiSum64Uint32AVX2(h, v32, len(v32))
+	h := make([]uint64, len(v32))
+	n := multiSum64Uint32AVX2(h, v32, len(v32))
 	for i := range n {
 		if want := Sum64Uint32(v32[i]); h[i] != want {
 			t.Fatalf("uint32 kernel: h[%d] = %016x, want %016x", i, h[i], want)

--- a/bloom/xxhash/sum64uint_simd_amd64.go
+++ b/bloom/xxhash/sum64uint_simd_amd64.go
@@ -185,46 +185,6 @@ func MultiSum64Uint32(h []uint64, v []uint32) int {
 	return n
 }
 
-// multiSum64Uint64AVX2 is the AVX2 tier of MultiSum64Uint64: two streams of
-// 4 hashes with the three-VPMULUDQ multiply decomposition.
-func multiSum64Uint64AVX2(h, v []uint64, n int) int {
-	p1Lo := archsimd.BroadcastUint64x4(prime1 & 0xFFFFFFFF)
-	p1Hi := archsimd.BroadcastUint64x4(prime1 >> 32)
-	p2Lo := archsimd.BroadcastUint64x4(prime2 & 0xFFFFFFFF)
-	p2Hi := archsimd.BroadcastUint64x4(prime2 >> 32)
-	p3Lo := archsimd.BroadcastUint64x4(prime3 & 0xFFFFFFFF)
-	p3Hi := archsimd.BroadcastUint64x4(prime3 >> 32)
-	p4 := archsimd.BroadcastUint64x4(prime4)
-	seed := archsimd.BroadcastUint64x4(prime5 + 8)
-	s27 := archsimd.BroadcastUint64x4(27)
-	s29 := archsimd.BroadcastUint64x4(29)
-	s31 := archsimd.BroadcastUint64x4(31)
-	s32 := archsimd.BroadcastUint64x4(32)
-	s33 := archsimd.BroadcastUint64x4(33)
-	s37 := archsimd.BroadcastUint64x4(37)
-	m := n / 8
-	cv := unsafecast.Slice[[8]uint64](v)[:m]
-	ch := unsafecast.Slice[[8]uint64](h)[:m]
-	for j := range cv {
-		v0 := archsimd.LoadUint64x4Slice(cv[j][0:4])
-		v1 := archsimd.LoadUint64x4Slice(cv[j][4:8])
-		h0 := seed.Xor(mulPrimeAVX2(rotAVX2(mulPrimeAVX2(v0, p2Lo, p2Hi, s32), s31, s33), p1Lo, p1Hi, s32))
-		h1 := seed.Xor(mulPrimeAVX2(rotAVX2(mulPrimeAVX2(v1, p2Lo, p2Hi, s32), s31, s33), p1Lo, p1Hi, s32))
-		h0 = mulPrimeAVX2(rotAVX2(h0, s27, s37), p1Lo, p1Hi, s32).Add(p4)
-		h1 = mulPrimeAVX2(rotAVX2(h1, s27, s37), p1Lo, p1Hi, s32).Add(p4)
-		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftRight(s33)), p2Lo, p2Hi, s32)
-		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftRight(s33)), p2Lo, p2Hi, s32)
-		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftRight(s29)), p3Lo, p3Hi, s32)
-		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftRight(s29)), p3Lo, p3Hi, s32)
-		h0 = h0.Xor(h0.ShiftRight(s32))
-		h1 = h1.Xor(h1.ShiftRight(s32))
-		h0.StoreSlice(ch[j][0:4])
-		h1.StoreSlice(ch[j][4:8])
-	}
-	archsimd.ClearAVXUpperBits()
-	return m * 8
-}
-
 // mulPrime32AVX2 multiplies a value with zero high halves (a widened
 // uint32) by a 64 bit constant: two products suffice.
 func mulPrime32AVX2(a, cLo, cHi, s32 archsimd.Uint64x4) archsimd.Uint64x4 {
@@ -334,8 +294,6 @@ func MultiSum64Uint64(h []uint64, v []uint64) int {
 		}
 		i = m * 32
 		archsimd.ClearAVXUpperBits()
-	} else if archsimd.X86.AVX2() && n >= 16 {
-		i = multiSum64Uint64AVX2(h, v, n)
 	}
 	for ; i < n; i++ {
 		h[i] = Sum64Uint64(v[i])

--- a/bloom/xxhash/sum64uint_simd_amd64.go
+++ b/bloom/xxhash/sum64uint_simd_amd64.go
@@ -176,11 +176,112 @@ func MultiSum64Uint32(h []uint64, v []uint32) int {
 		}
 		i = m * 32
 		archsimd.ClearAVXUpperBits()
+	} else if archsimd.X86.AVX2() && n >= 16 {
+		i = multiSum64Uint32AVX2(h, v, n)
 	}
 	for ; i < n; i++ {
 		h[i] = Sum64Uint32(v[i])
 	}
 	return n
+}
+
+// multiSum64Uint64AVX2 is the AVX2 tier of MultiSum64Uint64: two streams of
+// 4 hashes with the three-VPMULUDQ multiply decomposition.
+func multiSum64Uint64AVX2(h, v []uint64, n int) int {
+	p1Lo := archsimd.BroadcastUint64x4(prime1 & 0xFFFFFFFF)
+	p1Hi := archsimd.BroadcastUint64x4(prime1 >> 32)
+	p2Lo := archsimd.BroadcastUint64x4(prime2 & 0xFFFFFFFF)
+	p2Hi := archsimd.BroadcastUint64x4(prime2 >> 32)
+	p3Lo := archsimd.BroadcastUint64x4(prime3 & 0xFFFFFFFF)
+	p3Hi := archsimd.BroadcastUint64x4(prime3 >> 32)
+	p4 := archsimd.BroadcastUint64x4(prime4)
+	seed := archsimd.BroadcastUint64x4(prime5 + 8)
+	m := n / 8
+	cv := unsafecast.Slice[[8]uint64](v)[:m]
+	ch := unsafecast.Slice[[8]uint64](h)[:m]
+	for j := range cv {
+		v0 := archsimd.LoadUint64x4Slice(cv[j][0:4])
+		v1 := archsimd.LoadUint64x4Slice(cv[j][4:8])
+		h0 := seed.Xor(mulPrimeAVX2(rot31AVX2(mulPrimeAVX2(v0, p2Lo, p2Hi)), p1Lo, p1Hi))
+		h1 := seed.Xor(mulPrimeAVX2(rot31AVX2(mulPrimeAVX2(v1, p2Lo, p2Hi)), p1Lo, p1Hi))
+		h0 = mulPrimeAVX2(rot27AVX2(h0), p1Lo, p1Hi).Add(p4)
+		h1 = mulPrimeAVX2(rot27AVX2(h1), p1Lo, p1Hi).Add(p4)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(33)), p2Lo, p2Hi)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(33)), p2Lo, p2Hi)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(29)), p3Lo, p3Hi)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(29)), p3Lo, p3Hi)
+		h0 = h0.Xor(h0.ShiftAllRight(32))
+		h1 = h1.Xor(h1.ShiftAllRight(32))
+		h0.StoreSlice(ch[j][0:4])
+		h1.StoreSlice(ch[j][4:8])
+	}
+	archsimd.ClearAVXUpperBits()
+	return m * 8
+}
+
+// mulPrime32AVX2 multiplies a value with zero high halves (a widened
+// uint32) by a 64 bit constant: two products suffice.
+func mulPrime32AVX2(a, cLo, cHi archsimd.Uint64x4) archsimd.Uint64x4 {
+	ae := a.AsUint32x8()
+	return ae.MulEvenWiden(cLo.AsUint32x8()).Add(ae.MulEvenWiden(cHi.AsUint32x8()).ShiftAllLeft(32))
+}
+
+func rot23AVX2(a archsimd.Uint64x4) archsimd.Uint64x4 {
+	return a.ShiftAllLeft(23).Or(a.ShiftAllRight(41))
+}
+
+// multiSum64Uint32AVX2 is the AVX2 tier of MultiSum64Uint32.
+func multiSum64Uint32AVX2(h []uint64, v []uint32, n int) int {
+	p1Lo := archsimd.BroadcastUint64x4(prime1 & 0xFFFFFFFF)
+	p1Hi := archsimd.BroadcastUint64x4(prime1 >> 32)
+	p2Lo := archsimd.BroadcastUint64x4(prime2 & 0xFFFFFFFF)
+	p2Hi := archsimd.BroadcastUint64x4(prime2 >> 32)
+	p3Lo := archsimd.BroadcastUint64x4(prime3 & 0xFFFFFFFF)
+	p3Hi := archsimd.BroadcastUint64x4(prime3 >> 32)
+	p3 := archsimd.BroadcastUint64x4(prime3)
+	seed := archsimd.BroadcastUint64x4(prime5 + 4)
+	m := n / 8
+	cv := unsafecast.Slice[[8]uint32](v)[:m]
+	ch := unsafecast.Slice[[8]uint64](h)[:m]
+	for j := range cv {
+		v0 := archsimd.LoadUint32x4Slice(cv[j][0:4]).ExtendToUint64()
+		v1 := archsimd.LoadUint32x4Slice(cv[j][4:8]).ExtendToUint64()
+		h0 := mulPrimeAVX2(rot23AVX2(seed.Xor(mulPrime32AVX2(v0, p1Lo, p1Hi))), p2Lo, p2Hi).Add(p3)
+		h1 := mulPrimeAVX2(rot23AVX2(seed.Xor(mulPrime32AVX2(v1, p1Lo, p1Hi))), p2Lo, p2Hi).Add(p3)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(33)), p2Lo, p2Hi)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(33)), p2Lo, p2Hi)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(29)), p3Lo, p3Hi)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(29)), p3Lo, p3Hi)
+		h0 = h0.Xor(h0.ShiftAllRight(32))
+		h1 = h1.Xor(h1.ShiftAllRight(32))
+		h0.StoreSlice(ch[j][0:4])
+		h1.StoreSlice(ch[j][4:8])
+	}
+	archsimd.ClearAVXUpperBits()
+	return m * 8
+}
+
+// mulPrimeAVX2 computes the low 64 bits of a 64x64 multiply by a constant
+// on AVX2, where VPMULLQ does not exist: three VPMULUDQ cross products
+// (kelindar/simd's clang-generated recipe). cLo and cHi hold the low and
+// high 32 bits of the constant broadcast in every 64 bit lane, so only the
+// variable operand needs a shift.
+func mulPrimeAVX2(a, cLo, cHi archsimd.Uint64x4) archsimd.Uint64x4 {
+	ae := a.AsUint32x8()
+	lo := ae.MulEvenWiden(cLo.AsUint32x8())
+	mid := ae.MulEvenWiden(cHi.AsUint32x8())
+	mid = mid.Add(a.ShiftAllRight(32).AsUint32x8().MulEvenWiden(cLo.AsUint32x8()))
+	return lo.Add(mid.ShiftAllLeft(32))
+}
+
+// rot31AVX2 and rot27AVX2 rotate 64 bit lanes with immediate shifts
+// (VPROLQ is AVX-512 only).
+func rot31AVX2(a archsimd.Uint64x4) archsimd.Uint64x4 {
+	return a.ShiftAllLeft(31).Or(a.ShiftAllRight(33))
+}
+
+func rot27AVX2(a archsimd.Uint64x4) archsimd.Uint64x4 {
+	return a.ShiftAllLeft(27).Or(a.ShiftAllRight(37))
 }
 
 func MultiSum64Uint64(h []uint64, v []uint64) int {
@@ -226,6 +327,8 @@ func MultiSum64Uint64(h []uint64, v []uint64) int {
 		}
 		i = m * 32
 		archsimd.ClearAVXUpperBits()
+	} else if archsimd.X86.AVX2() && n >= 16 {
+		i = multiSum64Uint64AVX2(h, v, n)
 	}
 	for ; i < n; i++ {
 		h[i] = Sum64Uint64(v[i])

--- a/bloom/xxhash/sum64uint_simd_amd64.go
+++ b/bloom/xxhash/sum64uint_simd_amd64.go
@@ -196,22 +196,28 @@ func multiSum64Uint64AVX2(h, v []uint64, n int) int {
 	p3Hi := archsimd.BroadcastUint64x4(prime3 >> 32)
 	p4 := archsimd.BroadcastUint64x4(prime4)
 	seed := archsimd.BroadcastUint64x4(prime5 + 8)
+	s27 := archsimd.BroadcastUint64x4(27)
+	s29 := archsimd.BroadcastUint64x4(29)
+	s31 := archsimd.BroadcastUint64x4(31)
+	s32 := archsimd.BroadcastUint64x4(32)
+	s33 := archsimd.BroadcastUint64x4(33)
+	s37 := archsimd.BroadcastUint64x4(37)
 	m := n / 8
 	cv := unsafecast.Slice[[8]uint64](v)[:m]
 	ch := unsafecast.Slice[[8]uint64](h)[:m]
 	for j := range cv {
 		v0 := archsimd.LoadUint64x4Slice(cv[j][0:4])
 		v1 := archsimd.LoadUint64x4Slice(cv[j][4:8])
-		h0 := seed.Xor(mulPrimeAVX2(rot31AVX2(mulPrimeAVX2(v0, p2Lo, p2Hi)), p1Lo, p1Hi))
-		h1 := seed.Xor(mulPrimeAVX2(rot31AVX2(mulPrimeAVX2(v1, p2Lo, p2Hi)), p1Lo, p1Hi))
-		h0 = mulPrimeAVX2(rot27AVX2(h0), p1Lo, p1Hi).Add(p4)
-		h1 = mulPrimeAVX2(rot27AVX2(h1), p1Lo, p1Hi).Add(p4)
-		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(33)), p2Lo, p2Hi)
-		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(33)), p2Lo, p2Hi)
-		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(29)), p3Lo, p3Hi)
-		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(29)), p3Lo, p3Hi)
-		h0 = h0.Xor(h0.ShiftAllRight(32))
-		h1 = h1.Xor(h1.ShiftAllRight(32))
+		h0 := seed.Xor(mulPrimeAVX2(rotAVX2(mulPrimeAVX2(v0, p2Lo, p2Hi, s32), s31, s33), p1Lo, p1Hi, s32))
+		h1 := seed.Xor(mulPrimeAVX2(rotAVX2(mulPrimeAVX2(v1, p2Lo, p2Hi, s32), s31, s33), p1Lo, p1Hi, s32))
+		h0 = mulPrimeAVX2(rotAVX2(h0, s27, s37), p1Lo, p1Hi, s32).Add(p4)
+		h1 = mulPrimeAVX2(rotAVX2(h1, s27, s37), p1Lo, p1Hi, s32).Add(p4)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftRight(s33)), p2Lo, p2Hi, s32)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftRight(s33)), p2Lo, p2Hi, s32)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftRight(s29)), p3Lo, p3Hi, s32)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftRight(s29)), p3Lo, p3Hi, s32)
+		h0 = h0.Xor(h0.ShiftRight(s32))
+		h1 = h1.Xor(h1.ShiftRight(s32))
 		h0.StoreSlice(ch[j][0:4])
 		h1.StoreSlice(ch[j][4:8])
 	}
@@ -221,13 +227,9 @@ func multiSum64Uint64AVX2(h, v []uint64, n int) int {
 
 // mulPrime32AVX2 multiplies a value with zero high halves (a widened
 // uint32) by a 64 bit constant: two products suffice.
-func mulPrime32AVX2(a, cLo, cHi archsimd.Uint64x4) archsimd.Uint64x4 {
+func mulPrime32AVX2(a, cLo, cHi, s32 archsimd.Uint64x4) archsimd.Uint64x4 {
 	ae := a.AsUint32x8()
-	return ae.MulEvenWiden(cLo.AsUint32x8()).Add(ae.MulEvenWiden(cHi.AsUint32x8()).ShiftAllLeft(32))
-}
-
-func rot23AVX2(a archsimd.Uint64x4) archsimd.Uint64x4 {
-	return a.ShiftAllLeft(23).Or(a.ShiftAllRight(41))
+	return ae.MulEvenWiden(cLo.AsUint32x8()).Add(ae.MulEvenWiden(cHi.AsUint32x8()).ShiftLeft(s32))
 }
 
 // multiSum64Uint32AVX2 is the AVX2 tier of MultiSum64Uint32.
@@ -240,20 +242,25 @@ func multiSum64Uint32AVX2(h []uint64, v []uint32, n int) int {
 	p3Hi := archsimd.BroadcastUint64x4(prime3 >> 32)
 	p3 := archsimd.BroadcastUint64x4(prime3)
 	seed := archsimd.BroadcastUint64x4(prime5 + 4)
+	s23 := archsimd.BroadcastUint64x4(23)
+	s29 := archsimd.BroadcastUint64x4(29)
+	s32 := archsimd.BroadcastUint64x4(32)
+	s33 := archsimd.BroadcastUint64x4(33)
+	s41 := archsimd.BroadcastUint64x4(41)
 	m := n / 8
 	cv := unsafecast.Slice[[8]uint32](v)[:m]
 	ch := unsafecast.Slice[[8]uint64](h)[:m]
 	for j := range cv {
 		v0 := archsimd.LoadUint32x4Slice(cv[j][0:4]).ExtendToUint64()
 		v1 := archsimd.LoadUint32x4Slice(cv[j][4:8]).ExtendToUint64()
-		h0 := mulPrimeAVX2(rot23AVX2(seed.Xor(mulPrime32AVX2(v0, p1Lo, p1Hi))), p2Lo, p2Hi).Add(p3)
-		h1 := mulPrimeAVX2(rot23AVX2(seed.Xor(mulPrime32AVX2(v1, p1Lo, p1Hi))), p2Lo, p2Hi).Add(p3)
-		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(33)), p2Lo, p2Hi)
-		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(33)), p2Lo, p2Hi)
-		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftAllRight(29)), p3Lo, p3Hi)
-		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftAllRight(29)), p3Lo, p3Hi)
-		h0 = h0.Xor(h0.ShiftAllRight(32))
-		h1 = h1.Xor(h1.ShiftAllRight(32))
+		h0 := mulPrimeAVX2(rotAVX2(seed.Xor(mulPrime32AVX2(v0, p1Lo, p1Hi, s32)), s23, s41), p2Lo, p2Hi, s32).Add(p3)
+		h1 := mulPrimeAVX2(rotAVX2(seed.Xor(mulPrime32AVX2(v1, p1Lo, p1Hi, s32)), s23, s41), p2Lo, p2Hi, s32).Add(p3)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftRight(s33)), p2Lo, p2Hi, s32)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftRight(s33)), p2Lo, p2Hi, s32)
+		h0 = mulPrimeAVX2(h0.Xor(h0.ShiftRight(s29)), p3Lo, p3Hi, s32)
+		h1 = mulPrimeAVX2(h1.Xor(h1.ShiftRight(s29)), p3Lo, p3Hi, s32)
+		h0 = h0.Xor(h0.ShiftRight(s32))
+		h1 = h1.Xor(h1.ShiftRight(s32))
 		h0.StoreSlice(ch[j][0:4])
 		h1.StoreSlice(ch[j][4:8])
 	}
@@ -265,23 +272,23 @@ func multiSum64Uint32AVX2(h []uint64, v []uint32, n int) int {
 // on AVX2, where VPMULLQ does not exist: three VPMULUDQ cross products
 // (kelindar/simd's clang-generated recipe). cLo and cHi hold the low and
 // high 32 bits of the constant broadcast in every 64 bit lane, so only the
-// variable operand needs a shift.
-func mulPrimeAVX2(a, cLo, cHi archsimd.Uint64x4) archsimd.Uint64x4 {
+// variable operand needs a shift. All shift counts are per lane vectors:
+// the ShiftAll forms move the count through a legacy (non-VEX) MOVQ and
+// pay an AVX-SSE transition penalty on every call (golang/go#80835 — the
+// first version of these kernels measured 37x slower than scalar from
+// exactly that).
+func mulPrimeAVX2(a, cLo, cHi, s32 archsimd.Uint64x4) archsimd.Uint64x4 {
 	ae := a.AsUint32x8()
 	lo := ae.MulEvenWiden(cLo.AsUint32x8())
 	mid := ae.MulEvenWiden(cHi.AsUint32x8())
-	mid = mid.Add(a.ShiftAllRight(32).AsUint32x8().MulEvenWiden(cLo.AsUint32x8()))
-	return lo.Add(mid.ShiftAllLeft(32))
+	mid = mid.Add(a.ShiftRight(s32).AsUint32x8().MulEvenWiden(cLo.AsUint32x8()))
+	return lo.Add(mid.ShiftLeft(s32))
 }
 
-// rot31AVX2 and rot27AVX2 rotate 64 bit lanes with immediate shifts
-// (VPROLQ is AVX-512 only).
-func rot31AVX2(a archsimd.Uint64x4) archsimd.Uint64x4 {
-	return a.ShiftAllLeft(31).Or(a.ShiftAllRight(33))
-}
-
-func rot27AVX2(a archsimd.Uint64x4) archsimd.Uint64x4 {
-	return a.ShiftAllLeft(27).Or(a.ShiftAllRight(37))
+// rotAVX2 rotates 64 bit lanes left by k using per lane shifts (VPROLQ is
+// AVX-512 only); sk and skInv broadcast k and 64-k.
+func rotAVX2(a, sk, skInv archsimd.Uint64x4) archsimd.Uint64x4 {
+	return a.ShiftLeft(sk).Or(a.ShiftRight(skInv))
 }
 
 func MultiSum64Uint64(h []uint64, v []uint64) int {


### PR DESCRIPTION
AVX2-only hosts running `GOEXPERIMENT=simd` fell back to scalar hashing: VPMULLQ (the 64-bit vector multiply) is AVX-512 only. This adds an AVX2 tier for `MultiSum64Uint32` that synthesizes the multiplies with VPMULUDQ cross products (kelindar/simd's clang recipe) — the widened uint32 first multiply needs only two products, and the primes' split halves broadcast once per call.

Measured natively on Emerald Rapids (the dispatcher prefers AVX-512 there, so the kernel is benchmarked directly): **−12.5%** vs the scalar loop it replaces on AVX2-only hosts. A matching uint64 tier was built and measured **+2.5%** — five full three-product multiplies per hash merely tie superscalar MULQ — so per the verify-before-shipping bar it was dropped; the measurement is recorded in `docs/archsimd-port.md` (on #597).

Two process notes: the first version used `ShiftAll*` with constant counts and measured **37× slower than scalar** — the legacy-MOVQ trap (golang/go#80835) applies to constant counts too, so all shifts use per-lane forms with broadcast count vectors. And since CI runners have AVX-512, the dispatcher never reaches this tier there — the kernel is validated by a direct differential test against the scalar reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)