### PR TITLE
fix(reader): avoid leaking page buffers

### DIFF
--- a/file.go
+++ b/file.go
@@ -1349,7 +1349,6 @@ func (f *FilePages) readDictionary() error {
 		}
 		page = buffers.get(len(bodyPlain))
 		copy(page.data.Slice(), bodyPlain)
-		page.ref()
 	} else {
 		decoder := thrift.NewDecoder(f.protocol.NewReader(rbuf))
 		if err := decoder.Decode(header); err != nil {
@@ -1359,7 +1358,6 @@ func (f *FilePages) readDictionary() error {
 			return err
 		}
 		page = buffers.get(int(header.CompressedPageSize))
-		page.ref()
 		if _, err := io.ReadFull(rbuf, page.data.Slice()); err != nil {
 			page.unref()
 			return err
@@ -1536,7 +1534,6 @@ func (f *FilePages) readEncryptedPage() (*format.PageHeader, *buffer[byte], erro
 
 	page := buffers.get(len(bodyPlain))
 	copy(page.data.Slice(), bodyPlain)
-	page.ref()
 
 	if isDictPage {
 		d.dictPagePending = false


### PR DESCRIPTION
The recent encryption PR https://github.com/parquet-go/parquet-go/pull/504 introduced leaks in ref counting for buffered pages. The `buffers.get` function already sets the count to 1 so no need to increment again.

Previous implementation was
```go
page := buffers.get(int(header.CompressedPageSize))
defer page.unref()

if _, err := io.ReadFull(rbuf, page.data.Slice()); err != nil {
	return err
}
```

 Validation with `PARQUETGODEBUG=tracebuf=1 and GOGC=1`:

 - Latest upstream main: 4 buffer warnings
 - Fixed branch: 0 buffer warnings

Assisted-By: pi/gpt-5.6-sol