### PR TITLE
update jsonlite to v1.5.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/klauspost/compress v1.17.9
 	github.com/parquet-go/bitpack v1.0.3
-	github.com/parquet-go/jsonlite v1.5.4
+	github.com/parquet-go/jsonlite v1.5.5
 	github.com/pierrec/lz4/v4 v4.1.21
 	github.com/twpayne/go-geom v1.6.1
 	golang.org/x/sys v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/parquet-go/bitpack v1.0.3 h1:ZbzJ4Mjzrjp+ZNvY99XsJIxAKL+b04uxIb02+l4HbkE=
 github.com/parquet-go/bitpack v1.0.3/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
-github.com/parquet-go/jsonlite v1.5.4 h1:VQEIm54NYf/FO4jWgb1E9G7ws8prt6DohiU9eFiXY9c=
-github.com/parquet-go/jsonlite v1.5.4/go.mod h1:hN57TVzxtr04kaax5XwNgCCsh1KE7BT6dvY6X/zNH90=
+github.com/parquet-go/jsonlite v1.5.5 h1:TIqJ+b+mYoTvvEt1/ICS4fBacQO0xWwAbvtcrKjEcC8=
+github.com/parquet-go/jsonlite v1.5.5/go.mod h1:hN57TVzxtr04kaax5XwNgCCsh1KE7BT6dvY6X/zNH90=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/twpayne/go-geom v1.6.1 h1:iLE+Opv0Ihm/ABIcvQFGIiFBXd76oBIar9drAwHFhR4=


### PR DESCRIPTION
Bumps `github.com/parquet-go/jsonlite` from v1.5.4 to v1.5.5.

## What's in v1.5.5

[parquet-go/jsonlite#9](https://github.com/parquet-go/jsonlite/pull/9) — object key hashing:

- The 1-byte tag in an object's hash index was produced by `maphash`, a general-purpose 64-bit hash behind a non-inlinable runtime call, with 63 of the bits discarded. It's now a fold-and-multiply hash sized to what the tag actually consumes, inlined, on the eight architectures the compiler marks `unalignedOK`. Other architectures keep `maphash`.
- Tag indexes are bump-allocated from per-parse blocks rather than one allocation per indexed object.

In jsonlite's own benchmarks: **-33%** on `Lookup`, **-46%** allocations on object-heavy documents, **-14%** on wide-object parsing.

## Effect here: none measurable

Interleaved runs of both benchmark binaries, n=12:

```
                                 │   v1.5.4    │            v1.5.5             │
WriteJSONShredded/small/167B       446.8µ ± 4%   439.4µ ± 3%   ~ (p=0.443)
WriteJSONShredded/medium/390B      480.4µ ± 4%   470.9µ ± 4%   ~ (p=0.178)
WriteJSONShredded/large/1065B      615.9µ ± 5%   615.3µ ± 3%   ~ (p=0.977)
WriteJSONLeaves                    160.8µ ± 2%   161.8µ ± 3%   ~ (p=0.347)
geomean                            381.8µ        378.8µ        -0.79%
```

Nothing reaches significance, and the reason is specific rather than "it's noise":

`writeJSONToGroup` calls `val.Lookup(w.fieldName)` once per schema field per row, which *is* the path v1.5.5 optimizes. But the benchmark payloads have **4 fields** at the top level (`severity`, `message`, `trace`, `http`) and **7** in the nested `http` object. jsonlite only builds a hash index above 8 fields; below that `Lookup` linear-scans the keys, and that branch is unchanged in v1.5.5.

So this is a clean bump that benefits schemas with more than 8 fields per group. The ones we currently benchmark aren't among them — worth knowing if someone later looks for the Lookup win here and doesn't find it.

## Verification

`go build ./...`, `go vet ./...` and the full `go test ./...` suite pass. Measured on an Apple M4 Max (arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)